### PR TITLE
Updates short date formatting to use user's browser preference.

### DIFF
--- a/src/Ombi/ClientApp/src/app/issues/issueDetails.component.html
+++ b/src/Ombi/ClientApp/src/app/issues/issueDetails.component.html
@@ -63,7 +63,7 @@
                                 
                                 <div class="messages msg_sent"> <i *ngIf="isAdmin" style="float:right;" class="fas fa-times" aria-hidden="true" (click)="deleteComment(comment.id)"></i>
                                     <p>{{comment.comment}}</p>
-                                    <time>{{comment.username}} • {{comment.date  | amLocal | amDateFormat: 'l LT'}}</time>
+                                    <time>{{comment.username}} • {{comment.date | amFromUtc | amLocal | amUserLocale | amDateFormat: 'l LT'}}</time>
                                 </div>
                             </div>
                         </div>

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/panels/tv-request-grid/tv-request-grid.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/panels/tv-request-grid/tv-request-grid.component.html
@@ -44,7 +44,7 @@
 
           <ng-container matColumnDef="airDate">
             <th mat-header-cell *matHeaderCellDef> {{ 'Requests.AirDate' | translate }} </th>
-            <td mat-cell *matCellDef="let element"> {{element.airDate | amLocal | amDateFormat: 'L' }}</td>
+            <td mat-cell *matCellDef="let element"> {{element.airDate | amLocal | amUserLocale | amDateFormat: 'L' }}</td>
           </ng-container>
 
           <ng-container matColumnDef="status">

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/panels/tv-requests/tv-requests-panel.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/panels/tv-requests/tv-requests-panel.component.html
@@ -39,7 +39,7 @@
 
           <ng-container matColumnDef="airDate">
             <th mat-header-cell *matHeaderCellDef> {{ 'Requests.AirDate' | translate }} </th>
-            <td mat-cell *matCellDef="let element"> {{element.airDate | amLocal | amDateFormat: 'L' }}</td>
+            <td mat-cell *matCellDef="let element"> {{element.airDate | amLocal | amUserLocale | amDateFormat: 'L' }}</td>
           </ng-container>
 
           <ng-container matColumnDef="status">

--- a/src/Ombi/ClientApp/src/app/pipes/UserLocalePipe.ts
+++ b/src/Ombi/ClientApp/src/app/pipes/UserLocalePipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import * as moment from "moment";
+
+const momentConstructor = moment;
+
+@Pipe({ name: "amUserLocale" })
+export class UserLocalePipe implements PipeTransform {
+  transform(value: moment.MomentInput): moment.Moment {
+    const locale = navigator.language;
+    return momentConstructor(value).locale(locale);
+  }
+}

--- a/src/Ombi/ClientApp/src/app/pipes/pipe.module.ts
+++ b/src/Ombi/ClientApp/src/app/pipes/pipe.module.ts
@@ -3,11 +3,12 @@ import { HumanizePipe } from "./HumanizePipe";
 import { ThousandShortPipe } from "./ThousandShortPipe";
 import { SafePipe } from "./SafePipe";
 import { QualityPipe } from "./QualityPipe";
