### PR TITLE
Display 'partly available' status on TV show discover card

### DIFF
--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
@@ -6,7 +6,7 @@
             {{ 'Common.' + RequestType[result.type] | translate }}
         </div>
         <div class="{{getStatusClass()}} top-right" id="status{{result.id}}">
-            <span class="indicator"></span><span class="indicator-text" id="availabilityStatus{{result.id}}">{{getAvailbilityStatus()}}</span>
+            <span class="indicator"></span><span class="indicator-text" id="availabilityStatus{{result.id}}">{{getAvailabilityStatus()}}</span>
         </div>
     </div>
         <img [routerLink]="generateDetailsLink()" id="cardImage" src="{{result.posterPath}}" class="image"

--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.scss
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.scss
@@ -201,30 +201,26 @@ small {
   margin-right:5px;
 }
 
-.top-right.available span.indicator, span.indicator-text{
+.top-right span.indicator, span.indicator-text{
   display:block;
+}
+.top-right span.indicator:before{
+  display: inline-block;
 }
 
 .top-right.available span.indicator:before{
-  display: inline-block;
   background-color: #1DE9B6;
 }
 
-.top-right.approved span.indicator, span.indicator-text {
-  display: block;
-}
-
 .top-right.approved span.indicator:before{
-  display: inline-block;
   background-color: #ff5722;
 }
 
-.top-right.requested span.indicator, span.indicator-text {
-  display: block;
+.top-right.partly-available span.indicator:before{
+  background-color: #ffd740;
 }
 
 .top-right.requested span.indicator:before{
-  display: inline-block;
   background-color: #ffd740;
 }
 

--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
@@ -92,6 +92,9 @@ export class DiscoverCardComponent implements OnInit {
         if (this.result.available) {
             return "available";
         }
+        if (this.tvSearchResult?.partlyAvailable) {
+            return "partly-available";
+        }
         if (this.result.approved) {
             return "approved";
         }
@@ -101,9 +104,12 @@ export class DiscoverCardComponent implements OnInit {
         return "";
     }
 
-    public getAvailbilityStatus(): string {
+    public getAvailabilityStatus(): string {
         if (this.result.available) {
             return this.translate.instant("Common.Available");
+        }
+        if (this.tvSearchResult?.partlyAvailable) {
+            return this.translate.instant("Common.PartlyAvailable");
         }
         if (this.result.approved) {
             return this.translate.instant("Common.Approved");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34862846/160397303-2e71e3e9-8ff4-43aa-9ea1-0653f7518cd1.png)
Before this change, it would show as "Approved" if the TV show was listed in Sonarr, or without a status if Sonarr was not setup.