### PR TITLE
Fix conflicting property name for Swagger

### DIFF
--- a/src/Ombi.Api.Plex/Models/Metadata.cs
+++ b/src/Ombi.Api.Plex/Models/Metadata.cs
@@ -39,6 +39,7 @@ namespace Ombi.Api.Plex.Models
         public string grandparentTheme { get; set; }
         public string chapterSource { get; set; }
         public Medium[] Media { get; set; }
+         [JsonProperty("Guid")] // force uppercase to solve conflict with lowercase guid
         public List<PlexGuids> Guid { get; set; } = new List<PlexGuids>();
     }
 


### PR DESCRIPTION
Finally solved side-effect of https://github.com/Ombi-app/Ombi/pull/4652 and https://github.com/Ombi-app/Ombi/commit/ab1a11af78efbe9d37bd55aa80a640796c138a98 's quick fix.
Plex sync tested and working.
Fixes https://github.com/Ombi-app/Ombi/issues/4720
