### PR TITLE
Enhance display of denied TV shows

### DIFF
--- a/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
@@ -308,6 +308,9 @@ namespace Ombi.Core.Engine.V2
             item.PartlyAvailable = oldModel.PartlyAvailable;
             item.Requested = oldModel.Requested;
             item.Available = oldModel.Available;
+            item.Denied = oldModel.Denied;
+            item.DeniedReason = oldModel.DeniedReason;
+            item.FullyDenied = oldModel.FullyDenied;
             item.Approved = oldModel.Approved;
             item.SeasonRequests = oldModel.SeasonRequests;
             item.RequestId = oldModel.RequestId;

--- a/src/Ombi.Core/Models/Search/SearchTvShowViewModel.cs
+++ b/src/Ombi.Core/Models/Search/SearchTvShowViewModel.cs
@@ -56,6 +56,7 @@ namespace Ombi.Core.Models.Search
         public bool FullyAvailable { get; set; }
         // We only have some episodes
         public bool PartlyAvailable { get; set; }
+        public bool FullyDenied { get; set; }
         public override RequestType Type => RequestType.TvShow;
 
         public string BackdropPath { get; set; }

--- a/src/Ombi.Core/Models/Search/V2/SearchFullInfoTvShowViewModel.cs
+++ b/src/Ombi.Core/Models/Search/V2/SearchFullInfoTvShowViewModel.cs
@@ -48,6 +48,7 @@ namespace Ombi.Core.Models.Search.V2
         public bool FullyAvailable { get; set; }
         // We only have some episodes
         public bool PartlyAvailable { get; set; }
+        public bool FullyDenied { get; set; }
         public override RequestType Type => RequestType.TvShow;
     }
 

--- a/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
@@ -62,7 +62,7 @@ namespace Ombi.Core.Rule.Rules.Search
                     request.Requested = true;
                     request.Approved = tvRequests.ChildRequests.Any(x => x.Approved);
                     request.Denied = tvRequests.ChildRequests.Any(x => x.Denied ?? false);
-                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied ?? false).DeniedReason;
+                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied ?? false)?.DeniedReason;
 
                     // Let's modify the seasonsrequested to reflect what we have requested...
                     foreach (var season in request.SeasonRequests)

--- a/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
@@ -62,7 +62,7 @@ namespace Ombi.Core.Rule.Rules.Search
                     request.Requested = true;
                     request.Approved = tvRequests.ChildRequests.Any(x => x.Approved);
                     request.Denied = tvRequests.ChildRequests.Any(x => x.Denied ?? false);
-                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied == true).DeniedReason;
+                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied ?? false).DeniedReason;
 
                     // Let's modify the seasonsrequested to reflect what we have requested...
                     foreach (var season in request.SeasonRequests)

--- a/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
@@ -62,6 +62,7 @@ namespace Ombi.Core.Rule.Rules.Search
                     request.Requested = true;
                     request.Approved = tvRequests.ChildRequests.Any(x => x.Approved);
                     request.Denied = tvRequests.ChildRequests.Any(x => x.Denied ?? false);
+                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied == true).DeniedReason;
 
                     // Let's modify the seasonsrequested to reflect what we have requested...
                     foreach (var season in request.SeasonRequests)
@@ -98,6 +99,11 @@ namespace Ombi.Core.Rule.Rules.Search
                 if (request.SeasonRequests.Any() && request.SeasonRequests.All(x => x.Episodes.Any(e => e.Available && e.AirDate > DateTime.MinValue  && e.AirDate <= DateTime.UtcNow)))
                 {
                     request.PartlyAvailable = true;
+                }
+
+                if (request.SeasonRequests.Any() && request.SeasonRequests.All(x => x.Episodes.All(e => e.Denied ?? false)))
+                {
+                    request.FullyDenied = true;
                 }
 
                 var hasUnairedRequests = request.SeasonRequests.Any() && request.SeasonRequests.All(x => x.Episodes.Any(e => e.AirDate >= DateTime.UtcNow));

--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
@@ -206,6 +206,7 @@ export class DiscoverCardComponent implements OnInit {
         this.result.overview = updated.overview;
         this.result.approved = updated.approved;
         this.result.available = updated.fullyAvailable;
+        this.result.denied = updated.fullyDenied;
 
         this.fullyLoaded = true;
     }

--- a/src/Ombi/ClientApp/src/app/interfaces/ISearchTvResultV2.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ISearchTvResultV2.ts
@@ -25,6 +25,9 @@ export interface ISearchTvResultV2 {
     seasonRequests: INewSeasonRequests[];
     requestAll: boolean;
     approved: boolean;
+    denied: boolean;
+    deniedReason: string;
+    fullyDenied: boolean;
     requested: boolean;
     available: boolean;
     plexUrl: string;

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
@@ -65,7 +65,7 @@
                                     (click)="request()"><i class="fas fa-plus"></i>
                                     {{ 'Common.Request' | translate }}</button>
 
-                                    <button *ngIf="allEpisodesRequested()" mat-raised-button class="btn-spacing" color="warn" [disabled]>
+                                    <button *ngIf="!tv.fullyDenied && allEpisodesRequested()" mat-raised-button class="btn-spacing" color="warn" [disabled]>
                                         <i class="fas fa-check"></i>
                                         {{ 'Common.Requested' | translate }}</button>
 
@@ -82,6 +82,10 @@
                                         class="btn-spacing" color="accent" [disabled]>
                                     <i class="fas fa-check"></i> {{'Common.PartiallyAvailable' | translate }}</button>
                                     <!-- end unaired episodes-->
+                                    
+                                    <button id="deniedButton" *ngIf="tv.fullyDenied" [matTooltip]="tv.deniedReason" mat-raised-button class="btn-spacing" color="warn">
+                                        <i class="fas fa-times"></i> {{'Common.Denied' | translate }}
+                                    </button>
 
                                 <button mat-raised-button class="btn-spacing" color="danger" id="reportIssueBtn" *ngIf="issuesEnabled" (click)="issue()">
                                     <i class="fas fa-exclamation"></i> {{


### PR DESCRIPTION
TV shows having all episodes denied will show as "Denied" on the discover page (pending https://github.com/Ombi-app/Ombi/pull/4579) and on the details page.

Before:
![image](https://user-images.githubusercontent.com/34862846/162256911-9255a6d2-2212-491b-b4e9-ed2b1825e6c1.png)

After:
![image](https://user-images.githubusercontent.com/34862846/162255370-d3f36d55-e914-48af-b427-578327a97b4f.png)

Partially denied TV shows behave the same as before:
![image](https://user-images.githubusercontent.com/34862846/162255461-2d08e1ce-c676-43c6-91d2-7e0224ada777.png)
