### PR TITLE
Fix newsletter not publishing double episodes

### DIFF
--- a/src/Ombi.Store/Entities/EmbyEpisode.cs
+++ b/src/Ombi.Store/Entities/EmbyEpisode.cs
@@ -57,11 +57,5 @@ namespace Ombi.Store.Entities
             return content.OfType<EmbyContent>().FirstOrDefault(
                 x => x.EmbyId == this.EmbySeries.EmbyId);
         }
-
-        public override bool IsIn(IMediaServerContent content)
-        {
-            return content.Episodes.Cast<EmbyEpisode>().Any(x => x.EmbyId == this.EmbyId);
-        }
-
     }
 }

--- a/src/Ombi.Store/Entities/JellyfinEpisode.cs
+++ b/src/Ombi.Store/Entities/JellyfinEpisode.cs
@@ -58,10 +58,5 @@ namespace Ombi.Store.Entities
             return content.OfType<JellyfinContent>().FirstOrDefault(
                 x => x.JellyfinId == this.JellyfinSeries.JellyfinId);
         }
-        
-        public override bool IsIn(IMediaServerContent content)
-        {
-            return content.Episodes.Cast<JellyfinEpisode>().Any(x => x.JellyfinId == this.JellyfinId);
-        }
     }
 }

--- a/src/Ombi.Store/Entities/MediaServerContent.cs
+++ b/src/Ombi.Store/Entities/MediaServerContent.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations.Schema;
-using Ombi.Store.Repository;
+using System.Linq;
 
 namespace Ombi.Store.Entities
 {
@@ -42,6 +41,9 @@ namespace Ombi.Store.Entities
         public IMediaServerContent Series { get; set; }
 
         public abstract IMediaServerContent SeriesIsIn(ICollection<IMediaServerContent> content);
-        public abstract bool IsIn(IMediaServerContent content);
+        public bool IsIn(IMediaServerContent content)
+        {
+            return content.Episodes.Any(x => x.SeasonNumber == this.SeasonNumber && x.EpisodeNumber == this.EpisodeNumber);
+        }
     }
 }

--- a/src/Ombi.Store/Entities/PlexEpisode.cs
+++ b/src/Ombi.Store/Entities/PlexEpisode.cs
@@ -28,11 +28,5 @@ namespace Ombi.Store.Entities
             return content.OfType<PlexServerContent>().FirstOrDefault(
                  x => x.Key == this.PlexSeries.Key);
         }
-
-        public override bool IsIn(IMediaServerContent content)
-        {
-            return content.Episodes.Cast<PlexEpisode>().Any(x => x.Key == this.Key);
-        }
-
     }
 }


### PR DESCRIPTION
Double episodes have a single Id in the media server. The duplicate check in the newsletter would check against this Id, leading to double episodes being party ignored (only the first episode would be published).