### PR TITLE
SSO with Header Authentication

### DIFF
--- a/src/Ombi.Settings/Settings/Models/AuthenticationSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/AuthenticationSettings.cs
@@ -13,5 +13,8 @@ namespace Ombi.Settings.Settings.Models
         public bool RequireNonAlphanumeric { get; set; }
         public bool RequireUppercase { get; set; }
         public bool EnableOAuth { get; set; } // Plex OAuth
+        public bool EnableHeaderAuth { get; set; } // Header SSO
+        public string HeaderAuthVariable { get; set; } // Header SSO
+
     }
 }

--- a/src/Ombi/ClientApp/src/app/auth/auth.service.ts
+++ b/src/Ombi/ClientApp/src/app/auth/auth.service.ts
@@ -28,6 +28,10 @@ export class AuthService extends ServiceHelpers {
         return this.http.post<boolean>(`${this.url}/requirePassword`, JSON.stringify(login), { headers: this.headers });
     }
 
+    public headerAuth(): Observable<any> {
+      return this.http.post<boolean>(`${this.url}/header_auth`, {}, { headers: this.headers });
+    }
+
     public getToken() {
         return this.jwtHelperService.tokenGetter();
     }

--- a/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
@@ -238,6 +238,8 @@ export interface IAuthenticationSettings extends ISettings {
   requireNonAlphanumeric: boolean;
   requireUppercase: boolean;
   enableOAuth: boolean;
+  enableHeaderAuth: boolean;
+  headerAuthVariable: string;
 }
 
 export interface ICustomPage extends ISettings {

--- a/src/Ombi/ClientApp/src/app/login/login.component.ts
+++ b/src/Ombi/ClientApp/src/app/login/login.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnDestroy, OnInit, Inject } from "@angular/core";
+import { Component, OnDestroy, OnInit, Inject } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { TranslateService } from "@ngx-translate/core";
@@ -106,7 +106,7 @@ export class LoginComponent implements OnDestroy, OnInit {
 
     this.settingsService
       .getAuthentication()
-      .subscribe((x) => (this.authenticationSettings = x));
+      .subscribe((x) => { this.authenticationSettings = x; this.headerAuth(); });
     this.settingsService.getClientId().subscribe((x) => (this.clientId = x));
     this.images.getRandomBackground().subscribe((x) => {
       this.background = this.sanitizer.bypassSecurityTrustStyle(
@@ -121,7 +121,6 @@ export class LoginComponent implements OnDestroy, OnInit {
     if (base.length > 1) {
       this.baseUrl = base;
     }
-
     this.translate
       .get("Login.Errors.IncorrectCredentials")
       .subscribe((x) => (this.errorBody = x));
@@ -253,6 +252,31 @@ export class LoginComponent implements OnDestroy, OnInit {
         this.router.navigate(["login"]);
       }
     );
+  }
+
+  public headerAuth() {
+
+    if (this.authenticationSettings.enableHeaderAuth) {
+      this.authService.headerAuth().subscribe(
+        (x) => {
+          this.store.save("id_token", x.access_token);
+
+          if (this.authService.loggedIn()) {
+            this.ngOnDestroy();
+            this.router.navigate(["/"]);
+          } else {
+            this.notify.open(this.errorBody, "OK", {
+              duration: 3000,
+            });
+          }
+        },
+        (err) => {
+          this.notify.open(this.errorBody, "OK", {
+            duration: 3000000,
+          });
+        }
+      );
+    }
   }
 
   public ngOnDestroy() {

--- a/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.html
@@ -1,66 +1,81 @@
-﻿<settings-menu></settings-menu>
+<settings-menu></settings-menu>
 <div class="small-middle-container">
 <wiki></wiki>
 <fieldset *ngIf="form">
     <legend>Authentication</legend>
     <div class="md-form-field" style="margin-top:1em;"></div>
     <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
-            <div class="form-group">
-                <div class="checkbox">
-                    <mat-slide-toggle id="allowNoPassword" name="allowNoPassword" formControlName="allowNoPassword">
-                    Allow users to login without a password</mat-slide-toggle>
-                </div>
-            </div>
+      <div class="form-group">
+        <div class="checkbox">
+          <mat-slide-toggle id="allowNoPassword" name="allowNoPassword" formControlName="allowNoPassword">
+            Allow users to login without a password
+          </mat-slide-toggle>
+        </div>
+      </div>
 
-            <div class="form-group">
-                <div class="checkbox">
-                    <mat-slide-toggle id="enableOAuth" name="enableOAuth" formControlName="enableOAuth">Enable Plex OAuth</mat-slide-toggle>
-                </div>
-            </div>
+      <div class="form-group">
+        <div class="checkbox">
+          <mat-slide-toggle id="enableOAuth" name="enableOAuth" formControlName="enableOAuth">Enable Plex OAuth</mat-slide-toggle>
+        </div>
+      </div>
 
-            <!-- <hr/>
-            <div class="form-group">
-                <div class="checkbox">
-                    <input type="checkbox" id="requiredDigit" name="requiredDigit" formControlName="requiredDigit">
-                    <label for="requiredDigit">Require a digit in the password</label>
-                </div>
-            </div>
+      <div class="form-group">
+        <div class="checkbox">
+          <mat-slide-toggle id="enableHeaderAuth" name="enableHeaderAuth" formControlName="enableHeaderAuth">Enable Authentication with Header Variable</mat-slide-toggle>
+        </div>
+      </div>
 
-            <div class="form-group">
-                <label for="requiredLength" class="control-label">Required password length</label>
-                <div>
-                    <input type="text" class="form-control form-control-custom " id="requiredLength" name="requiredLength" formControlName="requiredLength">
-                </div>
-            </div>
+      <div class="form-group">
+        <label for="headerAuthVariable" class="control-label">Header Authentication Variable</label>
+        <div>
+          <input type="text" class="form-control form-control-custom " id="headerAuthVariable" name="headerAuthVariable" formControlName="headerAuthVariable">
+        </div>
+      </div>
 
-            <div class="form-group">
-                <div class="checkbox">
-                    <input type="checkbox" id="requiredLowercase" name="requiredLowercase" formControlName="requiredLowercase">
-                    <label for="requiredLowercase">Require a lowercase character in the password</label>
-                </div>
-            </div>
+      <!-- <hr/>
+  <div class="form-group">
+      <div class="checkbox">
+          <input type="checkbox" id="requiredDigit" name="requiredDigit" formControlName="requiredDigit">
+          <label for="requiredDigit">Require a digit in the password</label>
+      </div>
+  </div>
 
-            <div class="form-group">
-                <div class="checkbox">
-                    <input type="checkbox" id="requireNonAlphanumeric" name="requireNonAlphanumeric" formControlName="requireNonAlphanumeric">
-                    <label for="requireNonAlphanumeric">Require a NonAlphanumeric character in the password</label>
-                </div>
-            </div>
-            
-            <div class="form-group">
-                <div class="checkbox">
-                    <input type="checkbox" id="requireUppercase" name="requireUppercase" formControlName="requireUppercase">
-                    <label for="requireUppercase">Require a uppercase character in the password</label>
-                </div>
-            </div> -->
+  <div class="form-group">
+      <label for="requiredLength" class="control-label">Required password length</label>
+      <div>
+          <input type="text" class="form-control form-control-custom " id="requiredLength" name="requiredLength" formControlName="requiredLength">
+      </div>
+  </div>
 
-            <div class="form-group">
-                <div>
-                    <button mat-raised-button type="submit" color="primary" [disabled]="form.invalid" class="mat-focus-indicator mat-stroked-button accent mat-accent mat-raised-button mat-button-base" ng-reflect-disabled="false">
-                        <span class="mat-button-wrapper">Submit</span><div matripple="" class="mat-ripple mat-button-ripple" ng-reflect-disabled="false" ng-reflect-centered="false" ng-reflect-trigger="[object HTMLButtonElement]"></div>
-                        <div class="mat-button-focus-overlay"></div></button><div class="md-form-field" style="margin-top:1em;"></div>
-                </div>
-            </div>
-        </form>
+  <div class="form-group">
+      <div class="checkbox">
+          <input type="checkbox" id="requiredLowercase" name="requiredLowercase" formControlName="requiredLowercase">
+          <label for="requiredLowercase">Require a lowercase character in the password</label>
+      </div>
+  </div>
+
+  <div class="form-group">
+      <div class="checkbox">
+          <input type="checkbox" id="requireNonAlphanumeric" name="requireNonAlphanumeric" formControlName="requireNonAlphanumeric">
+          <label for="requireNonAlphanumeric">Require a NonAlphanumeric character in the password</label>
+      </div>
+  </div>
+
+  <div class="form-group">
+      <div class="checkbox">
+          <input type="checkbox" id="requireUppercase" name="requireUppercase" formControlName="requireUppercase">
+          <label for="requireUppercase">Require a uppercase character in the password</label>
+      </div>
+  </div> -->
+
+      <div class="form-group">
+        <div>
+          <button mat-raised-button type="submit" color="primary" [disabled]="form.invalid" class="mat-focus-indicator mat-stroked-button accent mat-accent mat-raised-button mat-button-base" ng-reflect-disabled="false">
+            <span class="mat-button-wrapper">Submit</span><div matripple="" class="mat-ripple mat-button-ripple" ng-reflect-disabled="false" ng-reflect-centered="false" ng-reflect-trigger="[object HTMLButtonElement]"></div>
+            <div class="mat-button-focus-overlay"></div>
+          </button><div class="md-form-field" style="margin-top:1em;"></div>
+        </div>
+      </div>
+    </form>
 </fieldset>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormBuilder, FormGroup } from "@angular/forms";
 
 import { NotificationService } from "../../services";
@@ -26,6 +26,8 @@ export class AuthenticationComponent implements OnInit {
                 requireNonAlphanumeric: [x.requireNonAlphanumeric],
                 requireUppercase: [x.requireUppercase],
                 enableOAuth: [x.enableOAuth],
+                enableHeaderAuth: [x.enableHeaderAuth],
+                headerAuthVariable: [x.headerAuthVariable],
             });
         });
     }

