### PR TITLE
Missing Poster broken link fix

### DIFF
--- a/src/Ombi/ClientApp/src/app/media-details/components/movie/movie-details.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/movie/movie-details.component.html
@@ -24,7 +24,7 @@
 
             <div class="row justify-content-center justify-content-sm-start header-container">
                 <div class="details-poster-container">
-                    <media-poster [posterPath]="'https://image.tmdb.org/t/p/w300/' + movie.posterPath"></media-poster>
+                    <media-poster [posterPath]=movie.posterPath></media-poster>
                 </div>
 
                 <!--Next to poster-->
@@ -107,7 +107,7 @@
                                 </span>
                             </span>
                         </span>
-                        
+
                         <span *ngIf="movieRequest?.showSubscribe">
                             <button *ngIf="!movieRequest?.subscribed" (click)="notify()" id="notifyBtn"
                                 mat-raised-button class="btn-spacing"> <i class="fas fa-bell"></i>

--- a/src/Ombi/ClientApp/src/app/media-details/components/movie/movie-details.component.ts
+++ b/src/Ombi/ClientApp/src/app/media-details/components/movie/movie-details.component.ts
@@ -68,6 +68,7 @@ export class MovieDetailsComponent implements OnInit{
         if (this.imdbId) {
             this.searchService.getMovieByImdbId(this.imdbId).subscribe(async x => {
                 this.movie = x;
+                this.checkPoster();
                 if (this.movie.requestId > 0) {
                     // Load up this request
                     this.hasRequest = true;
@@ -78,6 +79,7 @@ export class MovieDetailsComponent implements OnInit{
         } else {
             this.searchService.getFullMovieDetails(this.theMovidDbId).subscribe(async x => {
                 this.movie = x;
+                this.checkPoster();
                 if (this.movie.requestId > 0) {
                     // Load up this request
                     this.hasRequest = true;
@@ -272,7 +274,14 @@ export class MovieDetailsComponent implements OnInit{
             }
         });
     }
-
+    private checkPoster() {
+      if (this.movie.posterPath == null) {
+        this.movie.posterPath = "../../../images/default_movie_poster.png";
+      }
+      else {
+        this.movie.posterPath = "https://image.tmdb.org/t/p/w300/" + this.movie.posterPath
+      };
+    }
     private loadAdvancedInfo() {
         const profile = this.radarrService.getQualityProfilesFromSettings();
         const folders = this.radarrService.getRootFoldersFromSettings();

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.html
@@ -42,7 +42,7 @@
                 <div class="small-middle-container">
                     <div class="row justify-content-center justify-content-sm-start header-container">
                         <div class="details-poster-container">
-                            <media-poster [posterPath]="'https://image.tmdb.org/t/p/w300/' + tv.images.original"></media-poster>
+                            <media-poster [posterPath]=tv.images.original></media-poster>
                         </div>
                         <!--Next to poster-->
                         <div class="details-button-container">
@@ -82,7 +82,7 @@
                                         class="btn-spacing" color="accent" [disabled]>
                                     <i class="fas fa-check"></i> {{'Common.PartiallyAvailable' | translate }}</button>
                                     <!-- end unaired episodes-->
-                                    
+
                                     <button id="deniedButton" *ngIf="tv.denied" [matTooltip]="tv.deniedReason" mat-raised-button class="btn-spacing" color="warn">
                                         <i class="fas fa-times"></i> {{'Common.Denied' | translate }}
                                     </button>

--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.ts
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.ts
@@ -48,6 +48,7 @@ export class TvDetailsComponent implements OnInit {
 
     public async ngOnInit() {
         await this.load();
+        this.checkPoster();
     }
 
     public async load() {
@@ -128,7 +129,14 @@ export class TvDetailsComponent implements OnInit {
     public allEpisodesRequested(): boolean {
         return this.tv.seasonRequests.every(e => e.episodes.every(x => x.approved || x.requested));
     }
-
+    private checkPoster() {
+      if (this.tv.images.original == null) {
+        this.tv.images.original = "../../../images/default_movie_poster.png";
+      }
+      else {
+        this.tv.images.original = 'https://image.tmdb.org/t/p/w300/' + this.tv.images.original
+      };
+    }
     private loadAdvancedInfo() {
         const profile = this.sonarrService.getQualityProfilesWithoutSettings();
         const folders = this.sonarrService.getRootFoldersWithoutSettings();


### PR DESCRIPTION
added checks and string formatting in the case of having a missing poster on tmdb to both tv and movies, removed the hard coded tmdb url from the html template and moved into component.