### PR TITLE
Minor changes to Emby and Jellyfin sync

### DIFF
--- a/src/Ombi.Api.Emby/EmbyApi.cs
+++ b/src/Ombi.Api.Emby/EmbyApi.cs
@@ -106,7 +106,7 @@ namespace Ombi.Api.Emby
 
             request.AddQueryString("Fields", "ProviderIds,Overview");
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("IsMissing", "False");
 
             return await Api.Request<EmbyItemContainer<EmbyMovie>>(request);
         }
@@ -180,7 +180,7 @@ namespace Ombi.Api.Emby
                 request.AddQueryString("ParentId", parentIdFilder);
             }
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("IsMissing", "False");
 
             AddHeaders(request, apiKey);
 
@@ -207,7 +207,7 @@ namespace Ombi.Api.Emby
             request.AddQueryString("IncludeItemTypes", type);
             request.AddQueryString("Fields", includeOverview ? "ProviderIds,Overview" : "ProviderIds");
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("IsMissing", "False");
 
             AddHeaders(request, apiKey);
 
@@ -229,7 +229,7 @@ namespace Ombi.Api.Emby
                 request.AddQueryString("ParentId", parentIdFilder);
             }
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("isMissing", "False");
 
             AddHeaders(request, apiKey);
 

--- a/src/Ombi.Api.Jellyfin/JellyfinApi.cs
+++ b/src/Ombi.Api.Jellyfin/JellyfinApi.cs
@@ -82,7 +82,7 @@ namespace Ombi.Api.Jellyfin
 
             request.AddQueryString("Fields", "ProviderIds,Overview");
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("isMissing", "False");
 
             return await Api.Request<JellyfinItemContainer<JellyfinMovie>>(request);
         }
@@ -143,7 +143,7 @@ namespace Ombi.Api.Jellyfin
             request.AddQueryString("IncludeItemTypes", type);
             request.AddQueryString("Fields", includeOverview ? "ProviderIds,Overview" : "ProviderIds");
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("isMissing", "False");
 
             AddHeaders(request, apiKey);
 
@@ -165,7 +165,7 @@ namespace Ombi.Api.Jellyfin
                 request.AddQueryString("ParentId", parentIdFilder);
             }
 
-            request.AddQueryString("IsVirtualItem", "False");
+            request.AddQueryString("isMissing", "False");
 
             AddHeaders(request, apiKey);
 

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -170,18 +170,26 @@ namespace Ombi.Schedule.Jobs.Emby
 
                         if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value != ep.IndexNumber)
                         {
-                            epToAdd.Add(new EmbyEpisode
+                            int episodeNumber = ep.IndexNumber;
+                            do
                             {
-                                EmbyId = ep.Id,
-                                EpisodeNumber = ep.IndexNumberEnd.Value,
-                                SeasonNumber = ep.ParentIndexNumber,
-                                ParentId = ep.SeriesId,
-                                TvDbId = ep.ProviderIds.Tvdb,
-                                TheMovieDbId = ep.ProviderIds.Tmdb,
-                                ImdbId = ep.ProviderIds.Imdb,
-                                Title = ep.Name,
-                                AddedAt = DateTime.UtcNow
-                            });
+                                _logger.LogDebug($"Multiple-episode file detected. Adding episode ${episodeNumber}");
+                                episodeNumber++;
+                                epToAdd.Add(new EmbyEpisode
+                                {
+                                    EmbyId = ep.Id,
+                                    EpisodeNumber = episodeNumber,
+                                    SeasonNumber = ep.ParentIndexNumber,
+                                    ParentId = ep.SeriesId,
+                                    TvDbId = ep.ProviderIds.Tvdb,
+                                    TheMovieDbId = ep.ProviderIds.Tmdb,
+                                    ImdbId = ep.ProviderIds.Imdb,
+                                    Title = ep.Name,
+                                    AddedAt = DateTime.UtcNow
+                                });
+
+                            } while (episodeNumber < ep.IndexNumberEnd.Value);
+                        
                         }
                     }
                 }

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -130,12 +130,6 @@ namespace Ombi.Schedule.Jobs.Emby
                 {
                     processed++;
 
-                    if (ep.LocationType?.Equals("Virtual", StringComparison.InvariantCultureIgnoreCase) ?? false)
-                    {
-                        // For some reason Emby is not respecting the `IsVirtualItem` field.
-                        continue;
-                    }
-
                     // Let's make sure we have the parent request, stop those pesky forign key errors,
                     // Damn me having data integrity
                     var parent = await _repo.GetByEmbyId(ep.SeriesId);

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinEpisodeSync.cs
@@ -106,12 +106,6 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                 {
                     processed++;
 
-                    if (ep.LocationType?.Equals("Virtual", StringComparison.InvariantCultureIgnoreCase) ?? false)
-                    {
-                        // For some reason Jellyfin is not respecting the `IsVirtualItem` field.
-                        continue;
-                    }
-
                     // Let's make sure we have the parent request, stop those pesky forign key errors,
                     // Damn me having data integrity
                     var parent = await _repo.GetByJellyfinId(ep.SeriesId);

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinEpisodeSync.cs
@@ -146,18 +146,25 @@ namespace Ombi.Schedule.Jobs.Jellyfin
 
                         if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value != ep.IndexNumber)
                         {
-                            epToAdd.Add(new JellyfinEpisode
+                            int episodeNumber = ep.IndexNumber;
+                            do
                             {
-                                JellyfinId = ep.Id,
-                                EpisodeNumber = ep.IndexNumberEnd.Value,
-                                SeasonNumber = ep.ParentIndexNumber,
-                                ParentId = ep.SeriesId,
-                                TvDbId = ep.ProviderIds.Tvdb,
-                                TheMovieDbId = ep.ProviderIds.Tmdb,
-                                ImdbId = ep.ProviderIds.Imdb,
-                                Title = ep.Name,
-                                AddedAt = DateTime.UtcNow
-                            });
+                                _logger.LogDebug($"Multiple-episode file detected. Adding episode ${episodeNumber}");
+                                episodeNumber++;
+                                epToAdd.Add(new JellyfinEpisode
+                                {
+                                    JellyfinId = ep.Id,
+                                    EpisodeNumber = episodeNumber,
+                                    SeasonNumber = ep.ParentIndexNumber,
+                                    ParentId = ep.SeriesId,
+                                    TvDbId = ep.ProviderIds.Tvdb,
+                                    TheMovieDbId = ep.ProviderIds.Tmdb,
+                                    ImdbId = ep.ProviderIds.Imdb,
+                                    Title = ep.Name,
+                                    AddedAt = DateTime.UtcNow
+                                });
+
+                            } while (episodeNumber < ep.IndexNumberEnd.Value);
                         }
                     }
                 }


### PR DESCRIPTION
- Use a more reliable filter to missing items. IsVirtualItem is not an available filter ; instead isMissing has found itself to be reliable.
- Allow syncing files containing more than 2 episodes.