--- a/src/Ombi/Controllers/V1/TokenController.cs
+++ b/src/Ombi/Controllers/V1/TokenController.cs
@@ -16,6 +16,8 @@ using Ombi.Models.External;
 using Ombi.Models.Identity;
 using Ombi.Store.Entities;
 using Ombi.Store.Repository;
+using Ombi.Core.Settings;
+using Ombi.Settings.Settings.Models;
 
 namespace Ombi.Controllers.V1
 {
@@ -25,13 +27,14 @@ namespace Ombi.Controllers.V1
     public class TokenController : ControllerBase
     {
         public TokenController(OmbiUserManager um, IOptions<TokenAuthentication> ta, ITokenRepository token,
-            IPlexOAuthManager oAuthManager, ILogger<TokenController> logger)
+            IPlexOAuthManager oAuthManager, ILogger<TokenController> logger, ISettingsService<AuthenticationSettings> auth)
         {
             _userManager = um;
             _tokenAuthenticationOptions = ta.Value;
             _token = token;
             _plexOAuthManager = oAuthManager;
             _log = logger;
+            _authSettings = auth;
         }
 
         private readonly TokenAuthentication _tokenAuthenticationOptions;
@@ -39,6 +42,7 @@ namespace Ombi.Controllers.V1
         private readonly OmbiUserManager _userManager;
         private readonly IPlexOAuthManager _plexOAuthManager;
         private readonly ILogger<TokenController> _log;
+        private readonly ISettingsService<AuthenticationSettings> _authSettings;
 
         /// <summary>
         /// Gets the token.
@@ -283,25 +287,31 @@ namespace Ombi.Controllers.V1
             // TODO
             // var ombiSettings = await repo.GetSettingsAsync();
             // END TODO
-
-
-            if (Request.HttpContext?.Request?.Headers != null && Request.HttpContext.Request.Headers.ContainsKey("X-Remote-User"))
+            var authSettings = await _authSettings.GetSettingsAsync();
+            _log.LogInformation("Logging with header: " + authSettings.HeaderAuthVariable);
+            if (authSettings.HeaderAuthVariable != null)
             {
-                username = Request.HttpContext.Request.Headers["X-Remote-User"].ToString();
-                
-                // Check if user exists
-                var user = await _userManager.FindByNameAsync(username);
-                if (user == null)
+                if (Request.HttpContext?.Request?.Headers != null && Request.HttpContext.Request.Headers.ContainsKey(authSettings.HeaderAuthVariable))
+                {
+                    username = Request.HttpContext.Request.Headers[authSettings.HeaderAuthVariable].ToString();
+
+                    // Check if user exists
+                    var user = await _userManager.FindByNameAsync(username);
+                    if (user == null)
+                    {
+                        return new UnauthorizedResult();
+                    }
+
+                    return await CreateToken(true, user);
+                }
+                else
                 {
                     return new UnauthorizedResult();
                 }
-
-                return await CreateToken(true, user);
-            }
+            }    
             else
             {
                 return new UnauthorizedResult();
-
             }
         }
     }

