### PR TITLE
fix swagger api key auth

### DIFF
--- a/src/Ombi/Extensions/StartupExtensions.cs
+++ b/src/Ombi/Extensions/StartupExtensions.cs
@@ -41,6 +41,21 @@ namespace Ombi
                     Type = SecuritySchemeType.ApiKey
                 });
 
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme, 
+                                Id = "ApiKey"
+                            }
+                        },
+                        new string[] {}
+                    }
+                });
+
                 c.CustomSchemaIds(x => x.FullName);
 
                 try


### PR DESCRIPTION
the api auth for swagger page has been broken
http://localhost:5000/swagger/index.html

and according to swagger doc
https://swagger.io/docs/specification/authentication/api-keys/
we are setting it up wrong

![WX20220128-162208](https://user-images.githubusercontent.com/3071863/151639143-1c608b11-684a-4084-a12d-ef526e1db16f.png)

local test:
able to get response
![WX20220128-161724](https://user-images.githubusercontent.com/3071863/151639198-68190fa7-b089-4ba3-97e6-3ca1fd9abe45.png)

swagger json config looks good
![WX20220128-162255](https://user-images.githubusercontent.com/3071863/151639210-831826ac-be77-491a-8220-4dce50bc1236.png)


 