### PR TITLE
Filter out Genres from Discover

### DIFF
--- a/src/Ombi.Settings/Settings/Models/External/TheMovieDbSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/External/TheMovieDbSettings.cs
@@ -7,5 +7,9 @@ namespace Ombi.Core.Settings.Models.External
         public bool ShowAdultMovies { get; set; }
 
         public List<int> ExcludedKeywordIds { get; set; }
+
+        public List<int> ExcludedMovieGenreIds { get; set; }
+
+        public List<int> ExcludedTvGenreIds { get; set; }
     }
 }

--- a/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
@@ -4,6 +4,10 @@ using System.Threading.Tasks;
 using Ombi.Api.TheMovieDb.Models;
 using Ombi.TheMovieDbApi.Models;
 
+// Due to conflicting Genre models in
+// Ombi.TheMovieDbApi.Models and Ombi.Api.TheMovieDb.Models   
+using Genre = Ombi.TheMovieDbApi.Models.Genre;
+
 namespace Ombi.Api.TheMovieDb
 {
     public interface IMovieDbApi
@@ -34,5 +38,6 @@ namespace Ombi.Api.TheMovieDb
         Task<Keyword> GetKeyword(int keywordId);
         Task<WatchProviders> GetMovieWatchProviders(int theMoviedbId, CancellationToken token);
         Task<WatchProviders> GetTvWatchProviders(int theMoviedbId, CancellationToken token);
+        Task<List<Genre>> GetGenres(string media);
     }
 }

--- a/src/Ombi.TheMovieDbApi/Models/TheMovieDbContainer.cs
+++ b/src/Ombi.TheMovieDbApi/Models/TheMovieDbContainer.cs
@@ -36,4 +36,9 @@ namespace Ombi.TheMovieDbApi.Models
         public int total_results { get; set; }
         public int total_pages { get; set; }
     }
+
+    public class GenreContainer<T>
+    {
+        public List<T> genres { get; set; }
+    }
 }

--- a/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
@@ -202,6 +202,7 @@ namespace Ombi.Api.TheMovieDb
                 request.AddQueryString("page", page.ToString());
             }
             await AddDiscoverSettings(request);
+            await AddGenreFilter(request, type);
             AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request, cancellationToken);
             return Mapper.Map<List<MovieDbSearchResult>>(result.results);
@@ -237,6 +238,7 @@ namespace Ombi.Api.TheMovieDb
             request.AddQueryString("vote_count.gte", "250");
 
             await AddDiscoverSettings(request);
+            await AddGenreFilter(request, type);
             AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieDbSearchResult>>(result.results);
@@ -273,6 +275,7 @@ namespace Ombi.Api.TheMovieDb
                 request.AddQueryString("page", page.ToString());
             }
             await AddDiscoverSettings(request);
+            await AddGenreFilter(request, type);
             AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieDbSearchResult>>(result.results);
@@ -301,6 +304,7 @@ namespace Ombi.Api.TheMovieDb
             }
 
             await AddDiscoverSettings(request);
+            await AddGenreFilter(request, "movie");
             AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieDbSearchResult>>(result.results);
@@ -391,6 +395,28 @@ namespace Ombi.Api.TheMovieDb
             if (settings.ExcludedKeywordIds?.Any() == true)
             {
                 request.AddQueryString("without_keywords", string.Join(",", settings.ExcludedKeywordIds));
+            }
+        }
+
+        private async Task AddGenreFilter(Request request, string media_type)
+        {
+            var settings = await Settings;
+            List<int> excludedGenres;
+
+            switch (media_type) {
+                case "tv":
+                    excludedGenres = settings.ExcludedTvGenreIds;
+                    break;
+                case "movie":
+                    excludedGenres = settings.ExcludedMovieGenreIds;
+                    break;
+                default:
+                    return;
+            }
+
+            if (excludedGenres?.Any() == true)
+            {
+                request.AddQueryString("without_genres", string.Join(",", excludedGenres));
             }
         }
 

--- a/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
@@ -13,6 +13,10 @@ using Ombi.Core.Settings.Models.External;
 using Ombi.Helpers;
 using Ombi.TheMovieDbApi.Models;
 
