### PR TITLE
Detect reidentified content in Emby and Jellyfin

### DIFF
--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -157,6 +157,17 @@ namespace Ombi.Schedule.Jobs.Emby
                     }
 
                     var existingTv = await _repo.GetByEmbyId(tvShow.Id);
+
+                    if (existingTv != null &&
+                        ( existingTv.ImdbId != tvShow.ProviderIds?.Imdb 
+                        || existingTv.TheMovieDbId != tvShow.ProviderIds?.Tmdb
+                        || existingTv.TvDbId != tvShow.ProviderIds?.Tvdb))
+                    {
+                        _logger.LogCritical($"Series '{tvShow.Name}' has different IDs, probably a reidentification.");
+                        await _repo.DeleteTv(existingTv);
+                        existingTv = null;
+                    }
+
                     if (existingTv == null)
                     {
                         _logger.LogDebug("Adding new TV Show {0}", tvShow.Name);

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -163,7 +163,7 @@ namespace Ombi.Schedule.Jobs.Emby
                         || existingTv.TheMovieDbId != tvShow.ProviderIds?.Tmdb
                         || existingTv.TvDbId != tvShow.ProviderIds?.Tvdb))
                     {
-                        _logger.LogCritical($"Series '{tvShow.Name}' has different IDs, probably a reidentification.");
+                        _logger.LogDebug($"Series '{tvShow.Name}' has different IDs, probably a reidentification.");
                         await _repo.DeleteTv(existingTv);
                         existingTv = null;
                     }

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -170,7 +170,7 @@ namespace Ombi.Schedule.Jobs.Emby
 
                     if (existingTv == null)
                     {
-                        _logger.LogDebug("Adding new TV Show {0}", tvShow.Name);
+                        _logger.LogDebug("Adding TV Show {0}", tvShow.Name);
                         mediaToAdd.Add(new EmbyContent
                         {
                             TvDbId = tvShow.ProviderIds?.Tvdb,
@@ -284,12 +284,11 @@ namespace Ombi.Schedule.Jobs.Emby
             else
             {
                 var movieHasChanged = false;
-                if(existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb)
+                if (existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb)
                 {
                     _logger.LogDebug($"Updating existing movie '{movieInfo.Name}'");
                     MapEmbyContent(existingMovie, movieInfo, server, has4K, quality);
                     movieHasChanged = true;
-
                 }
                 else if (!quality.Equals(existingMovie?.Quality, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -303,7 +302,7 @@ namespace Ombi.Schedule.Jobs.Emby
                     movieHasChanged = true;
                 }
 
-                if(movieHasChanged)
+                if (movieHasChanged)
                 {
                     toUpdate.Add(existingMovie);
                 }

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
@@ -132,6 +132,17 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                         }
 
                         var existingTv = await _repo.GetByJellyfinId(tvShow.Id);
+
+                        if (existingTv != null &&
+                            ( existingTv.ImdbId != tvShow.ProviderIds?.Imdb 
+                           || existingTv.TheMovieDbId != tvShow.ProviderIds?.Tmdb
+                           || existingTv.TvDbId != tvShow.ProviderIds?.Tvdb))
+                        {
+                            _logger.LogDebug($"Series '{tvShow.Name}' has different IDs, probably a reidentification.");
+                            await _repo.DeleteTv(existingTv);
+                            existingTv = null;
+                        }
+                        
                         if (existingTv == null)
                         {
                             _logger.LogDebug("Adding new TV Show {0}", tvShow.Name);

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
@@ -230,22 +230,22 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                     return;
                 }
                 _logger.LogDebug($"Adding new movie {movieInfo.Name}");
-                content.Add(new JellyfinContent
-                {
-                    ImdbId = movieInfo.ProviderIds.Imdb,
-                    TheMovieDbId = movieInfo.ProviderIds?.Tmdb,
-                    Title = movieInfo.Name,
-                    Type = MediaType.Movie,
-                    JellyfinId = movieInfo.Id,
-                    Url = JellyfinHelper.GetJellyfinMediaUrl(movieInfo.Id, server?.ServerId, server.ServerHostname),
-                    AddedAt = DateTime.UtcNow,
-                    Quality = has4K ? null : quality,
-                    Has4K = has4K
-                });
+                var newMovie = new JellyfinContent();
+                newMovie.AddedAt = DateTime.UtcNow;
+                MapJellyfinMovie(newMovie, movieInfo, server, has4K, quality);
+                content.Add(newMovie);;
             }
             else
             {
-                if (!quality.Equals(existingMovie?.Quality, StringComparison.InvariantCultureIgnoreCase))
+                var movieHasChanged = false;
+                if(existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb)
+                {
+                    _logger.LogDebug($"Updating existing movie '{movieInfo.Name}'");
+                    MapJellyfinMovie(existingMovie, movieInfo, server, has4K, quality);
+                    movieHasChanged = true;
+
+                }
+                else if (!quality.Equals(existingMovie?.Quality, StringComparison.InvariantCultureIgnoreCase))
                 {
                     _logger.LogDebug($"We have found another quality for Movie '{movieInfo.Name}', Quality: '{quality}'");
                     existingMovie.Quality = has4K ? null : quality;
@@ -255,6 +255,12 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                     // If a 4k movie comes in (we don't store the quality on 4k)
                     // it will always get updated even know it's not changed
                     toUpdate.Add(existingMovie);
+                    movieHasChanged = true;
+                }
+                
+                if(movieHasChanged)
+                {
+                    toUpdate.Add(existingMovie);
                 }
                 else
                 {
@@ -262,6 +268,18 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                     _logger.LogDebug($"We already have movie {movieInfo.Name}");
                 }
             }
+        }
+
+        private void MapJellyfinMovie(JellyfinContent content, JellyfinMovie movieInfo, JellyfinServers server, bool has4K, string quality)
+        {
+            content.ImdbId = movieInfo.ProviderIds.Imdb;
+            content.TheMovieDbId = movieInfo.ProviderIds?.Tmdb;
+            content.Title = movieInfo.Name;
+            content.Type = MediaType.Movie;
+            content.JellyfinId = movieInfo.Id;
+            content.Url = JellyfinHelper.GetJellyfinMediaUrl(movieInfo.Id, server?.ServerId, server.ServerHostname);
+            content.Quality = has4K ? null : quality;
+            content.Has4K = has4K;
         }
 
         private bool ValidateSettings(JellyfinServers server)

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
@@ -145,7 +145,7 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                         
                         if (existingTv == null)
                         {
-                            _logger.LogDebug("Adding new TV Show {0}", tvShow.Name);
+                            _logger.LogDebug("Adding TV Show {0}", tvShow.Name);
                             mediaToAdd.Add(new JellyfinContent
                             {
                                 TvDbId = tvShow.ProviderIds?.Tvdb,
@@ -249,12 +249,11 @@ namespace Ombi.Schedule.Jobs.Jellyfin
             else
             {
                 var movieHasChanged = false;
-                if(existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb)
+                if (existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb)
                 {
                     _logger.LogDebug($"Updating existing movie '{movieInfo.Name}'");
                     MapJellyfinMovie(existingMovie, movieInfo, server, has4K, quality);
                     movieHasChanged = true;
-
                 }
                 else if (!quality.Equals(existingMovie?.Quality, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -269,7 +268,7 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                     movieHasChanged = true;
                 }
                 
-                if(movieHasChanged)
+                if (movieHasChanged)
                 {
                     toUpdate.Add(existingMovie);
                 }

--- a/src/Ombi.Store/Repository/EmbyContentRepository.cs
+++ b/src/Ombi.Store/Repository/EmbyContentRepository.cs
@@ -102,6 +102,13 @@ namespace Ombi.Store.Repository
             return InternalSaveChanges();
         }
 
+        public override async Task DeleteTv(EmbyContent tv)
+        {
+            var episodesToDelete = GetAllEpisodes().Cast<EmbyEpisode>().Where(x => x.ParentId == tv.EmbyId).ToList();
+            Db.EmbyEpisode.RemoveRange(episodesToDelete);
+            await Delete(tv);
+        }
+
         public override RecentlyAddedType RecentlyAddedType => RecentlyAddedType.Emby;
     }
 }

--- a/src/Ombi.Store/Repository/IMediaServerContentRepository.cs
+++ b/src/Ombi.Store/Repository/IMediaServerContentRepository.cs
@@ -14,6 +14,7 @@ namespace Ombi.Store.Repository
         IQueryable<IMediaServerEpisode> GetAllEpisodes();
         Task<IMediaServerEpisode> Add(IMediaServerEpisode content);
         Task AddRange(IEnumerable<IMediaServerEpisode> content);
+        Task DeleteTv(Content tv);
         void UpdateWithoutSave(IMediaServerContent existingContent);
     }
 }

--- a/src/Ombi.Store/Repository/JellyfinContentRepository.cs
+++ b/src/Ombi.Store/Repository/JellyfinContentRepository.cs
@@ -104,6 +104,13 @@ namespace Ombi.Store.Repository
             return InternalSaveChanges();
         }
 
+        public override async Task DeleteTv(JellyfinContent tv)
+        {
+            var episodesToDelete = GetAllEpisodes().Cast<JellyfinEpisode>().Where(x => x.ParentId == tv.JellyfinId).ToList();
+            Db.JellyfinEpisode.RemoveRange(episodesToDelete);
+            await Delete(tv);
+        }
+
         public override RecentlyAddedType RecentlyAddedType => RecentlyAddedType.Jellyfin;
     }
 }

