### PR TITLE
Provide the base URL if possible for Sonarr/Radarr

### DIFF
--- a/src/Ombi.Api.Radarr/Models/V2/SystemStatus.cs
+++ b/src/Ombi.Api.Radarr/Models/V2/SystemStatus.cs
@@ -3,5 +3,6 @@
     public class SystemStatus
     {
         public string version { get; set; }
+        public string urlBase { get; set; }
     }
 }

--- a/src/Ombi.Core/Models/TesterResultModel.cs
+++ b/src/Ombi.Core/Models/TesterResultModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Ombi.Core.Models
+{
+    public class TesterResultModel
+    {
+        public bool IsValid { get; set; }
+        public string ExpectedSubDir { get; set; }
+    }
+}

--- a/src/Ombi/ClientApp/src/app/interfaces/ITester.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ITester.ts
@@ -1,0 +1,4 @@
+export interface ITesterResult {
+  isValid: boolean;
+  expectedSubDir?: string;
+}

--- a/src/Ombi/ClientApp/src/app/interfaces/index.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/index.ts
@@ -1,4 +1,4 @@
-﻿export * from "./ICommon";
+export * from "./ICommon";
 export * from "./ICouchPotato";
 export * from "./IImages";
 export * from "./IMediaServerStatus";
@@ -20,3 +20,4 @@ export * from "./ISearchMusicResult";
 export * from "./IVote";
 export * from "./IFailedRequests";
 export * from "./IHub";
+export * from "./ITester";

--- a/src/Ombi/ClientApp/src/app/services/applications/tester.service.ts
+++ b/src/Ombi/ClientApp/src/app/services/applications/tester.service.ts
@@ -25,6 +25,7 @@ import {
     ISlackNotificationSettings,
     ISonarrSettings,
     ITelegramNotifcationSettings,
+    ITesterResult,
     IWebhookNotificationSettings,
     IWhatsAppSettings,
 } from "../../interfaces";
@@ -83,16 +84,16 @@ export class TesterService extends ServiceHelpers {
         return this.http.post<boolean>(`${this.url}jellyfin`, JSON.stringify(settings),  {headers: this.headers});
     }
 