--- a/src/Ombi/Controllers/V1/TokenController.cs
+++ b/src/Ombi/Controllers/V1/TokenController.cs
@@ -272,5 +272,37 @@ namespace Ombi.Controllers.V1
 
             return ip;
         }
+
+        [HttpPost("header_auth")]
+        [ProducesResponseType(401)]
+        public async Task<IActionResult> HeaderAuth()
+        {
+            string username = null;
+
+            // Check if Header Auth is enabled and Proxy IP is trusted
+            // TODO
+            // var ombiSettings = await repo.GetSettingsAsync();
+            // END TODO
+
+
+            if (Request.HttpContext?.Request?.Headers != null && Request.HttpContext.Request.Headers.ContainsKey("X-Remote-User"))
+            {
+                username = Request.HttpContext.Request.Headers["X-Remote-User"].ToString();
+                
+                // Check if user exists
+                var user = await _userManager.FindByNameAsync(username);
+                if (user == null)
+                {
+                    return new UnauthorizedResult();
+                }
+
+                return await CreateToken(true, user);
+            }
+            else
+            {
+                return new UnauthorizedResult();
+
+            }
+        }
     }
 }

--- a/src/Ombi/Controllers/V1/TokenController.cs
+++ b/src/Ombi/Controllers/V1/TokenController.cs
@@ -283,13 +283,9 @@ namespace Ombi.Controllers.V1
         {
             string username = null;
 
-            // Check if Header Auth is enabled and Proxy IP is trusted
-            // TODO
-            // var ombiSettings = await repo.GetSettingsAsync();
-            // END TODO
             var authSettings = await _authSettings.GetSettingsAsync();
             _log.LogInformation("Logging with header: " + authSettings.HeaderAuthVariable);
-            if (authSettings.HeaderAuthVariable != null)
+            if (authSettings.HeaderAuthVariable != null && authSettings.EnableHeaderAuth)
             {
                 if (Request.HttpContext?.Request?.Headers != null && Request.HttpContext.Request.Headers.ContainsKey(authSettings.HeaderAuthVariable))
                 {


### PR DESCRIPTION
I've a reverse proxy in place, and wanted for some time to integrate user management with SSO.
I've looked at different options and the easiest and possibly most versatile one was to implement header authentication, so that people can authenticate however they see fit on a reverse proxy and just set a header variable to the username to login.

This PR solves this problem by adding a setting in the Authentication page to enable user authentication via header variable, and lets the user specify a variable to use.
If enabled classic authentication is completely bypassed **if the user is found.** 
Needless to say that users have to be created somehow beforehand, either locally, by importing plex/emby.. or possibly in the future via LDAP if the other PR are merged.

If it is enabled, but the header is unset or the user is not known it reverts to the classic authentication.
A side case, but common to any SSO without SLO is that logout does not work anymore as the user is immediately logged in again.

Linked to https://feathub.com/tidusjar/Ombi/+460 and https://features.ombi.io/suggestions/117140/sso-oauthsaml

I admit it's kinda monkey patched in there, although I tried to handle every case gracefully, so I welcome code review from experienced contributors, let me know if something can be improved.

![image](https://user-images.githubusercontent.com/501958/154162346-6e514679-d34e-445a-a3be-c3c853331874.png)
