### PR TITLE
Fix TMDB logo URL

### DIFF
--- a/src/Ombi/ClientApp/src/app/media-details/components/movie/panels/movie-information-panel.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/movie/panels/movie-information-panel.component.html
@@ -2,7 +2,7 @@
     <div class="rating medium-font">
         <span *ngIf="movie.voteAverage"
             matTooltip="{{'MediaDetails.Votes' | translate }}  {{movie.voteCount | thousandShort: 1}}">
-            <img class="rating-small" src="{{baseUrl}}images/tmdb-logo.svg"> {{movie.voteAverage | number:'1.0-1'}}/10
+            <img class="rating-small" src="{{baseUrl}}/images/tmdb-logo.svg"> {{movie.voteAverage | number:'1.0-1'}}/10
         </span>
         <span *ngIf="ratings?.critics_rating && ratings?.critics_score">
             <img class="rating-small"


### PR DESCRIPTION
Previous value `{{baseUrl}}images/tmdb-logo.svg` leads to broken image requests, e.g. `server.com/ombiimage/tmdb-logo.svg`. We need to trail the `baseURL` with a `/` to ensure the correct path, e.g. `server.com/ombi/image/tmdb-logo.svg`. See also lines 9 and lines 14.