### PR TITLE
Ombi.Api.Lidarr: Remove unused fields from ArtistAdd

### DIFF
--- a/src/Ombi.Api.Lidarr/Models/ArtistAdd.cs
+++ b/src/Ombi.Api.Lidarr/Models/ArtistAdd.cs
@@ -5,27 +5,16 @@ namespace Ombi.Api.Lidarr.Models
 {
     public class ArtistAdd
     {
-        public string status { get; set; }
-        public bool ended { get; set; }
         public string artistName { get; set; }
         public string foreignArtistId { get; set; }
-        public int tadbId { get; set; }
-        public int discogsId { get; set; }
-        public string overview { get; set; }
-        public string disambiguation { get; set; }
         public Link[] links { get; set; }
         public Image[] images { get; set; }
-        public string remotePoster { get; set; }
         public int qualityProfileId { get; set; }
         public int metadataProfileId { get; set; }
         public bool albumFolder { get; set; }
         public bool monitored { get; set; }
         public string cleanName { get; set; }
-        public string sortName { get; set; }
-        public object[] tags { get; set; }
         public DateTime added { get; set; }
-        public Ratings ratings { get; set; }
-        public Statistics statistics { get; set; }
         public Addoptions addOptions { get; set; }
         public string rootFolderPath { get; set; }
     }


### PR DESCRIPTION
When an artist is not found in Lidarr as part of requesting an album,
MusicSender will make a POST request against the /api/v1/artist endpoint
to add such artist.

Not all fields defined in ArtistAdd are initialized, and those
uninitialized will be `null` values in the JSON body of the request, as
shown in this intercepted request:

```
{
    "addOptions": {
        "AlbumsToMonitor": [
            "e5c48b66-44ef-3685-ad53-45dbcd7294c0"
        ],
        "monitor": 6,
        "monitored": true,
        "searchForMissingAlbums": false
    },
    "added": "2022-08-10T06:49:32.4374278+00:00",
    "albumFolder": true,
    "artistName": "Manolo García",
    "cleanName": "manologarcía",
    "disambiguation": null,
    "discogsId": 0,
    "ended": false,
    "foreignArtistId": "1c8309da-9789-40bf-b9c2-e20064263820",
    "images": [],
    "links": [],
    "metadataProfileId": 1,
    "monitored": true,
    "overview": null,
    "qualityProfileId": 3,
    "ratings": null,
    "remotePoster": null,
    "rootFolderPath": "/media/music/",
    "sortName": null,
    "statistics": null,
    "status": null,
    "tadbId": 0,
    "tags": null
}
```

This request will fail and Lidarr will return a 400 BadRequest error
with the following message:

```
2022-08-10 01:45:52.458 +00:00 [Error] StatusCode: BadRequest, Reason: Bad Request, RequestUri: http://lidarr:8686/api/v1/artist
2022-08-10 01:45:52.459 +00:00 [Debug] {
  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "traceId": "00-52e01b322a05d7c6633eca2488ef2a5c-06345b3bb8c4bb6c-00",
  "errors": {
    "$.status": [
      "The JSON value could not be converted to NzbDrone.Core.Music.ArtistStatusType. Path: $.status | LineNumber: 0 | BytePositionInLine: 14."
    ]
  }
}
```

Removing all the `null` fields from the JSON body fixes the problem and
correctly adds the artist to Lidarr.