### PR TITLE
Fix Apple app store image path and inconsistent quotes

### DIFF
--- a/src/Ombi/ClientApp/src/app/user-preferences/components/user-preference/user-preference.component.html
+++ b/src/Ombi/ClientApp/src/app/user-preferences/components/user-preference/user-preference.component.html
@@ -56,14 +56,14 @@
               <qrcode id="qrCode" *ngIf="qrCodeEnabled" [qrdata]="qrCode" [size]="256" [level]="'L'"></qrcode>
               <div class="row">
                 <div class="col-12">
-                  <a href='https://play.google.com/store/apps/details?id=com.tidusjar.Ombi&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'
-                    target="_blank"><img width="200px" alt='Get it on Google Play'
-                      src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' /></a>
+                  <a href="https://play.google.com/store/apps/details?id=com.tidusjar.Ombi&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+                    target="_blank"><img width="200px" alt="Get it on Google Play"
+                      src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" /></a>
                 </div>
                 <div class="col-12">
                   <a href='https://apps.apple.com/us/app/ombi/id1335260043' target="_blank"><img
-                      style="margin-left:13px" width="170px" alt='Get it from the App Store'
-                      src='../../../images/appstore.svg' /></a>
+                      style="margin-left:13px" width="170px" alt="Get it from the App Store"
+                      src="images/appstore.svg" /></a>
                 </div>
                 <div class="col-12">
                   <button  style="margin-left:13px; margin-top: 20px;" mat-raised-button color="accent" type="button" (click)="openMobileApp($event)">Open Mobile App</button>


### PR DESCRIPTION
The path to the Apple App Store asset doesn't load with the current path.

In addition, there is a mixture of single and double quotes for various HTML attributes used.

Fixes #4190.