--- a/src/Ombi.Store/Repository/MediaServerRepository.cs
+++ b/src/Ombi.Store/Repository/MediaServerRepository.cs
@@ -22,5 +22,6 @@ namespace Ombi.Store.Repository
         public abstract Task AddRange(IEnumerable<IMediaServerEpisode> content);
         public abstract void UpdateWithoutSave(IMediaServerContent existingContent);
         public abstract Task UpdateRange(IEnumerable<IMediaServerContent> existingContent);
+        public abstract Task DeleteTv(T tv);
     }
 }

--- a/src/Ombi.Store/Repository/PlexContentRepository.cs
+++ b/src/Ombi.Store/Repository/PlexContentRepository.cs
@@ -169,5 +169,12 @@ namespace Ombi.Store.Repository
             Db.PlexServerContent.UpdateRange((IEnumerable<PlexServerContent>)existingContent);
             return InternalSaveChanges();
         }
+
+        public override Task DeleteTv(PlexServerContent tv)
+        {
+            // not used for now
+            // TODO: delete episodes, then delete series
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
This addresses the issue mentioned here: https://github.com/Ombi-app/Ombi/issues/4472#issuecomment-1030160547
This should prevent the need of clearing data if a media was manually reidentified due to automatic detection failing.

At first glance it seems Plex sync doesn't do it but the sync has a completely different logic so probably the issue doesn't occur there.