-    public radarrTest(settings: IRadarrSettings): Observable<boolean> {
-        return this.http.post<boolean>(`${this.url}radarr`, JSON.stringify(settings),  {headers: this.headers});
+    public radarrTest(settings: IRadarrSettings): Observable<ITesterResult> {
+        return this.http.post<ITesterResult>(`${this.url}radarr`, JSON.stringify(settings),  {headers: this.headers});
     }
 
-    public lidarrTest(settings: ILidarrSettings): Observable<boolean> {
-        return this.http.post<boolean>(`${this.url}lidarr`, JSON.stringify(settings),  {headers: this.headers});
+    public lidarrTest(settings: ILidarrSettings): Observable<ITesterResult> {
+        return this.http.post<ITesterResult>(`${this.url}lidarr`, JSON.stringify(settings),  {headers: this.headers});
     }
 
-    public sonarrTest(settings: ISonarrSettings): Observable<boolean> {
-        return this.http.post<boolean>(`${this.url}sonarr`, JSON.stringify(settings),  {headers: this.headers});
+    public sonarrTest(settings: ISonarrSettings): Observable<ITesterResult> {
+        return this.http.post<ITesterResult>(`${this.url}sonarr`, JSON.stringify(settings),  {headers: this.headers});
     }
 
     public couchPotatoTest(settings: ICouchPotatoSettings): Observable<boolean> {

--- a/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 
 import { ILidarrSettings, IMinimumAvailability, IProfiles, IRadarrProfile, IRadarrRootFolder } from "../../interfaces";
@@ -106,11 +106,13 @@ export class LidarrComponent implements OnInit {
             return;
         }
         const settings = <ILidarrSettings>form.value;
-        this.testerService.lidarrTest(settings).subscribe(x => {
-            if (x === true) {
-                this.notificationService.success("Successfully connected to Lidarr!");
+        this.testerService.lidarrTest(settings).subscribe(result => {
+            if (result.isValid) {
+                this.notificationService.success("Successfully connected to Sonarr!");
+            } else if (result.expectedSubDir !== null) {
+                this.notificationService.error("Your Sonarr Base URL must be set to " + result.expectedSubDir);
             } else {
-                this.notificationService.error("We could not connect to Lidarr!");
+                this.notificationService.error("We could not connect to Sonarr!");
             }
         });
     }

--- a/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.ts
@@ -108,11 +108,11 @@ export class LidarrComponent implements OnInit {
         const settings = <ILidarrSettings>form.value;
         this.testerService.lidarrTest(settings).subscribe(result => {
             if (result.isValid) {
-                this.notificationService.success("Successfully connected to Sonarr!");
+                this.notificationService.success("Successfully connected to Lidarr!");
             } else if (result.expectedSubDir !== null) {
-                this.notificationService.error("Your Sonarr Base URL must be set to " + result.expectedSubDir);
+                this.notificationService.error("Your Lidarr Base URL must be set to " + result.expectedSubDir);
             } else {
-                this.notificationService.error("We could not connect to Sonarr!");
+                this.notificationService.error("We could not connect to Lidarr!");
             }
         });
     }

--- a/src/Ombi/ClientApp/src/app/settings/radarr/radarr.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/radarr/radarr.component.ts
@@ -98,11 +98,11 @@ export class RadarrComponent implements OnInit {
         const settings = <IRadarrSettings> form.value;
         this.testerService.radarrTest(settings).subscribe(result => {
             if (result.isValid) {
-                this.notificationService.success("Successfully connected to Sonarr!");
+                this.notificationService.success("Successfully connected to Radarr!");
             } else if (result.expectedSubDir !== null) {
-                this.notificationService.error("Your Sonarr Base URL must be set to " + result.expectedSubDir);
+                this.notificationService.error("Your Radarr Base URL must be set to " + result.expectedSubDir);
             } else {
-                this.notificationService.error("We could not connect to Sonarr!");
+                this.notificationService.error("We could not connect to Radarr!");
             }
         });
     }

--- a/src/Ombi/ClientApp/src/app/settings/radarr/radarr.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/radarr/radarr.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 
 import { IMinimumAvailability, IRadarrProfile, IRadarrRootFolder } from "../../interfaces";
@@ -96,11 +96,13 @@ export class RadarrComponent implements OnInit {
             return;
         }
         const settings = <IRadarrSettings> form.value;
-        this.testerService.radarrTest(settings).subscribe(x => {
-            if (x === true) {
-                this.notificationService.success("Successfully connected to Radarr!");
+        this.testerService.radarrTest(settings).subscribe(result => {
+            if (result.isValid) {
+                this.notificationService.success("Successfully connected to Sonarr!");
+            } else if (result.expectedSubDir !== null) {
+                this.notificationService.error("Your Sonarr Base URL must be set to " + result.expectedSubDir);
             } else {
-                this.notificationService.error("We could not connect to Radarr!");
+                this.notificationService.error("We could not connect to Sonarr!");
             }
         });
     }

--- a/src/Ombi/ClientApp/src/app/settings/sonarr/sonarr.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/sonarr/sonarr.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
 
 import { ILanguageProfiles, ISonarrProfile, ISonarrRootFolder } from "../../interfaces";
@@ -150,9 +150,11 @@ export class SonarrComponent implements OnInit {
             return;
         }
         const settings = <ISonarrSettings> form.value;
-        this.testerService.sonarrTest(settings).subscribe(x => {
-            if (x) {
+        this.testerService.sonarrTest(settings).subscribe(result => {
+            if (result.isValid) {
                 this.notificationService.success("Successfully connected to Sonarr!");
+            } else if (result.expectedSubDir !== null) {
+                this.notificationService.error("Your Sonarr Base URL must be set to " + result.expectedSubDir);
             } else {
                 this.notificationService.error("We could not connect to Sonarr!");
             }

--- a/src/Ombi/Controllers/V1/External/TesterController.cs
+++ b/src/Ombi/Controllers/V1/External/TesterController.cs
@@ -15,6 +15,7 @@ using Ombi.Api.Sonarr;
 using Ombi.Api.Twilio;
 using Ombi.Attributes;
 using Ombi.Core.Authentication;
+using Ombi.Core.Models;
 using Ombi.Core.Models.UI;
 using Ombi.Core.Notifications;
 using Ombi.Core.Settings.Models.External;
@@ -364,19 +365,23 @@ namespace Ombi.Controllers.V1.External
         /// <param name="settings"></param>
         /// <returns></returns>
         [HttpPost("radarr")]
-        public async Task<bool> Radarr([FromBody] RadarrSettings settings)
+        public async Task<TesterResultModel> Radarr([FromBody] RadarrSettings settings)
         {
             try
             {
 
 
                 var result = await RadarrApi.SystemStatus(settings.ApiKey, settings.FullUri);
-                return result.version != null;
+                return new TesterResultModel
+                {
+                    IsValid = result.urlBase == settings.SubDir,
+                    ExpectedSubDir = result.urlBase
+                };
             }
             catch (Exception e)
             {
                 Log.LogError(LoggingEvents.Api, e, "Could not test Radarr");
-                return false;
+                return new TesterResultModel { IsValid = false };
             }
         }
 
@@ -386,23 +391,27 @@ namespace Ombi.Controllers.V1.External
         /// <param name="settings"></param>
         /// <returns></returns>
         [HttpPost("sonarr")]
-        public async Task<bool> Sonarr([FromBody] SonarrSettings settings)
+        public async Task<TesterResultModel> Sonarr([FromBody] SonarrSettings settings)
         {
             try
             {
 
                 var result = await SonarrApi.SystemStatus(settings.ApiKey, settings.FullUri);
-                return result.version != null;
+                return new TesterResultModel
+                {
+                    IsValid = result.urlBase == settings.SubDir,
+                    ExpectedSubDir = result.urlBase
+                };
             }
             catch (Exception e)
             {
                 Log.LogError(LoggingEvents.Api, e, "Could not test Sonarr");
-                return false;
+                return new TesterResultModel { IsValid = false };
             }
         }
 
         /// <summary>
-        /// Checks if we can connect to Sonarr with the provided settings
+        /// Checks if we can connect to CouchPotato with the provided settings
         /// </summary>
         /// <param name="settings"></param>
         /// <returns></returns>
@@ -497,24 +506,21 @@ namespace Ombi.Controllers.V1.External
         }
 
         [HttpPost("lidarr")]
-        public async Task<bool> LidarrTest([FromBody] LidarrSettings settings)
+        public async Task<TesterResultModel> LidarrTest([FromBody] LidarrSettings settings)
         {
             try
             {
                 var status = await LidarrApi.Status(settings.ApiKey, settings.FullUri);
-                if (status != null & status?.version.HasValue() ?? false)
+                return new TesterResultModel
                 {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                    IsValid = status?.urlBase == settings.SubDir,
+                    ExpectedSubDir = status?.urlBase
+                };
             }
             catch (Exception e)
             {
                 Log.LogError(LoggingEvents.Api, e, "Could not test Lidarr");
-                return false;
+                return new TesterResultModel { IsValid = false };
             }
         }
 


### PR DESCRIPTION
If the API returns a base URL that differs from the one currently set, output that in the error message.

Currently we show that the test passed, which is definitely wrong, as even though Sonarr/Radarr return a result here, they will fail for POST requests if the base URL is not set correctly, which is pretty confusing.