### PR TITLE
A more reliable Emby and Jellyfin sync

### DIFF
--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -143,7 +143,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 tv = await Api.GetAllShows(server.ApiKey, parentId, 0, AmountToTake, server.AdministratorId, server.FullUri);
             }
             var totalTv = tv.TotalRecordCount;
-            var processed = 1;
+            var processed = 0;
             while (processed < totalTv)
             {
                 foreach (var tvShow in tv.Items)
@@ -207,7 +207,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 movies = await Api.GetAllMovies(server.ApiKey, parentId, 0, AmountToTake, server.AdministratorId, server.FullUri);
             }
             var totalCount = movies.TotalRecordCount;
-            var processed = 1;
+            var processed = 0;
             var mediaToAdd = new HashSet<EmbyContent>();
             while (processed < totalCount)
             {

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -122,7 +122,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 allEpisodes = await Api.GetAllEpisodes(server.ApiKey, parentIdFilter, 0, AmountToTake, server.AdministratorId, server.FullUri);
             }
             var total = allEpisodes.TotalRecordCount;
-            var processed = 1;
+            var processed = 0;
             var epToAdd = new HashSet<EmbyEpisode>();
             while (processed < total)
             {

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
@@ -118,7 +118,7 @@ namespace Ombi.Schedule.Jobs.Jellyfin
             var mediaToAdd = new HashSet<JellyfinContent>();
             var tv = await Api.GetAllShows(server.ApiKey, parentId, 0, 200, server.AdministratorId, server.FullUri);
             var totalTv = tv.TotalRecordCount;
-            var processed = 1;
+            var processed = 0;
             while (processed < totalTv)
             {
                 foreach (var tvShow in tv.Items)
@@ -177,7 +177,7 @@ namespace Ombi.Schedule.Jobs.Jellyfin
         {
             var movies = await Api.GetAllMovies(server.ApiKey, parentId, 0, 200, server.AdministratorId, server.FullUri);
             var totalCount = movies.TotalRecordCount;
-            var processed = 1;
+            var processed = 0;
             var mediaToAdd = new HashSet<JellyfinContent>();
             while (processed < totalCount)
             {

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinEpisodeSync.cs
@@ -98,7 +98,7 @@ namespace Ombi.Schedule.Jobs.Jellyfin
         {
             var allEpisodes = await Api.GetAllEpisodes(server.ApiKey, parentIdFilter, 0, 200, server.AdministratorId, server.FullUri);
             var total = allEpisodes.TotalRecordCount;
-            var processed = 1;
+            var processed = 0;
             var epToAdd = new HashSet<JellyfinEpisode>();
             while (processed < total)
             {


### PR DESCRIPTION
There is an offset error in Emby sync: Emby API offset is 0-based and Ombi syncs from 0-99 then from 101-200.
This means the 100th movie, the 100th TV episode of a show, and the 100th show would not get synced. Now if that's not a bug that made me think I was crazy...!