### PR TITLE
Fix some Radarr settings no longer initialized in settings page

### DIFF
--- a/src/Ombi/ClientApp/src/app/settings/radarr/components/radarr-form.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/radarr/components/radarr-form.component.ts
@@ -39,6 +39,14 @@ export class RadarrFormComponent implements OnInit {
             { name: "In Cinemas", value: "InCinemas" },
             { name: "Physical / Web", value: "Released" },
         ];
+
+        if (this.form.controls.defaultQualityProfile.value) {
+            this.getProfiles(this.form);
+        }
+
+        if (this.form.controls.defaultRootPath.value) {
+            this.getRootFolders(this.form);
+        }
     }
 
     public toggleValidators() {


### PR DESCRIPTION
This was lost in the 4K refactoring.