### PR TITLE
Media sync refactoring

### DIFF
--- a/src/Ombi.Api.Emby/Models/Media/Tv/EmbyEpisodes.cs
+++ b/src/Ombi.Api.Emby/Models/Media/Tv/EmbyEpisodes.cs
@@ -1,9 +1,10 @@
 ﻿using Ombi.Api.Emby.Models.Movie;
+using Ombi.Api.MediaServer.Models.Media.Tv;
 using System;
 
 namespace Ombi.Api.Emby.Models.Media.Tv
 {
-    public class EmbyEpisodes
+    public class EmbyEpisodes : IMediaServerEpisodes
     {
         public string Name { get; set; }
         public string ServerId { get; set; }
@@ -41,5 +42,6 @@ namespace Ombi.Api.Emby.Models.Media.Tv
         public string MediaType { get; set; }
         public bool HasSubtitles { get; set; }
         public EmbyProviderids ProviderIds { get; set; }
+        int IMediaServerEpisodes.EpisodeNumber => IndexNumber;
     }
 }

--- a/src/Ombi.Api.Jellyfin/Models/Media/Tv/JellyfinEpisodes.cs
+++ b/src/Ombi.Api.Jellyfin/Models/Media/Tv/JellyfinEpisodes.cs
@@ -1,9 +1,10 @@
 ﻿using Ombi.Api.Jellyfin.Models.Movie;
+using Ombi.Api.MediaServer.Models.Media.Tv;
 using System;
 
 namespace Ombi.Api.Jellyfin.Models.Media.Tv
 {
-    public class JellyfinEpisodes
+    public class JellyfinEpisodes : IMediaServerEpisodes
     {
         public string Name { get; set; }
         public string ServerId { get; set; }
@@ -41,5 +42,6 @@ namespace Ombi.Api.Jellyfin.Models.Media.Tv
         public string MediaType { get; set; }
         public bool HasSubtitles { get; set; }
         public JellyfinProviderids ProviderIds { get; set; }
+        int IMediaServerEpisodes.EpisodeNumber => IndexNumber;
     }
 }

--- a/src/Ombi.Api.MediaServer/Models/Tv/IMediaServerEpisode.cs
+++ b/src/Ombi.Api.MediaServer/Models/Tv/IMediaServerEpisode.cs
@@ -1,0 +1,8 @@
+﻿namespace Ombi.Api.MediaServer.Models.Media.Tv
+{
+    public interface IMediaServerEpisodes
+    {
+        public int EpisodeNumber { get; }
+        public string Name { get; }
+    }
+} 

--- a/src/Ombi.Api.MediaServer/Ombi.Api.MediaServer.csproj
+++ b/src/Ombi.Api.MediaServer/Ombi.Api.MediaServer.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Ombi.Api\Ombi.Api.csproj" />
     <ProjectReference Include="..\Ombi.Helpers\Ombi.Helpers.csproj" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Ombi.Api.Plex/Models/Metadata.cs
