### PR TITLE
Fixes SickRageEpisodeSetStatus model to accept array of objects via data prop

### DIFF
--- a/src/Ombi.Api.SickRage/Models/SickRageEpisodeStatus.cs
+++ b/src/Ombi.Api.SickRage/Models/SickRageEpisodeStatus.cs
@@ -9,7 +9,7 @@
 
     public class SickRageEpisodeSetStatus
     {
-        public Data data { get; set; }
+        public Data[] data { get; set; }
         public string message { get; set; }
         public string result { get; set; }
     }


### PR DESCRIPTION
episode results returned from SiCKRAGE API when changing status of episodes is an array of objects, this merge request corrects SickRageEpisodeSetStatus model data property to accommodate that