### PR TITLE
Remove generic admin email in favor of admins' email

### DIFF
--- a/src/Ombi.Notifications/Agents/EmailNotification.cs
+++ b/src/Ombi.Notifications/Agents/EmailNotification.cs
@@ -47,7 +47,7 @@ namespace Ombi.Notifications.Agents
                     return false;
                 }
             }
-            if (string.IsNullOrEmpty(settings.Host) || string.IsNullOrEmpty(settings.AdminEmail) || string.IsNullOrEmpty(settings.Port.ToString()))
+            if (string.IsNullOrEmpty(settings.Host) || string.IsNullOrEmpty(settings.Port.ToString()))
             {
                 return false;
             }
@@ -73,26 +73,6 @@ namespace Ombi.Notifications.Agents
                 Subject = parsed.Subject,
             };
 
-            if (model.Substitutes.TryGetValue("AdminComment", out var isAdminString))
-            {
-                var isAdmin = bool.Parse(isAdminString);
-                if (isAdmin)
-                {
-                    var user = _userManager.Users.FirstOrDefault(x => x.Id == model.UserId);
-                    // Send to user
-                    message.To = user.Email;
-                }
-                else
-                {
-                    // Send to admin
-                    message.To = settings.AdminEmail;
-                }
-            }
-            else
-            {
-                // Send to admin
-                message.To = settings.AdminEmail;
-            }
 
             return message;
         }
@@ -138,9 +118,7 @@ namespace Ombi.Notifications.Agents
             message.Other.Add("PlainTextBody", plaintext);
 
             // Issues should be sent to admin
-            message.To = settings.AdminEmail;
-
-            await Send(message, settings);
+            await SendToAdmins(message, settings);
         }
 
         protected override async Task IssueComment(NotificationOptions model, EmailNotificationSettings settings)
@@ -154,18 +132,16 @@ namespace Ombi.Notifications.Agents
             var plaintext = await LoadPlainTextMessage(NotificationType.IssueComment, model, settings);
             message.Other.Add("PlainTextBody", plaintext);
 
-            if (model.Substitutes.TryGetValue("AdminComment", out var isAdminString))
+            if (model.Substitutes.TryGetValue("AdminComment", out var isAdminString) && !bool.Parse(isAdminString))
             {
-                var isAdmin = bool.Parse(isAdminString);
-                message.To = isAdmin ? model.Recipient : settings.AdminEmail;
+                await SendToAdmins(message, settings);
             }
             else
             {
                 message.To = model.Recipient;
+                await Send(message, settings);
             }
 
-
-            await Send(message, settings);
         }
 
         protected override async Task IssueResolved(NotificationOptions model, EmailNotificationSettings settings)
@@ -204,9 +180,7 @@ namespace Ombi.Notifications.Agents
             var plaintext = await LoadPlainTextMessage(NotificationType.ItemAddedToFaultQueue, model, settings);
             message.Other.Add("PlainTextBody", plaintext);
 
-            // Issues resolved should be sent to the user
-            message.To = settings.AdminEmail;
-            await Send(message, settings);
+            await SendToAdmins(message, settings);
         }
 
         protected override async Task RequestDeclined(NotificationOptions model, EmailNotificationSettings settings)
@@ -305,6 +279,19 @@ namespace Ombi.Notifications.Agents
         {
             await EmailProvider.Send(model, settings);
         }
+        
+        protected async Task SendToAdmins(NotificationMessage message, EmailNotificationSettings settings)
+        {
+            foreach (var recipient in (await GetAdminUsers()).DistinctBy(x => x.Email))
+            {
+                if (recipient.Email.IsNullOrEmpty())
+                {
+                    continue;
+                }
+                message.To = recipient.Email;
+                await Send(message, settings);
+            }
+        }
 
         protected override async Task Test(NotificationOptions model, EmailNotificationSettings settings)
         {
@@ -316,12 +303,11 @@ namespace Ombi.Notifications.Agents
             {
                 Message = html,
                 Subject = $"Ombi: Test",
-                To = settings.AdminEmail,
             };
 
             message.Other.Add("PlainTextBody", "This is just a test! Success!");
 
-            await Send(message, settings);
+            await SendToAdmins(message, settings);
         }
     }
 }

