### PR TITLE
Better URL encoding

### DIFF
--- a/src/Ombi.Api/ApiHelper.cs
+++ b/src/Ombi.Api/ApiHelper.cs
@@ -66,6 +66,8 @@ namespace Ombi.Api
                 startingTag = builder.Query.Contains("?") ? "&" : "?";
             }
 
+            value = Uri.EscapeDataString(value);
+            
             builder.Query = hasQuery
                 ? $"{builder.Query}{startingTag}{parameter}={value}"
                 : $"{startingTag}{parameter}={value}";

--- a/src/Ombi/ClientApp/src/app/services/searchV2.service.ts
+++ b/src/Ombi/ClientApp/src/app/services/searchV2.service.ts
@@ -21,7 +21,7 @@ export class SearchV2Service extends ServiceHelpers {
     }
 
     public multiSearch(searchTerm: string, filter: SearchFilter): Observable<IMultiSearchResult[]> {
-        return this.http.post<IMultiSearchResult[]>(`${this.url}/multi/${searchTerm}`, filter);
+        return this.http.post<IMultiSearchResult[]>(`${this.url}/multi/${encodeURIComponent(searchTerm)}`, filter);
     }
     public getFullMovieDetails(theMovieDbId: number): Observable<ISearchMovieResultV2> {
         return this.http.get<ISearchMovieResultV2>(`${this.url}/Movie/${theMovieDbId}`);

--- a/src/Ombi/Controllers/V2/SearchController.cs
+++ b/src/Ombi/Controllers/V2/SearchController.cs
@@ -52,7 +52,7 @@ namespace Ombi.Controllers.V2
         [HttpPost("multi/{searchTerm}")]
         public async Task<List<MultiSearchResult>> MultiSearch(string searchTerm, [FromBody] MultiSearchFilter filter)
         {
-            return await _multiSearchEngine.MultiSearch(searchTerm, filter, Request.HttpContext.RequestAborted);
+            return await _multiSearchEngine.MultiSearch(Uri.UnescapeDataString(searchTerm), filter, Request.HttpContext.RequestAborted);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #4065 

There were two issues around the same topic:

- Discover search query from frontend to backend was not properly encoded, so searching for "AC/DC" would break the routing (error 500). I couldn't think of any other routes that may also be affected.
- Query from backend to external APIs were not properly encoded, so searching for "&" would be interpreted as a new query parameter by the external service.

It's a big change but I can't find any regression so far, only better search results.