### PR TITLE
Verify Sonarr quality/rootfolder override

### DIFF
--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -206,7 +206,11 @@ namespace Ombi.Core.Senders
             // Overrides on the request take priority
             if (model.ParentRequest.QualityOverride.HasValue)
             {
-                qualityToUse = model.ParentRequest.QualityOverride.Value;
+                overrideQuality = model.ParentRequest.QualityOverride.Value;
+                if (overrideQuality > 0)
+                {
+                    qualityToUse = overrideQuality;
+                }
             }
             if (model.ParentRequest.RootFolder.HasValue)
             {

--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -206,7 +206,7 @@ namespace Ombi.Core.Senders
             // Overrides on the request take priority
             if (model.ParentRequest.QualityOverride.HasValue)
             {
-                overrideQuality = model.ParentRequest.QualityOverride.Value;
+                var overrideQuality = model.ParentRequest.QualityOverride.Value;
                 if (overrideQuality > 0)
                 {
                     qualityToUse = overrideQuality;

--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -206,15 +206,19 @@ namespace Ombi.Core.Senders
             // Overrides on the request take priority
             if (model.ParentRequest.QualityOverride.HasValue)
             {
-                var overrideQuality = model.ParentRequest.QualityOverride.Value;
-                if (overrideQuality > 0)
+                var qualityOverride = model.ParentRequest.QualityOverride.Value;
+                if (qualityOverride > 0)
                 {
-                    qualityToUse = overrideQuality;
+                    qualityToUse = qualityOverride;
                 }
             }
             if (model.ParentRequest.RootFolder.HasValue)
             {
-               rootFolderPath = await GetSonarrRootPath(model.ParentRequest.RootFolder.Value, s);
+                var rootfolderOverride = model.ParentRequest.RootFolder.Value;
+                if (rootfolderOverride > 0)
+                {
+                    rootFolderPath = await GetSonarrRootPath(rootfolderOverride, s);
+                }
             }
       
             // Are we using v3 sonarr?


### PR DESCRIPTION
Ombi implicitly trusts that the quality/rootfolder override is set correctly, and causes issues downstream.

Line `258` in [TvSender.cs](https://github.com/Ombi-app/Ombi/tree/develop/src/Ombi.Core/Senders/TvSender.cs#L258) it tries to add a series, but the `AddSeries` function in [SonarrApi.cs](https://github.com/Ombi-app/Ombi/blob/develop/src/Ombi.Api.Sonarr/SonarrApi.cs#L92) fails to validate the `NewSeries` object since the `qualityProfileId` attribute is set to `0`. In the end it assumes the series is added in Sonarr and causes a API request with series id set to `0` which causes the following error.

```
[Error] StatusCode: BadRequest, Reason: Bad Request, RequestUri: http://SONARR_HOST/sonarr/api/series/0
```

#3194 could be related to this.