--- a/src/Ombi.Notifications/BaseNotification.cs
+++ b/src/Ombi.Notifications/BaseNotification.cs
@@ -216,9 +216,14 @@ namespace Ombi.Notifications
                 .FirstOrDefault(x => x.Agent == agent && x.UserId == userId);
         }
 
-        protected async Task<IEnumerable<OmbiUser>> GetPrivilegedUsers()
+        protected async Task<IEnumerable<OmbiUser>> GetAdminUsers()
         {
             IEnumerable<OmbiUser> recipients = await _userManager.GetUsersInRoleAsync(OmbiRoles.Admin);
+            return recipients;
+        }
+        protected async Task<IEnumerable<OmbiUser>> GetPrivilegedUsers()
+        {
+            IEnumerable<OmbiUser> recipients = await GetAdminUsers();
             recipients = recipients.Concat(await _userManager.GetUsersInRoleAsync(OmbiRoles.PowerUser));
             return recipients;
         }

--- a/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
@@ -844,7 +844,7 @@ namespace Ombi.Schedule.Jobs.Ombi
                     return false;
                 }
             }
-            if (string.IsNullOrEmpty(settings.Host) || string.IsNullOrEmpty(settings.AdminEmail) || string.IsNullOrEmpty(settings.Port.ToString()))
+            if (string.IsNullOrEmpty(settings.Host) || string.IsNullOrEmpty(settings.Port.ToString()))
             {
                 return false;
             }

--- a/src/Ombi.Settings/Settings/Models/Notifications/EmailNotificationSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/Notifications/EmailNotificationSettings.cs
@@ -10,7 +10,6 @@
         public string SenderAddress { get; set; }
         public string Username { get; set; }
         public bool Authentication { get; set; }
-        public string AdminEmail { get; set; }
         public bool DisableTLS { get; set; }
         public bool DisableCertificateChecking { get; set; }
     }

--- a/src/Ombi/ClientApp/src/app/interfaces/INotificationSettings.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/INotificationSettings.ts
@@ -12,7 +12,6 @@ export interface IEmailNotificationSettings extends INotificationSettings {
     senderName: string;
     username: string;
     authentication: boolean;
-    adminEmail: string;
     disableTLS: boolean;
     disableCertificateChecking: boolean;
     notificationTemplates: INotificationTemplates[];

--- a/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.html
@@ -57,21 +57,6 @@
                                 <input matInput formControlName="senderName" matTooltip="The 'Friendly' name that will appear in the 'FROM:' part of the email">
                             </mat-form-field>
                         </div>
-
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Admin Email</mat-label>
-                                <input matInput formControlName="adminEmail" matTooltip="The administrator email will be used to send emails for admin only notifications (e.g. raised issues)">
-                                <mat-error *ngIf="emailForm.get('adminEmail').hasError('required')">
-                                    Admin Email is <strong>required</strong>
-                                  </mat-error>
-                                  <mat-error *ngIf="emailForm.get('adminEmail').hasError('email')">
-                                    Admin Email needs to be a valid email address
-                                  </mat-error>
-                            </mat-form-field>
-                        </div>
-
-                        
                         <div class="md-form-field" *ngIf="emailForm.controls['username'].validator">
                             <mat-form-field appearance="outline">
                                 <mat-label>Username</mat-label>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.ts
@@ -35,7 +35,6 @@ export class EmailNotificationComponent implements OnInit {
                 senderAddress: [x.senderAddress, [Validators.required, Validators.email]],
                 senderName: [x.senderName],
                 username: [x.username],
-                adminEmail: [x.adminEmail, [Validators.required, Validators.email]],
                 disableTLS: [x.disableTLS],
                 disableCertificateChecking: [x.disableCertificateChecking],
             });


### PR DESCRIPTION
This removes the generic admin email setting.
Instead we use the email addresses set on the users' profile.
Allows for notifications to many recipients in case of multiple admins.
Email testing now sends the test email to the currently logged in user.