### PR TITLE
Add more curly variables for partially available notification

### DIFF
--- a/src/Ombi.Notifications.Tests/NotificationMessageCurlysTests.cs
+++ b/src/Ombi.Notifications.Tests/NotificationMessageCurlysTests.cs
@@ -324,6 +324,8 @@ namespace Ombi.Notifications.Tests
             Assert.That("name", Is.EqualTo(sut.ApplicationName));
             Assert.That(sut.PartiallyAvailableEpisodeNumbers, Is.EqualTo("1, 2"));
             Assert.That(sut.PartiallyAvailableSeasonNumber, Is.EqualTo("1"));
+            Assert.That(sut.PartiallyAvailableEpisodeCount, Is.EqualTo("2"));
+            Assert.That(sut.PartiallyAvailableEpisodesList, Is.EqualTo("1x1, 1x2"));
         }
 
         [Test]

--- a/src/Ombi.Notifications/NotificationMessageCurlys.cs
+++ b/src/Ombi.Notifications/NotificationMessageCurlys.cs
@@ -186,6 +186,14 @@ namespace Ombi.Notifications
                 {
                     PartiallyAvailableEpisodeNumbers = epNumber;
                 }
+                if (opts.Substitutes.TryGetValue("EpisodesCount", out var epCount))
+                {
+                    PartiallyAvailableEpisodeCount = epCount;
+                }
+                if (opts.Substitutes.TryGetValue("SeasonEpisodes", out var sEpisodes))
+                {
+                    PartiallyAvailableEpisodesList = sEpisodes;
+                }
             }
         }
 
@@ -295,6 +303,8 @@ namespace Ombi.Notifications
         public string ProviderId { get; set; }
         public string PartiallyAvailableEpisodeNumbers { get; set; }
         public string PartiallyAvailableSeasonNumber { get; set; }
+        public string PartiallyAvailableEpisodeCount { get; set; }
+        public string PartiallyAvailableEpisodesList { get; set; }
 
         // System Defined
         private string LongDate => DateTime.Now.ToString("D");
@@ -336,6 +346,8 @@ namespace Ombi.Notifications
             { nameof(ProviderId), ProviderId },
             { nameof(PartiallyAvailableEpisodeNumbers), PartiallyAvailableEpisodeNumbers },
             { nameof(PartiallyAvailableSeasonNumber), PartiallyAvailableSeasonNumber },
+            { nameof(PartiallyAvailableEpisodesList), PartiallyAvailableEpisodesList },
+            { nameof(PartiallyAvailableEpisodeCount), PartiallyAvailableEpisodeCount },
         };
     }
 }

--- a/src/Ombi.Schedule/Jobs/ArrAvailabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/ArrAvailabilityChecker.cs
@@ -212,6 +212,8 @@ namespace Ombi.Schedule.Jobs.Radarr
                     };
                     notification.Substitutes.Add("Season", availableEpisode.First().SeasonNumber.ToString());
                     notification.Substitutes.Add("Episodes", string.Join(", ", availableEpisode.Select(x => x.EpisodeNumber)));
+                    notification.Substitutes.Add("EpisodesCount", $"{availableEpisode.Count}");
+                    notification.Substitutes.Add("SeasonEpisodes", string.Join(", ", availableEpisode.Select(x => $"{x.SeasonNumber}x{x.EpisodeNumber}" )));
                     await _notification.Notify(notification);
                 }
             }

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyAvaliabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyAvaliabilityChecker.cs
@@ -227,6 +227,8 @@ namespace Ombi.Schedule.Jobs.Emby
                     };
                     notification.Substitutes.Add("Season", availableEpisode.First().SeasonNumber.ToString());
                     notification.Substitutes.Add("Episodes", string.Join(", ", availableEpisode.Select(x => x.EpisodeNumber)));
+                    notification.Substitutes.Add("EpisodesCount", $"{availableEpisode.Count}");
+                    notification.Substitutes.Add("SeasonEpisodes", string.Join(", ", availableEpisode.Select(x => $"{x.SeasonNumber}x{x.EpisodeNumber}" )));
                     await _notificationService.Notify(notification);
                 }
             }

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinAvaliabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinAvaliabilityChecker.cs
@@ -253,6 +253,8 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                     };
                     notification.Substitutes.Add("Season", availableEpisode.First().SeasonNumber.ToString());
                     notification.Substitutes.Add("Episodes", string.Join(", ", availableEpisode.Select(x => x.EpisodeNumber)));
+                    notification.Substitutes.Add("EpisodesCount", $"{availableEpisode.Count}");
+                    notification.Substitutes.Add("SeasonEpisodes", string.Join(", ", availableEpisode.Select(x => $"{x.SeasonNumber}x{x.EpisodeNumber}" )));
                     await _notificationService.Notify(notification);
                 }
             }

--- a/src/Ombi.Schedule/Jobs/Plex/PlexAvailabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexAvailabilityChecker.cs
@@ -174,6 +174,8 @@ namespace Ombi.Schedule.Jobs.Plex
                     };
                     notification.Substitutes.Add("Season", availableEpisode.First().SeasonNumber.ToString());
                     notification.Substitutes.Add("Episodes", string.Join(", " ,availableEpisode.Select(x => x.EpisodeNumber)));
+                    notification.Substitutes.Add("EpisodesCount", $"{availableEpisode.Count}");
+                    notification.Substitutes.Add("SeasonEpisodes", string.Join(", ", availableEpisode.Select(x => $"{x.SeasonNumber}x{x.EpisodeNumber}" )));
                     await _notificationService.Notify(notification);
                 }
             }

--- a/src/Ombi.Store/Context/OmbiContext.cs
+++ b/src/Ombi.Store/Context/OmbiContext.cs
@@ -213,7 +213,7 @@ namespace Ombi.Store.Context
                             notificationToAdd = new NotificationTemplates
                             {
                                 NotificationType = notificationType,
-                                Message = "Your TV request for {Title} is now partially available! Season {PartiallyAvailableSeasonNumber} Episodes {PartiallyAvailableEpisodeNumbers}!",
+                                Message = "Your TV request for {Title} is now partially available! Episodes {PartiallyAvailableEpisodesList}!",
                                 Subject = "{ApplicationName}: Partially Available Request!",
                                 Agent = agent,
                                 Enabled = true,


### PR DESCRIPTION
This adds two new variables for partially available notifications:
- `PartiallyAvailableEpisodeCount`: the number of episodes that became available
- `PartiallyAvailableEpisodesList`: the list of episodes that became available with the format `SxE` where S is the season number, and E is the episode number. Example: `1x15`

The first one is a nice to have.
The second one solves an issue with `PartiallyAvailableSeasonNumber` and `PartiallyAvailableEpisodeNumbers` not being clear enough if the notification was about multiple seasons.

This turns the default notification from:

> Season 1 Episodes 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2

to:

> Episodes 1x1, 1x2, 1x3, 1x4, 1x5, 1x6, 1x7, 1x8, 1x9, 1x10, 2x1, 2x2, 2x3, 2x4, 2x5, 2x6, 2x7, 2x8, 2x9, 2x10, 3x1, 3x2