### PR TITLE
Better color codes for request statuses

### DIFF
--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.scss
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.scss
@@ -213,11 +213,11 @@ small {
 }
 
 .top-right.approved span.indicator:before{
-  background-color: #ff5722;
+  background-color: #ffd740;
 }
 
 .top-right.denied span.indicator:before{
-  background-color: #ff5722;
+  background-color: #660202;
 }
 
 .top-right.partly-available span.indicator:before{
@@ -225,7 +225,7 @@ small {
 }
 
 .top-right.requested span.indicator:before{
-  background-color: #ffd740;
+  background-color: #ff5722;
 }
 
 ::ng-deep a.poster-overlay{

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/panels/tv-request-grid/tv-request-grid.component.scss
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/panels/tv-request-grid/tv-request-grid.component.scss
@@ -31,7 +31,7 @@
   
   .top-right.approved span:before{
     display: inline-block;
-    background-color: #ff5722;
+    background-color: #ffd740;
   }
   
   .top-right.requested span {
@@ -40,10 +40,10 @@
   
   .top-right.requested span:before{
     display: inline-block;
-    background-color: #ffd740;
+    background-color: #ff5722;
   }
 
   .top-right.denied span:before{
     display: inline-block;
-    background-color: #ff4040;
+    background-color: #660202;
   }


### PR DESCRIPTION
Was before:
![image](https://user-images.githubusercontent.com/34862846/162379795-156bd343-b3c1-4d27-9e2b-c9e601111fc9.png)
![image](https://user-images.githubusercontent.com/34862846/162379779-794ef5d8-1947-444c-8857-208f7b545064.png)
![image](https://user-images.githubusercontent.com/34862846/162379757-f5884a1c-3e06-4868-975b-64b065faa45c.png)
![image](https://user-images.githubusercontent.com/34862846/162379737-006a7c9f-e03f-44c7-a09e-2855eaa4f1f2.png)


Now is:
![image](https://user-images.githubusercontent.com/34862846/162379595-52e26548-ab76-40b5-a931-3ff1e73f33b2.png)
![image](https://user-images.githubusercontent.com/34862846/162379612-9bd72934-5de7-4693-b312-321c68a83a1c.png)
![image](https://user-images.githubusercontent.com/34862846/162379620-4944a69f-d487-41f4-92f6-dd3ba8a51d07.png)
![image](https://user-images.githubusercontent.com/34862846/162379636-8cc04550-c144-4d89-b08e-269e491ee134.png)
