### PR TITLE
Hide subscribe button when request is closed

### DIFF
--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -533,7 +533,7 @@ namespace Ombi.Core.Engine
                 }
                 else
                 {
-                    if (!x.Available && !x.Available4K)
+                    if (!x.Available && !x.Available4K && (!x.Denied ?? true) && (!x.Denied4K ?? true))
                     {
                         x.ShowSubscribe = true;
                     }

--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -533,7 +533,10 @@ namespace Ombi.Core.Engine
                 }
                 else
                 {
-                    x.ShowSubscribe = true;
+                    if (!x.Available && !x.Available4K)
+                    {
+                        x.ShowSubscribe = true;
+                    }
                     var hasSub = sub.FirstOrDefault(r => r.RequestId == x.Id);
                     x.Subscribed = hasSub != null;
                 }

--- a/src/Ombi.Core/Engine/MusicRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MusicRequestEngine.cs
@@ -270,7 +270,7 @@ namespace Ombi.Core.Engine
                 }
                 else
                 {
-                    if (!x.Available)
+                    if (!x.Available && (!x.Denied ?? false))
                     {
                         x.ShowSubscribe = true;
                     }

--- a/src/Ombi.Core/Engine/MusicRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MusicRequestEngine.cs
@@ -270,7 +270,10 @@ namespace Ombi.Core.Engine
                 }
                 else
                 {
-                    x.ShowSubscribe = true;
+                    if (!x.Available)
+                    {
+                        x.ShowSubscribe = true;
+                    }
                     var hasSub = sub.FirstOrDefault(r => r.RequestId == x.Id);
                     x.Subscribed = hasSub != null;
                 }

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -886,7 +886,10 @@ namespace Ombi.Core.Engine
                 }
                 else
                 {
-                    x.ShowSubscribe = true;
+                    if (!x.Available)
+                    {
+                        x.ShowSubscribe = true;
+                    }
                     var result = relevantSubs.FirstOrDefault(s => s.RequestId == x.Id);
                     x.Subscribed = result != null;
                 }

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -886,7 +886,7 @@ namespace Ombi.Core.Engine
                 }
                 else
                 {
-                    if (!x.Available)
+                    if (!x.Available && (!x.Denied ?? true))
                     {
                         x.ShowSubscribe = true;
                     }


### PR DESCRIPTION
The subscribe button currently still shows when the request is available or denied. 
This PR will hide the button when the request has reached the end of its livecycle.

I anticipated the fix on TV and albums even though I couldn't find that option available in the web app. I'm assuming it wasn't ported to the new V4 layout?