### PR TITLE
feat(discover): Show more relevant shows in upcoming TV

### DIFF
--- a/src/Ombi.Core/Engine/MovieSearchEngine.cs
+++ b/src/Ombi.Core/Engine/MovieSearchEngine.cs
@@ -161,7 +161,7 @@ namespace Ombi.Core.Engine
             var result = await Cache.GetOrAddAsync(CacheKeys.UpcomingMovies, async () =>
             {
                 var langCode = await DefaultLanguageCode(null);
-                return await MovieApi.Upcoming(langCode);
+                return await MovieApi.UpcomingMovies(langCode);
             }, DateTimeOffset.Now.AddHours(12));
             if (result != null)
             {

--- a/src/Ombi.Core/Engine/V2/MovieSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/MovieSearchEngineV2.cs
@@ -287,7 +287,7 @@ namespace Ombi.Core.Engine.V2
             var result = await Cache.GetOrAddAsync(CacheKeys.UpcomingMovies, async () =>
             {
                 var langCode = await DefaultLanguageCode(null);
-                return await MovieApi.Upcoming(langCode);
+                return await MovieApi.UpcomingMovies(langCode);
             }, DateTimeOffset.Now.AddHours(12));
             if (result != null)
             {
@@ -307,7 +307,7 @@ namespace Ombi.Core.Engine.V2
             foreach (var pagesToLoad in pages)
             {
                 var apiResult = await Cache.GetOrAddAsync(nameof(UpcomingMovies) + pagesToLoad.Page + langCode,
-                    () =>  MovieApi.Upcoming(langCode, pagesToLoad.Page), DateTimeOffset.Now.AddHours(12));
+                    () =>  MovieApi.UpcomingMovies(langCode, pagesToLoad.Page), DateTimeOffset.Now.AddHours(12));
                 results.AddRange(apiResult.Skip(pagesToLoad.Skip).Take(pagesToLoad.Take));
             }
             return await TransformMovieResultsToResponse(results);

--- a/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
@@ -22,7 +22,7 @@ namespace Ombi.Api.TheMovieDb
         Task<List<MovieDbSearchResult>> GetMoviesViaKeywords(string keywordId, string langCode, CancellationToken cancellationToken, int? page = null);
         Task<List<TvSearchResult>> SearchTv(string searchTerm, string year = default);
         Task<List<MovieDbSearchResult>> TopRated(string languageCode, int? page = null);
-        Task<List<MovieDbSearchResult>> Upcoming(string languageCode, int? page = null);
+        Task<List<MovieDbSearchResult>> UpcomingMovies(string languageCode, int? page = null);
         Task<List<MovieDbSearchResult>> TopRatedTv(string languageCode, int? page = null);
         Task<List<MovieDbSearchResult>> TrendingTv(string languageCode, int? page = null);
         Task<List<MovieDbSearchResult>> UpcomingTv(string languageCode, int? page = null);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/34862846/165705021-68ba7ec4-d63e-454b-9d8e-8e01a377f3c1.png)
After:
![image](https://user-images.githubusercontent.com/34862846/165705088-e21b5f9b-a148-4092-ae50-932e300ff21b.png)

Upcoming TV would use filter release_date which does not exist for TVs so this basically turned out to be exactly the same as the popular section. I'm surprised this went unnoticed for so long (by myself included!).
We now use the first air date. I fiddled around and found the sweet spot to be shows that will release in the next month, as opposed to upcoming movies which looks for movies released between D+7 and D+27. 

Now that's a quick win 😃 