+++ b/src/Ombi.Api.Plex/Models/Metadata.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
+using Ombi.Api.MediaServer.Models.Media.Tv;
 
 namespace Ombi.Api.Plex.Models
 {
-    public class Metadata
+    public class Metadata : IMediaServerEpisodes
     {
         public int ratingKey { get; set; }
         public string key { get; set; }
@@ -39,6 +40,8 @@ namespace Ombi.Api.Plex.Models
         public string chapterSource { get; set; }
         public Medium[] Media { get; set; }
         public List<PlexGuids> Guid { get; set; } = new List<PlexGuids>();
+        int IMediaServerEpisodes.EpisodeNumber => index;
+        public string Name => title;
     }
 
     public class PlexGuids

--- a/src/Ombi.Api.Plex/Ombi.Api.Plex.csproj
+++ b/src/Ombi.Api.Plex/Ombi.Api.Plex.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ombi.Api\Ombi.Api.csproj" />
+    <ProjectReference Include="..\Ombi.Api.MediaServer\Ombi.Api.MediaServer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ombi.Schedule/Jobs/MediaServer/IMediaServerEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/MediaServer/IMediaServerEpisodeSync.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ombi.Api.MediaServer.Models.Media.Tv;
+using Ombi.Store.Entities;
+
+namespace Ombi.Schedule.Jobs.MediaServer
+{
+    public interface IMediaServerEpisodeSync<T, U> : IBaseJob
+    where T:  IMediaServerEpisode
+    where U: IMediaServerEpisodes
+    {
+        Task<HashSet<T>> ProcessEpisodes(IAsyncEnumerable<U> serverEpisodes, ICollection<T> currentEpisodes);
+    }
+}

--- a/src/Ombi.Schedule/Jobs/MediaServer/MediaServerEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/MediaServer/MediaServerEpisodeSync.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Ombi.Hubs;
+using Ombi.Store.Entities;
+using Ombi.Store.Repository;
+using Quartz;
+using Ombi.Api.MediaServer.Models.Media.Tv;
+
+namespace Ombi.Schedule.Jobs.MediaServer
+{
+    public abstract class MediaServerEpisodeSync<T, U, V, W> : IMediaServerEpisodeSync<U, T>
+    where T : IMediaServerEpisodes
+    where U : IMediaServerEpisode
+    where V : IMediaServerContentRepository<W>
+    where W : IMediaServerContent
+    {
+        public MediaServerEpisodeSync(
+            ILogger l,
+            V repo,
+            IHubContext<NotificationHub> notification)
+        {
+            _logger = l;
+            _repo = repo;
+            _notification = notification;
+        }
+
+        protected readonly IHubContext<NotificationHub> _notification;
+        protected readonly ILogger _logger;
+        protected readonly V _repo;
+        protected abstract IAsyncEnumerable<T> GetMediaServerEpisodes();
+        protected abstract Task<U> GetExistingEpisode(T ep);
+        protected abstract bool IsIn(T ep, ICollection<U> list);
+
+        protected async Task CacheEpisodes()
+        {
+            var epToAdd = new HashSet<U>();
+            await ProcessEpisodes(GetMediaServerEpisodes(), epToAdd);
+        }
+
+        protected abstract void addEpisode(T ep, ICollection<U> epToAdd);
+
+        private bool _disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                //_settings?.Dispose();
+            }
+            _disposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public abstract Task Execute(IJobExecutionContext context);
+
+        public async Task<HashSet<U>> ProcessEpisodes(IAsyncEnumerable<T> serverEpisodes, ICollection<U> episodesAlreadyAdded)
+        {
+            var episodesBeingAdded = new HashSet<U>();
+
+            await foreach (var ep in GetMediaServerEpisodes())
+            {
+                if (IsIn(ep, episodesAlreadyAdded) || IsIn(ep, episodesBeingAdded))
+                {
+                    _logger.LogWarning($"Episode {ep.Name} already processed in this update.");
+                    continue;
+                }
+                // Sanity checks
+                if (ep.EpisodeNumber == 0) // no check on season number, Season 0 can be Specials
+                {
+                    _logger.LogWarning($"Episode {ep.Name} has no episode number. Skipping.");
+                    continue;
+                }
+
+                var existingEpisode = await GetExistingEpisode(ep);
+                if (existingEpisode == null)
+                {
+                    addEpisode(ep, episodesBeingAdded);
+                }
+                else
+                {
+                    _logger.LogWarning($"Episode {ep.Name} already exists in database.");
+                    // TODO: update if something changed on the media server
+                }
+            }
+
+
+            if (episodesBeingAdded.Any())
+            {
+                await _repo.AddRange((IEnumerable<IMediaServerEpisode>)episodesBeingAdded);
+            }
+            return episodesBeingAdded;
+        }
+    }
+}

--- a/src/Ombi.Schedule/Jobs/Plex/Interfaces/IPlexEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/Interfaces/IPlexEpisodeSync.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Ombi.Api.Plex.Models;
+using Ombi.Schedule.Jobs.MediaServer;
 using Ombi.Store.Entities;
 
 namespace Ombi.Schedule.Jobs.Plex.Interfaces
 {
-    public interface IPlexEpisodeSync : IBaseJob
+    public interface IPlexEpisodeSync : IMediaServerEpisodeSync<PlexEpisode, Metadata>, IBaseJob
     {
-        Task<HashSet<PlexEpisode>> ProcessEpsiodes(Metadata[] episodes, IQueryable<PlexEpisode> currentEpisodes);
     }
 }

--- a/src/Ombi.Schedule/Jobs/Plex/PlexContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexContentSync.cs
@@ -226,7 +226,7 @@ namespace Ombi.Schedule.Jobs.Plex
                     await Repo.SaveChangesAsync();
                     if (content.Metadata != null)
                     {
-                        var episodesAdded = await EpisodeSync.ProcessEpsiodes(content.Metadata, (IQueryable<PlexEpisode>)allEps);
+                        var episodesAdded = await EpisodeSync.ProcessEpisodes(content.Metadata.ToAsyncEnumerable(), (ICollection<PlexEpisode>)allEps.ToHashSet());
                         episodesProcessed.AddRange(episodesAdded.Select(x => x.Id));
                     }
                 }
@@ -326,7 +326,7 @@ namespace Ombi.Schedule.Jobs.Plex
                                 Logger.LogDebug($"We already have movie {movie.title}, But found a 4K version!");
                                 existing.Has4K = true;
                                 await Repo.Update(existing);
-                            } 
+                            }
                             else
                             {
                                 qualitySaved = true;


### PR DESCRIPTION
This is still very much WIP but I wanted to share what I've been up to. 
This is an attempt at merging common logic between Emby/Plex/Jellyfin sync. The idea is to not repeat Ombi logic across all media servers sync, and only leave the API and media-server-specific part in the dedicated class.

Once again (https://github.com/Ombi-app/Ombi/pull/4463) I underestimated the complexity of the task so the end result is not as satisfying as I expected. I'm hoping to streamline some stuff by the end of the PR.

Hopefully this will help future maintenance (I'm looking at https://github.com/Ombi-app/Ombi/issues/4472 2nd proposed solution).

- [x] Episode sync
- [ ] Content sync
- [ ] Clean up
- [ ] TESTS!