### PR TITLE
Update WebhookApi.cs

### DIFF
--- a/src/Ombi.Api.Webhook/WebhookApi.cs
+++ b/src/Ombi.Api.Webhook/WebhookApi.cs
@@ -19,7 +19,7 @@ namespace Ombi.Api.Webhook
 
         public async Task PushAsync(string baseUrl, string accessToken, IDictionary<string, string> parameters)
         {
-            var request = new Request("/", baseUrl, HttpMethod.Post);
+            var request = new Request("", baseUrl, HttpMethod.Post);
 
             if (!string.IsNullOrWhiteSpace(accessToken))
             {


### PR DESCRIPTION
Fixes #2448. Forward slash is no longer appended to the URL. If a user wants a / at the end of the URL, they will have to enter it in the webhook baseUrl.

This has been an issue I have had specifically with my Matrix webhook, but should apply to any general web hook. 