+// Due to conflicting Genre models in
+// Ombi.TheMovieDbApi.Models and Ombi.Api.TheMovieDb.Models   
+using Genre = Ombi.TheMovieDbApi.Models.Genre;
+
 namespace Ombi.Api.TheMovieDb
 {
     public class TheMovieDbApi : IMovieDbApi
@@ -342,6 +346,16 @@ namespace Ombi.Api.TheMovieDb
 
             var keyword = await Api.Request<Keyword>(request);
             return keyword == null || keyword.Id == 0 ? null : keyword;
+        }
+
+        public async Task<List<Genre>> GetGenres(string media)
+        {
+            var request = new Request($"genre/{media}/list", BaseUri, HttpMethod.Get);
+            request.AddQueryString("api_key", ApiToken);
+            AddRetry(request);
+
+            var result = await Api.Request<GenreContainer<Genre>>(request);
+            return result.genres ?? new List<Genre>();
         }
 
         public Task<TheMovieDbContainer<MultiSearch>> MultiSearch(string searchTerm, string languageCode, CancellationToken cancellationToken)

--- a/src/Ombi/ClientApp/src/app/interfaces/IMovieDb.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/IMovieDb.ts
@@ -2,8 +2,3 @@
     id: number;
     name: string;
 }
-
-export interface IMovieDbGenre {
-    id: number;
-    name: string;
-}

--- a/src/Ombi/ClientApp/src/app/interfaces/IMovieDb.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/IMovieDb.ts
@@ -2,3 +2,8 @@
     id: number;
     name: string;
 }
+
+export interface IMovieDbGenre {
+    id: number;
+    name: string;
+}

