### PR TITLE
Better 'denied' request status for TV shows

### DIFF
--- a/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
@@ -310,7 +310,6 @@ namespace Ombi.Core.Engine.V2
             item.Available = oldModel.Available;
             item.Denied = oldModel.Denied;
             item.DeniedReason = oldModel.DeniedReason;
-            item.FullyDenied = oldModel.FullyDenied;
             item.Approved = oldModel.Approved;
             item.SeasonRequests = oldModel.SeasonRequests;
             item.RequestId = oldModel.RequestId;

--- a/src/Ombi.Core/Models/Search/SearchTvShowViewModel.cs
+++ b/src/Ombi.Core/Models/Search/SearchTvShowViewModel.cs
@@ -56,7 +56,6 @@ namespace Ombi.Core.Models.Search
         public bool FullyAvailable { get; set; }
         // We only have some episodes
         public bool PartlyAvailable { get; set; }
-        public bool FullyDenied { get; set; }
         public override RequestType Type => RequestType.TvShow;
 
         public string BackdropPath { get; set; }

--- a/src/Ombi.Core/Models/Search/V2/SearchFullInfoTvShowViewModel.cs
+++ b/src/Ombi.Core/Models/Search/V2/SearchFullInfoTvShowViewModel.cs
@@ -48,7 +48,6 @@ namespace Ombi.Core.Models.Search.V2
         public bool FullyAvailable { get; set; }
         // We only have some episodes
         public bool PartlyAvailable { get; set; }
-        public bool FullyDenied { get; set; }
         public override RequestType Type => RequestType.TvShow;
     }
 

--- a/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
@@ -61,8 +61,6 @@ namespace Ombi.Core.Rule.Rules.Search
                     request.RequestId = tvRequests.Id;
                     request.Requested = true;
                     request.Approved = tvRequests.ChildRequests.Any(x => x.Approved);
-                    request.Denied = tvRequests.ChildRequests.Any(x => x.Denied ?? false);
-                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied ?? false)?.DeniedReason;
 
                     // Let's modify the seasonsrequested to reflect what we have requested...
                     foreach (var season in request.SeasonRequests)
@@ -86,7 +84,8 @@ namespace Ombi.Core.Rule.Rules.Search
                                 episodeSearching.Requested = true;
                                 episodeSearching.Available = ep.Available;
                                 episodeSearching.Approved = ep.Season.ChildRequest.Approved;
-                                episodeSearching.Denied = request.Denied;
+                                episodeSearching.Denied = ep.Season.ChildRequest.Denied;
+                                episodeSearching.DeniedReason = ep.Season.ChildRequest.DeniedReason;
                             }
                         }
                     }
@@ -103,7 +102,8 @@ namespace Ombi.Core.Rule.Rules.Search
 
                 if (request.SeasonRequests.Any() && request.SeasonRequests.All(x => x.Episodes.All(e => e.Denied ?? false)))
                 {
-                    request.FullyDenied = true;
+                    request.Denied = true;
+                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.Denied ?? false)?.DeniedReason;
                 }
 
                 var hasUnairedRequests = request.SeasonRequests.Any() && request.SeasonRequests.All(x => x.Episodes.Any(e => e.AirDate >= DateTime.UtcNow));
@@ -123,7 +123,7 @@ namespace Ombi.Core.Rule.Rules.Search
                     if (albumRequest != null) // Do we already have a request for this?
                     {
                         obj.Requested = true;
-                        obj.RequestId = albumRequest.Id; 
+                        obj.RequestId = albumRequest.Id;
                         obj.Denied = albumRequest.Denied;
                         obj.DeniedReason = albumRequest.DeniedReason;
                         obj.Approved = albumRequest.Approved;

--- a/src/Ombi.Store/Entities/Requests/SeasonRequests.cs
+++ b/src/Ombi.Store/Entities/Requests/SeasonRequests.cs
@@ -31,6 +31,8 @@ namespace Ombi.Store.Repository.Requests
         public bool Requested { get; set; }
         [NotMapped]
         public bool? Denied { get; set; }
+        [NotMapped]
+        public string DeniedReason { get; set; }
 
         public int SeasonId { get; set; }
         [ForeignKey(nameof(SeasonId))]

--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
@@ -213,7 +213,7 @@ export class DiscoverCardComponent implements OnInit {
         this.result.overview = updated.overview;
         this.result.approved = updated.approved;
         this.result.available = updated.fullyAvailable;
-        this.result.denied = updated.fullyDenied;
+        this.result.denied = updated.denied;
 
         this.fullyLoaded = true;
     }

--- a/src/Ombi/ClientApp/src/app/interfaces/ISearchTvResultV2.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ISearchTvResultV2.ts
@@ -27,7 +27,6 @@ export interface ISearchTvResultV2 {
     approved: boolean;
     denied: boolean;
     deniedReason: string;
-    fullyDenied: boolean;
     requested: boolean;
     available: boolean;
     plexUrl: string;

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
@@ -65,7 +65,7 @@
                                     (click)="request()"><i class="fas fa-plus"></i>
                                     {{ 'Common.Request' | translate }}</button>
 
-                                    <button *ngIf="!tv.fullyDenied && allEpisodesRequested()" mat-raised-button class="btn-spacing" color="warn" [disabled]>
+                                    <button *ngIf="!tv.denied && allEpisodesRequested()" mat-raised-button class="btn-spacing" color="warn" [disabled]>
                                         <i class="fas fa-check"></i>
                                         {{ 'Common.Requested' | translate }}</button>
 
@@ -83,7 +83,7 @@
                                     <i class="fas fa-check"></i> {{'Common.PartiallyAvailable' | translate }}</button>
                                     <!-- end unaired episodes-->
                                     
-                                    <button id="deniedButton" *ngIf="tv.fullyDenied" [matTooltip]="tv.deniedReason" mat-raised-button class="btn-spacing" color="warn">
+                                    <button id="deniedButton" *ngIf="tv.denied" [matTooltip]="tv.deniedReason" mat-raised-button class="btn-spacing" color="warn">
                                         <i class="fas fa-times"></i> {{'Common.Denied' | translate }}
                                     </button>
 


### PR DESCRIPTION
- Fixes an issue where individual episodes would all show as denied if an other episode of that show was denied. 
- (API only) A TV show will be 'Denied' if all its episodes are denied (replaces the very recently added 'FullyDenied' property).
- (API only) The denied reason is now exposed for individual episodes.