### PR TITLE
Add Title to Partially Available Message

### DIFF
--- a/src/Ombi.Store/Context/OmbiContext.cs
+++ b/src/Ombi.Store/Context/OmbiContext.cs
@@ -212,7 +212,7 @@ namespace Ombi.Store.Context
                             notificationToAdd = new NotificationTemplates
                             {
                                 NotificationType = notificationType,
-                                Message = "Your TV request is now partially available! Season {PartiallyAvailableSeasonNumber} Episodes {PartiallyAvailableEpisodeNumbers}!",
+                                Message = "Your TV request for {Title} is now partially available! Season {PartiallyAvailableSeasonNumber} Episodes {PartiallyAvailableEpisodeNumbers}!",
                                 Subject = "{ApplicationName}: Partially Available Request!",
                                 Agent = agent,
                                 Enabled = true,


### PR DESCRIPTION
If the Title of the show is not menitoned it can be unclear what episodes are now available.