+import { UserLocalePipe } from "./UserLocalePipe";
 
 @NgModule({
     imports:        [],
-    declarations:   [HumanizePipe, ThousandShortPipe, SafePipe, QualityPipe],
-    exports:        [HumanizePipe, ThousandShortPipe, SafePipe, QualityPipe],
+    declarations:   [HumanizePipe, ThousandShortPipe, SafePipe, QualityPipe, UserLocalePipe],
+    exports:        [HumanizePipe, ThousandShortPipe, SafePipe, QualityPipe, UserLocalePipe],
 })
 export class PipeModule {
 

--- a/src/Ombi/ClientApp/src/app/requests/tvrequest-children.component.html
+++ b/src/Ombi/ClientApp/src/app/requests/tvrequest-children.component.html
@@ -86,7 +86,7 @@
                                             {{ep.title}}
                                         </td>
                                         <td>
-                                            {{ep.airDate | amLocal | amDateFormat: 'L' }}
+                                            {{ep.airDate | amLocal | amUserLocale | amDateFormat: 'L' }}
                                         </td>
                                         <td>
                                             <span *ngIf="child.denied" class="label label-danger" id="deniedLabel"

--- a/src/Ombi/ClientApp/src/app/search/moviesearchgrid.component.html
+++ b/src/Ombi/ClientApp/src/app/search/moviesearchgrid.component.html
@@ -70,7 +70,7 @@
                             <h4>{{result.title}} ({{result.releaseDate | amLocal | amDateFormat: 'YYYY'}})</h4>
                         </a>
 
-                        <span *ngIf="result.releaseDate" class="label label-info" target="_blank">Release Date: {{result.releaseDate | amLocal | amDateFormat: 'L'}}</span>
+                        <span *ngIf="result.releaseDate" class="label label-info" target="_blank">Release Date: {{result.releaseDate | amLocal | amUserLocale | amDateFormat: 'L'}}</span>
 
                         <a *ngIf="result.homepage" href="{{result.homepage}}" id="homepageLabel" target="_blank">
                             <span class="label label-info">HomePage</span>

--- a/src/Ombi/ClientApp/src/app/search/music/albumsearch.component.html
+++ b/src/Ombi/ClientApp/src/app/search/music/albumsearch.component.html
@@ -54,7 +54,7 @@
 
                 
                 <ng-template [ngIf]="result.releaseDate">
-                        <span class="label label-info" id="availableLabel">Release Date: {{result.releaseDate | amLocal | amDateFormat: 'L'}}</span>
+                        <span class="label label-info" id="availableLabel">Release Date: {{result.releaseDate | amLocal | amUserLocale | amDateFormat: 'L'}}</span>
                     </ng-template>
                     <ng-template [ngIf]="result.rating">
                         <span class="label label-info" id="availableLabel">{{result.rating}}/10</span>

--- a/src/Ombi/ClientApp/src/app/search/seriesinformation.component.html
+++ b/src/Ombi/ClientApp/src/app/search/seriesinformation.component.html
@@ -43,7 +43,7 @@
                                 {{ep.title}}
                             </td>
                             <td *ngIf="ep.airDateDisplay != 'Unknown'">
-                                {{ep.airDate | amLocal | amDateFormat: 'L' }}
+                                {{ep.airDate | amLocal | amUserLocale | amDateFormat: 'L' }}
                             </td>      
                             <td *ngIf="ep.airDateDisplay == 'Unknown'">
                                 {{ep.airDateDisplay }}

--- a/src/Ombi/ClientApp/src/app/search/tvsearch.component.html
+++ b/src/Ombi/ClientApp/src/app/search/tvsearch.component.html
@@ -84,7 +84,7 @@
                                     <span *ngIf="node.status" class="label label-primary" id="statusLabel" target="_blank">{{node.status}}</span>
 
 
-                                    <span *ngIf="node.firstAired" class="label label-info" target="_blank" id="airDateLabel">{{ 'Search.TvShows.AirDate' | translate }} {{node.firstAired | amLocal | amDateFormat: 'L'}}</span>
+                                    <span *ngIf="node.firstAired" class="label label-info" target="_blank" id="airDateLabel">{{ 'Search.TvShows.AirDate' | translate }} {{node.firstAired | amLocal | amUserLocale | amDateFormat: 'L'}}</span>
 
                                     <span *ngIf="node.network" class="label label-info" id="networkLabel" target="_blank">{{node.network}}</span>
 

--- a/src/Ombi/ClientApp/src/app/shared/chat-box/chat-box.component.html
+++ b/src/Ombi/ClientApp/src/app/shared/chat-box/chat-box.component.html
@@ -13,7 +13,7 @@
               <p class="name" *ngIf="m?.username">{{m.username}}</p>
               <br/>
               <p class="message">{{m.message}}</p>
-              <p class="timestamp">{{m.date  | amLocal | amDateFormat: 'l LT'}}</p>
+              <p class="timestamp">{{m.date | amFromUtc | amLocal | amUserLocale | amDateFormat: 'l LT'}}</p>
             </div>
           </div>
         </div>

--- a/src/Ombi/ClientApp/src/app/shared/episode-request/episode-request.component.html
+++ b/src/Ombi/ClientApp/src/app/shared/episode-request/episode-request.component.html
@@ -42,7 +42,7 @@
             {{ep.title}}
           </div>
           <div class="col-2" *ngIf="ep.airDateDisplay != 'Unknown'">
-            {{ep.airDate | amLocal | amDateFormat: 'L' }}
+            {{ep.airDate | amLocal | amUserLocale | amDateFormat: 'L' }}
           </div>
           <div class="col-2" *ngIf="ep.airDateDisplay == 'Unknown'">
             {{ep.airDateDisplay }}

--- a/src/Ombi/ClientApp/src/app/usermanagement/usermanagement.component.html
+++ b/src/Ombi/ClientApp/src/app/usermanagement/usermanagement.component.html
@@ -61,13 +61,13 @@
                 <th mat-header-cell *matHeaderCellDef>  Next Request Due </th>
                 <td mat-cell *matCellDef="let u"> 
                         <div *ngIf="u.movieRequestQuota != null && u.movieRequestQuota.remaining != u.movieRequestLimit">
-                                    {{'UserManagment.MovieDue' | translate: {date: (u.movieRequestQuota.nextRequest | amLocal | amDateFormat: 'l')} }}
+                                    {{'UserManagment.MovieDue' | translate: {date: (u.movieRequestQuota.nextRequest | amLocal | amUserLocale | amDateFormat: 'l')} }}
                         </div>
                         <div *ngIf="u.episodeRequestQuota != null && u.episodeRequestQuota.remaining != u.episodeRequestLimit">
-                                    {{'UserManagment.TvDue' | translate: {date: (u.episodeRequestQuota.nextRequest  | amLocal | amDateFormat: 'l')} }}
+                                    {{'UserManagment.TvDue' | translate: {date: (u.episodeRequestQuota.nextRequest  | amLocal | amUserLocale | amDateFormat: 'l')} }}
                         </div>
                         <div *ngIf="u.musicRequestQuota != null && u.musicRequestQuota.remaining != u.musicRequestLimit">
-                                    {{'UserManagment.MusicDue' | translate: {date: (u.musicRequestQuota.nextRequest  | amLocal | amDateFormat: 'l')} }}
+                                    {{'UserManagment.MusicDue' | translate: {date: (u.musicRequestQuota.nextRequest  | amLocal | amUserLocale | amDateFormat: 'l')} }}
                         </div>
                 </td>
           </ng-container>
@@ -75,7 +75,7 @@
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>  Last Logged In </th>
                 <td mat-cell *matCellDef="let u">
                         <span *ngIf="u.lastLoggedIn">
-                                        {{u.lastLoggedIn  | amFromUtc | amLocal | amDateFormat: 'l LT'}}
+                                {{u.lastLoggedIn  | amFromUtc | amLocal | amUserLocale | amDateFormat: 'l LT'}}
                         </span>
                         <span *ngIf="!u.lastLoggedIn">
                                         Not logged in yet!


### PR DESCRIPTION
Formatting for all short dates is now using window.navigator.language. 
Dates for chat messages are also converted from UTC to local time first.
![image](https://user-images.githubusercontent.com/12289537/135833952-26f31689-e531-43d8-a290-0877de6c4bf9.png)

Let me know if you think using window.navigator.languages[0] (if present) might be a better option in your opinion.