### PR TITLE
Fix double-slash in failed requests removal URL

### DIFF
--- a/src/Ombi/ClientApp/src/app/services/requestretry.service.ts
+++ b/src/Ombi/ClientApp/src/app/services/requestretry.service.ts
@@ -16,6 +16,6 @@ export class RequestRetryService extends ServiceHelpers {
         return this.http.get<IFailedRequestsViewModel[]>(this.url, {headers: this.headers});
     }
     public deleteFailedRequest(failedId: number): Observable<boolean> {
-        return this.http.delete<boolean>(`${this.url}/${failedId}`, {headers: this.headers});
+        return this.http.delete<boolean>(`${this.url}${failedId}`, {headers: this.headers});
     }
 }


### PR DESCRIPTION
Fixes #3870

The base URL ends with a slash, so adding another one here results in two, which leads to an HTTP 500.