### PR TITLE
Make Serilog configurable and default minimum level to Information

### DIFF
--- a/src/Ombi/Ombi.csproj
+++ b/src/Ombi/Ombi.csproj
@@ -75,9 +75,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="ncrontab" Version="3.3.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="5.0.0-preview.8.20414.8" />

--- a/src/Ombi/Startup.cs
+++ b/src/Ombi/Startup.cs
@@ -49,7 +49,7 @@ namespace Ombi
             Configuration = builder.Build();
 
             ILogger config = new LoggerConfiguration()
-                .MinimumLevel.Debug()
+                .ReadFrom.Configuration(Configuration)
                 .WriteTo.RollingFile(Path.Combine(StoragePath.StoragePath.IsNullOrEmpty() ? env.ContentRootPath : StoragePath.StoragePath, "Logs", "log-{Date}.txt"))
                 .CreateLogger();
 

--- a/src/Ombi/appsettings.Development.json
+++ b/src/Ombi/appsettings.Development.json
@@ -8,5 +8,8 @@
       "System.Net.Http.HttpClient.health-checks": "Information",
       "HealthChecks": "Information"
     }
+  },
+  "Serilog": {
+    "MinimumLevel": "Debug"
   }
 }

--- a/src/Ombi/appsettings.json
+++ b/src/Ombi/appsettings.json
@@ -10,6 +10,9 @@
       "HealthChecks": "Warning"
     }
   },
+  "Serilog": {
+    "MinimumLevel": "Information"
+  },
   "ApplicationSettings": {
     "NotificationService": "https://ombinotifications.azurewebsites.net/api/",
     "OmbiService": "?"


### PR DESCRIPTION
This will prevent production setups from being flooded with debug logs whilst still allowing debug logs for developers.
See https://github.com/serilog/serilog-settings-configuration