--- a/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
@@ -284,6 +284,8 @@ export interface IVoteSettings extends ISettings {
 export interface ITheMovieDbSettings extends ISettings {
     showAdultMovies: boolean;
     excludedKeywordIds: number[];
+    excludedMovieGenreIds: number[];
+    excludedTvGenreIds: number[]
 }
 
 export interface IUpdateModel

--- a/src/Ombi/ClientApp/src/app/services/applications/themoviedb.service.ts
+++ b/src/Ombi/ClientApp/src/app/services/applications/themoviedb.service.ts
@@ -4,7 +4,7 @@ import { Injectable, Inject } from "@angular/core";
 import { empty, Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 
-import { IMovieDbKeyword } from "../../interfaces";
+import { IMovieDbGenre, IMovieDbKeyword } from "../../interfaces";
 import { ServiceHelpers } from "../service.helpers";
 
 @Injectable()
@@ -21,5 +21,9 @@ export class TheMovieDbService extends ServiceHelpers {
     public getKeyword(keywordId: number): Observable<IMovieDbKeyword> {
         return this.http.get<IMovieDbKeyword>(`${this.url}/Keywords/${keywordId}`, { headers: this.headers })
             .pipe(catchError((error: HttpErrorResponse) => error.status === 404 ? empty() : throwError(error)));
+    }
+
+    public getGenres(media: string): Observable<IMovieDbGenre[]> {
+        return this.http.get<IMovieDbGenre[]>(`${this.url}/Genres/${media}`, { headers: this.headers })
     }
 }

--- a/src/Ombi/ClientApp/src/app/services/applications/themoviedb.service.ts
+++ b/src/Ombi/ClientApp/src/app/services/applications/themoviedb.service.ts
@@ -4,7 +4,7 @@ import { Injectable, Inject } from "@angular/core";
 import { empty, Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 
-import { IMovieDbGenre, IMovieDbKeyword } from "../../interfaces";
+import { IMovieDbKeyword } from "../../interfaces";
 import { ServiceHelpers } from "../service.helpers";
 
 @Injectable()
@@ -23,7 +23,7 @@ export class TheMovieDbService extends ServiceHelpers {
             .pipe(catchError((error: HttpErrorResponse) => error.status === 404 ? empty() : throwError(error)));
     }
 
-    public getGenres(media: string): Observable<IMovieDbGenre[]> {
-        return this.http.get<IMovieDbGenre[]>(`${this.url}/Genres/${media}`, { headers: this.headers })
+    public getGenres(media: string): Observable<IMovieDbKeyword[]> {
+        return this.http.get<IMovieDbKeyword[]>(`${this.url}/Genres/${media}`, { headers: this.headers })
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.html
@@ -28,47 +28,41 @@
 
                     <mat-chip-list #chipList>
                         <mat-chip *ngFor="let key of excludedKeywords" [selectable]="false" [removable]="true"
-                            (removed)="remove(key)">
+                            (removed)="remove(key, 'keyword')">
                             {{key.name}}
                             <i matChipRemove class="fas fa-times fa-lg"></i>
                         </mat-chip>
                     </mat-chip-list>
 
-                    <mat-form-field class="example-full-width">
-                        <input type="text" placeholder="Excluded Genres for Movie Suggestions" matInput
-                            formControlName="input" [matAutocomplete]="auto"
-                            matTooltip="Prevent movies with certain genres from being suggested. May require a restart to take effect.">
-                        <mat-autocomplete (optionSelected)="optionSelected($event.option.value)" autoActiveFirstOption
-                            #auto="matAutocomplete">
-                            <mat-option *ngFor="let option of filteredMovieGenres" [value]="option">
-                                {{option.name}}
+                    <mat-form-field appearance="outline" >
+                        <mat-label>Movie Genres</mat-label>
+                        <mat-select formControlName="excludedMovieGenres" multiple>
+                            <mat-option *ngFor="let genre of filteredMovieGenres" [value]="genre.id">
+                                {{genre.name}}
                             </mat-option>
-                        </mat-autocomplete>
+                        </mat-select>
                     </mat-form-field>
 
                     <mat-chip-list #chipList>
                         <mat-chip *ngFor="let key of excludedMovieGenres" [selectable]="false" [removable]="true"
-                            (removed)="remove(key)">
+                            (removed)="remove(key, 'movieGenre')">
                             {{key.name}}
                             <i matChipRemove class="fas fa-times fa-lg"></i>
                         </mat-chip>
                     </mat-chip-list>                    
 
-                    <mat-form-field class="example-full-width">
-                        <input type="text" placeholder="Excluded Genres for TV Suggestions" matInput
-                            formControlName="input" [matAutocomplete]="auto"
-                            matTooltip="Prevent TV Shows with certain genres from being suggested. May require a restart to take effect.">
-                        <mat-autocomplete (optionSelected)="optionSelected($event.option.value)" autoActiveFirstOption
-                            #auto="matAutocomplete">
-                            <mat-option *ngFor="let option of filteredTvGenres" [value]="option">
-                                {{option.name}}
+                    <mat-form-field appearance="outline" >
+                        <mat-label>Tv Genres</mat-label>
+                        <mat-select formControlName="excludedTvGenres" multiple>
+                            <mat-option *ngFor="let genre of filteredTvGenres" [value]="genre.id">
+                                {{genre.name}}
                             </mat-option>
-                        </mat-autocomplete>
+                        </mat-select>
                     </mat-form-field>
 
                     <mat-chip-list #chipList>
                         <mat-chip *ngFor="let key of excludedTvGenres" [selectable]="false" [removable]="true"
-                            (removed)="remove(key)">
+                            (removed)="remove(key, 'tvGenre')">
                             {{key.name}}
                             <i matChipRemove class="fas fa-times fa-lg"></i>
                         </mat-chip>

--- a/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.html
@@ -15,7 +15,7 @@
                 <form [formGroup]='tagForm'>
 
                     <mat-form-field class="example-full-width">
-                        <input type="text" placeholder="Excluded Keyword IDs for Movie Suggestions" matInput
+                        <input type="text" placeholder="Excluded Keyword IDs for Movie & TV Suggestions" matInput
                             formControlName="input" [matAutocomplete]="auto"
                             matTooltip="Prevent movies with certain keywords from being suggested. May require a restart to take effect.">
                         <mat-autocomplete (optionSelected)="optionSelected($event.option.value)" autoActiveFirstOption
@@ -28,6 +28,46 @@
 
                     <mat-chip-list #chipList>
                         <mat-chip *ngFor="let key of excludedKeywords" [selectable]="false" [removable]="true"
+                            (removed)="remove(key)">
+                            {{key.name}}
+                            <i matChipRemove class="fas fa-times fa-lg"></i>
+                        </mat-chip>
+                    </mat-chip-list>
+
+                    <mat-form-field class="example-full-width">
+                        <input type="text" placeholder="Excluded Genres for Movie Suggestions" matInput
+                            formControlName="input" [matAutocomplete]="auto"
+                            matTooltip="Prevent movies with certain genres from being suggested. May require a restart to take effect.">
+                        <mat-autocomplete (optionSelected)="optionSelected($event.option.value)" autoActiveFirstOption
+                            #auto="matAutocomplete">
+                            <mat-option *ngFor="let option of filteredMovieGenres" [value]="option">
+                                {{option.name}}
+                            </mat-option>
+                        </mat-autocomplete>
+                    </mat-form-field>
+
+                    <mat-chip-list #chipList>
+                        <mat-chip *ngFor="let key of excludedMovieGenres" [selectable]="false" [removable]="true"
+                            (removed)="remove(key)">
+                            {{key.name}}
+                            <i matChipRemove class="fas fa-times fa-lg"></i>
+                        </mat-chip>
+                    </mat-chip-list>                    
+
+                    <mat-form-field class="example-full-width">
+                        <input type="text" placeholder="Excluded Genres for TV Suggestions" matInput
+                            formControlName="input" [matAutocomplete]="auto"
+                            matTooltip="Prevent TV Shows with certain genres from being suggested. May require a restart to take effect.">
+                        <mat-autocomplete (optionSelected)="optionSelected($event.option.value)" autoActiveFirstOption
+                            #auto="matAutocomplete">
+                            <mat-option *ngFor="let option of filteredTvGenres" [value]="option">
+                                {{option.name}}
+                            </mat-option>
+                        </mat-autocomplete>
+                    </mat-form-field>
+
+                    <mat-chip-list #chipList>
+                        <mat-chip *ngFor="let key of excludedTvGenres" [selectable]="false" [removable]="true"
                             (removed)="remove(key)">
                             {{key.name}}
                             <i matChipRemove class="fas fa-times fa-lg"></i>

--- a/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.html
@@ -33,15 +33,17 @@
                             <i matChipRemove class="fas fa-times fa-lg"></i>
                         </mat-chip>
                     </mat-chip-list>
-
-                    <mat-form-field appearance="outline" >
-                        <mat-label>Movie Genres</mat-label>
-                        <mat-select formControlName="excludedMovieGenres" multiple>
-                            <mat-option *ngFor="let genre of filteredMovieGenres" [value]="genre.id">
-                                {{genre.name}}
-                            </mat-option>
-                        </mat-select>
-                    </mat-form-field>
+                    
+                    <div class="md-form-field" style="margin-top:1em;">
+                        <mat-form-field appearance="outline" >
+                            <mat-label>Movie Genres</mat-label>
+                            <mat-select formControlName="excludedMovieGenres" multiple>
+                                <mat-option *ngFor="let genre of filteredMovieGenres" [value]="genre.id">
+                                    {{genre.name}}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                    </div>
 
                     <mat-chip-list #chipList>
                         <mat-chip *ngFor="let key of excludedMovieGenres" [selectable]="false" [removable]="true"
@@ -51,14 +53,16 @@
                         </mat-chip>
                     </mat-chip-list>                    
 
-                    <mat-form-field appearance="outline" >
-                        <mat-label>Tv Genres</mat-label>
-                        <mat-select formControlName="excludedTvGenres" multiple>
-                            <mat-option *ngFor="let genre of filteredTvGenres" [value]="genre.id">
-                                {{genre.name}}
-                            </mat-option>
-                        </mat-select>
-                    </mat-form-field>
+                    <div class="md-form-field" style="margin-top:1em;">
+                        <mat-form-field appearance="outline" >
+                            <mat-label>Tv Genres</mat-label>
+                            <mat-select formControlName="excludedTvGenres" multiple>
+                                <mat-option *ngFor="let genre of filteredTvGenres" [value]="genre.id">
+                                    {{genre.name}}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                    </div>
 
                     <mat-chip-list #chipList>
                         <mat-chip *ngFor="let key of excludedTvGenres" [selectable]="false" [removable]="true"

--- a/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.ts
@@ -18,6 +18,7 @@ interface IKeywordTag {
 interface IGenres {
     id: number;
     name: string;
+    initial: boolean;
 }
 
 @Component({
@@ -48,6 +49,8 @@ export class TheMovieDbComponent implements OnInit {
           });
         this.settingsService.getTheMovieDbSettings().subscribe(settings => {
             this.settings = settings;
+
+            // Map Keyword ids -> keyword name
             this.excludedKeywords = settings.excludedKeywordIds
                 ? settings.excludedKeywordIds.map(id => ({
                     id,
@@ -55,13 +58,52 @@ export class TheMovieDbComponent implements OnInit {
                     initial: true,
                 }))
                 : [];
-                this.excludedKeywords.forEach(key => {
-                    this.tmdbService.getKeyword(key.id).subscribe(keyResult => {
-                        this.excludedKeywords.filter((val, idx) => {
-                            val.name = keyResult.name;
-                        })
-                    });
+
+            this.excludedKeywords.forEach(key => {
+                this.tmdbService.getKeyword(key.id).subscribe(keyResult => {
+                    this.excludedKeywords.filter((val, idx) => {
+                        val.name = keyResult.name;
+                    })
                 });
+            });
+
+            // Map Movie Genre ids -> genre name
+            this.excludedMovieGenres = settings.excludedMovieGenreIds
+                ? settings.excludedMovieGenreIds.map(id => ({
+                    id,
+                    name: "",
+                    initial: true,
+                }))
+                : [];
+
+            this.tmdbService.getGenres("movie").subscribe(results => {
+                results.forEach(genre => {
+                    this.excludedMovieGenres.forEach(key => {
+                        this.excludedMovieGenres.filter((val, idx) => {
+                            val.name = genre.name
+                        })
+                    })
+                });
+            });
+            
+            // Map Tv Genre ids -> genre name
+            this.excludedTvGenres = settings.excludedTvGenreIds
+                ? settings.excludedTvGenreIds.map(id => ({
+                    id,
+                    name: "",
+                    initial: true,
+                }))
+                : [];
+
+            this.tmdbService.getGenres("tv").subscribe(results => {
+                results.forEach(genre => {
+                    this.excludedTvGenres.forEach(key => {
+                        this.excludedTvGenres.filter((val, idx) => {
+                            val.name = genre.name
+                        })
+                    })
+                });
+            });
         });
 
         this.tagForm
@@ -75,7 +117,6 @@ export class TheMovieDbComponent implements OnInit {
           })
         )
         .subscribe((r) => (this.filteredTags = r));
-
     }
 
     public remove(tag: IKeywordTag): void {

--- a/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnInit, ElementRef, ViewChild } from "@angular/core";
 import { MatAutocomplete } from "@angular/material/autocomplete";
 
-import { ITheMovieDbSettings, IMovieDbKeyword } from "../../interfaces";
+import { ITheMovieDbSettings, IMovieDbKeyword, IMovieDbGenre } from "../../interfaces";
 import { NotificationService } from "../../services";
 import { SettingsService } from "../../services";
 import { TheMovieDbService } from "../../services";
@@ -15,6 +15,11 @@ interface IKeywordTag {
     initial: boolean;
 }
 
+interface IGenres {
+    id: number;
+    name: string;
+}
+
 @Component({
     templateUrl: "./themoviedb.component.html",
     styleUrls: ["./themoviedb.component.scss"]
@@ -23,8 +28,13 @@ export class TheMovieDbComponent implements OnInit {
 
     public settings: ITheMovieDbSettings;
     public excludedKeywords: IKeywordTag[];
+    public excludedMovieGenres: IGenres[];
+    public excludedTvGenres: IGenres[];
     public tagForm: FormGroup;
     public filteredTags: IMovieDbKeyword[];
+    public filteredMovieGenres: IMovieDbGenre[];
+    public filteredTvGenres: IMovieDbGenre[];
+
     @ViewChild('fruitInput') public fruitInput: ElementRef<HTMLInputElement>;
 
     constructor(private settingsService: SettingsService,

--- a/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/themoviedb/themoviedb.component.ts
@@ -1,4 +1,4 @@
-﻿import {COMMA, ENTER, K} from "@angular/cdk/keycodes";
+﻿import {COMMA, ENTER} from "@angular/cdk/keycodes";
 import { Component, OnInit, ElementRef, ViewChild } from "@angular/core";
 import { MatAutocomplete } from "@angular/material/autocomplete";
 

--- a/src/Ombi/Controllers/V1/External/TheMovieDbController.cs
+++ b/src/Ombi/Controllers/V1/External/TheMovieDbController.cs
@@ -5,6 +5,10 @@ using Ombi.Attributes;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+// Due to conflicting Genre models in
+// Ombi.TheMovieDbApi.Models and Ombi.Api.TheMovieDb.Models   
+using Genre = Ombi.TheMovieDbApi.Models.Genre;
+
 namespace Ombi.Controllers.External
 {
     [Admin]
@@ -34,5 +38,13 @@ namespace Ombi.Controllers.External
             var keyword = await TmdbApi.GetKeyword(keywordId);
             return keyword == null ? NotFound() : (IActionResult)Ok(keyword);
         }
+
+        /// <summary>
+        /// Gets the genres for either Tv or Movies depending on media type
+        /// </summary>
+        /// <param name="media">Either `tv` or `movie`.</param> 
+        [HttpGet("Genres/{media}")]
+        public async Task<IEnumerable<Genre>> GetGenres(string media) =>
+            await TmdbApi.GetGenres(media);
     }
 }


### PR DESCRIPTION
Hi @tidusjar - opening up this PR now for discussion + feedback.

This is the PR to introduce filtering out genres from the Discover lists.

TheMovieDB API only has the capability to get a list of all genre mappings and unfortunately does not have a lookup api