### PR TITLE
Fix label ID in chatbox page

### DIFF
--- a/src/Ombi/ClientApp/src/app/shared/chat-box/chat-box.component.html
+++ b/src/Ombi/ClientApp/src/app/shared/chat-box/chat-box.component.html
@@ -1,7 +1,7 @@
 <div class='container'>
     <div class='chatbox'>
       <div class='chatbox__user-list'>
-        <h1>{{ "Issues.UserManagement" | translate }}</h1>
+        <h1>{{ "NavigationBar.UserManagement" | translate }}</h1>
         <div class='chatbox__user--active' *ngFor="let user of userList">
             <p>{{user}}</p>
         </div>


### PR DESCRIPTION
Typo from a previous PR broke the "Users" label in the chatbox.