### PR TITLE
Log Microsoft warnings to log file

### DIFF
--- a/src/Ombi/appsettings.json
+++ b/src/Ombi/appsettings.json
@@ -4,7 +4,7 @@
     "LogLevel": {
       "Default": "Warning",
       "System": "Warning",
-      "Microsoft": "None",
+      "Microsoft": "Warning",
       "Hangfire": "None",
       "System.Net.Http.HttpClient.health-checks": "Warning",
       "HealthChecks": "Warning"


### PR DESCRIPTION
In my case, Microsoft.EntityFrameworkCore.Query errors were silent in the file log which doesn't help troubleshooting.