### PR TITLE
Added media type tag to media type text

### DIFF
--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
@@ -2,7 +2,7 @@
 
 <div id="result{{result.id}}" *ngIf="fullyLoaded" class="ombi-card dark-card c" [style.display]="hide ? 'none' : 'block'">
     <div class="card-top-info">
-        <div class="top-left" id="type{{result.id}}">
+        <div class="top-left" id="type{{result.id}}-{{RequestType[result.type]}}">
             {{ 'Common.' + RequestType[result.type] | translate }}
         </div>
         <div class="{{getStatusClass()}} top-right" id="status{{result.id}}">


### PR DESCRIPTION
Added a simple addition to the "top-left" element's id in the form of the media type, this enables theming individual media types which isn't possible in the current setup, added to id so it won't break other hard-coded CSS/existing themes.