### PR TITLE
Add a link to Ombi details page in email notifications

### DIFF
--- a/src/Ombi.Notifications.Templates/EmailBasicTemplate.cs
+++ b/src/Ombi.Notifications.Templates/EmailBasicTemplate.cs
@@ -31,16 +31,35 @@ namespace Ombi.Notifications.Templates
         private const string DateKey = "{@DATENOW}";
         private const string Logo = "{@LOGO}";
 
-        public string LoadTemplate(string subject, string body, string imgsrc = default(string), string logo = default(string))
+        public string LoadTemplate(string subject, string body, string imgsrc = default(string), string logo = default(string), string url = default(string))
         {
             var sb = new StringBuilder(File.ReadAllText(TemplateLocation));
             sb.Replace(SubjectKey, subject);
             sb.Replace(BodyKey, body);
             sb.Replace(DateKey, DateTime.Now.ToString("f"));
-            sb.Replace(Poster, string.IsNullOrEmpty(imgsrc) ? string.Empty : $"<tr><td align=\"center\"><img src=\"{imgsrc}\" alt=\"Poster\" width=\"400px\" text-align=\"center\"/></td></tr>");
+            sb.Replace(Poster, GetPosterContent(imgsrc, url));
             sb.Replace(Logo, string.IsNullOrEmpty(logo) ? OmbiLogo : logo);
 
             return sb.ToString();
+        }
+
+        private string GetPosterContent(string imgsrc, string url) {
+            string posterContent;
+            
+            if (string.IsNullOrEmpty(imgsrc))
+            {
+                posterContent = string.Empty;
+            }
+            else
+            {
+                posterContent = $"<img src=\"{imgsrc}\" alt=\"Poster\" width=\"400px\" text-align=\"center\"/>";
+                if (!string.IsNullOrEmpty(url))
+                {
+                    posterContent = $"<a href=\"{url}\">{posterContent}</a>";
+                }
+                posterContent = $"<tr><td align=\"center\">{posterContent}</td></tr>";
+            }
+            return posterContent;
         }
     }
 }

--- a/src/Ombi.Notifications.Templates/IEmailBasicTemplate.cs
+++ b/src/Ombi.Notifications.Templates/IEmailBasicTemplate.cs
@@ -2,7 +2,7 @@
 {
     public interface IEmailBasicTemplate
     {
-        string LoadTemplate(string subject, string body, string img = default(string), string logo = default(string));
+        string LoadTemplate(string subject, string body, string img = default(string), string logo = default(string), string url = default(string));
         string TemplateLocation { get; }
     }
 }

--- a/src/Ombi.Notifications/Agents/EmailNotification.cs
+++ b/src/Ombi.Notifications/Agents/EmailNotification.cs
@@ -64,7 +64,7 @@ namespace Ombi.Notifications.Agents
                 return null;
             }
             var email = new EmailBasicTemplate();
-            var html = email.LoadTemplate(parsed.Subject, parsed.Message, parsed.Image, Customization.Logo);
+            var html = email.LoadTemplate(parsed.Subject, parsed.Message, parsed.Image, Customization.Logo, parsed.DetailsUrl);
 
 
             var message = new NotificationMessage

--- a/src/Ombi.Notifications/NotificationMessageContent.cs
+++ b/src/Ombi.Notifications/NotificationMessageContent.cs
@@ -7,6 +7,7 @@ namespace Ombi.Notifications
         public bool Disabled { get; set; }
         public string Subject { get; set; }
         public string Message { get; set; }
+        public string DetailsUrl { get; set; }
         public string Image { get; set; }
         public IReadOnlyDictionary<string, string> Data { get; set; }
     }

--- a/src/Ombi.Notifications/NotificationMessageCurlys.cs
+++ b/src/Ombi.Notifications/NotificationMessageCurlys.cs
@@ -151,6 +151,7 @@ namespace Ombi.Notifications
             RequestId = req?.Id.ToString();
             RequestedUser = req?.RequestedUser?.UserName;
             RequestedDate = req?.RequestedDate.ToString("D");
+            DetailsUrl = GetDetailsUrl(s, req);
 
             if (Type.IsNullOrEmpty())
             {
@@ -214,6 +215,26 @@ namespace Ombi.Notifications
             }
         }
 
+        private string GetDetailsUrl(CustomizationSettings s, BaseRequest req)
+        {
+            if (string.IsNullOrEmpty(s.ApplicationUrl))
+            {
+                return string.Empty;
+            }
+
+            switch (req)
+            {
+                case MovieRequests movieRequest:
+                    return $"{s.ApplicationUrl}/details/movie/{movieRequest.TheMovieDbId}";
+                case ChildRequests tvRequest:
+                    return $"{s.ApplicationUrl}/details/tv/{tvRequest.ParentRequest.ExternalProviderId}";
+                case AlbumRequest albumRequest:
+                    return $"{s.ApplicationUrl}/details/artist/{albumRequest.ForeignArtistId}";
+                default:
+                    return string.Empty;
+            }
+        }
+
         private void CalculateRequestStatus(BaseRequest req)
         {
             RequestStatus = string.Empty;
@@ -255,6 +276,7 @@ namespace Ombi.Notifications
         public string Year { get; set; }
         public string EpisodesList { get; set; }
         public string SeasonsList { get; set; }
+        public string DetailsUrl { get; set; }
         public string PosterImage { get; set; }
         public string ApplicationName { get; set; }
         public string ApplicationUrl { get; set; }

--- a/src/Ombi.Notifications/NotificationMessageResolver.cs
+++ b/src/Ombi.Notifications/NotificationMessageResolver.cs
@@ -26,6 +26,7 @@ namespace Ombi.Notifications
         {
             var content = Resolve(notification.Message, notification.Subject, c.Curlys);
             content.Image = c.PosterImage;
+            content.DetailsUrl = c.DetailsUrl;
             return content;
         }
 


### PR DESCRIPTION
Posters in email notifications are now clickable and redirect to Ombi details page.
Mostly useful IMO to allow for a quick approve/deny action when receiving a notification.