### PR TITLE
Fix for overlay of the social icons container

### DIFF
--- a/src/Ombi/ClientApp/src/app/media-details/components/movie/movie-details.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/movie/movie-details.component.html
@@ -2,7 +2,7 @@
     <mat-spinner [color]="'accent'"></mat-spinner>
 </div>
 
-<div *ngIf="movie" class="dark-theme">
+<div *ngIf="movie" class="main-content-container">
 
     <top-banner [background]="movie.background" [available]="movie.available" [title]="movie.title" [releaseDate]="movie.releaseDate" [tagline]="movie.tagline"></top-banner>
     <div class="social-icons-container">

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="!tv" class="justify-content-md-center top-spacing loading-spinner">
     <mat-spinner [color]="'accent'"></mat-spinner>
 </div>
-<div *ngIf="tv">
+<div *ngIf="tv" class="main-content-container">
     <div *ngIf="tv.id === 0; else main">
         <div class="small-middle-container no-info">
             <h1><i class="far fa-frown-o" aria-hidden="true"></i></h1>

--- a/src/Ombi/ClientApp/src/app/media-details/media-details.component.scss
+++ b/src/Ombi/ClientApp/src/app/media-details/media-details.component.scss
@@ -329,7 +329,7 @@
     margin-left:10px;
 }
 
-.dark-theme{
+.main-content-container{
     position:relative;
 }
 


### PR DESCRIPTION
Quick commit to fix the social icon container not showing on the TV details page