### PR TITLE
perf: stop populating obsolete subscribe fields from search endpoint

### DIFF
--- a/src/Ombi.Core/Engine/MovieSearchEngine.cs
+++ b/src/Ombi.Core/Engine/MovieSearchEngine.cs
@@ -16,7 +16,6 @@ using Ombi.Store.Repository;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Principal;
 using System.Threading.Tasks;
 
 namespace Ombi.Core.Engine
@@ -216,34 +215,9 @@ namespace Ombi.Core.Engine
 
             await RunSearchRules(viewMovie);
 
-            // This requires the rules to be run first to populate the RequestId property
-            await CheckForSubscription(viewMovie);
-
             return viewMovie;
         }
 
-        private async Task CheckForSubscription(SearchMovieViewModel viewModel)
-        {
-            // Check if this user requested it
-            var user = await GetUser();
-            if (user == null)
-            {
-                return;
-            }
-            var request = await RequestService.MovieRequestService.GetAll()
-                .AnyAsync(x => x.RequestedUserId.Equals(user.Id) && x.TheMovieDbId == viewModel.Id);
-            if (request || viewModel.Available)
-            {
-                viewModel.ShowSubscribe = false;
-            }
-            else
-            {
-                viewModel.ShowSubscribe = true;
-                var sub = await _subscriptionRepository.GetAll().FirstOrDefaultAsync(s => s.UserId == user.Id
-                                                                                          && s.RequestId == viewModel.RequestId && s.RequestType == RequestType.Movie);
-                viewModel.Subscribed = sub != null;
-            }
-        }
 
         private async Task<SearchMovieViewModel> ProcessSingleMovie(MovieDbSearchResult movie)
         {

--- a/src/Ombi.Core/Models/Search/SearchViewModel.cs
+++ b/src/Ombi.Core/Models/Search/SearchViewModel.cs
@@ -36,6 +36,7 @@ namespace Ombi.Core.Models.Search
         [Obsolete("Use request service instead")]
         public bool Subscribed { get; set; }
         [NotMapped]
+        [Obsolete("Use request service instead")]
         public bool ShowSubscribe { get; set; }
     }
 }


### PR DESCRIPTION
Follow up of https://github.com/Ombi-app/Ombi/pull/4585
API consumers of Subscribed and ShowSubscribe fields should migrate from /search/movie/* endpoint to /Request/movie/info/*.
For the record, these fields could not be trusted because they were cached on a global level whereas these fields are user-dependent. The Request endpoint is not cached and those fields have been fixed for movies in https://github.com/Ombi-app/Ombi/pull/4585.