### PR TITLE
Remove added trailing slash from webhook URL

### DIFF
--- a/src/Ombi.Api.Webhook/WebhookApi.cs
+++ b/src/Ombi.Api.Webhook/WebhookApi.cs
@@ -19,8 +19,8 @@ namespace Ombi.Api.Webhook
 
         public async Task PushAsync(string baseUrl, string accessToken, IDictionary<string, string> parameters)
         {
-            var request = new Request("", baseUrl, HttpMethod.Post);
-
+            var request = new Request("", baseUrl, HttpMethod.Post) {IgnoreBaseUrlAppend = true};
+            
             if (!string.IsNullOrWhiteSpace(accessToken))
             {
                 request.AddHeader("Access-Token", accessToken);


### PR DESCRIPTION
At the moment it is impossible to use a webhook pointing to an endpoint without Ombi adding a trailing `/` at the end of the URL. This PR removes the feature that let Ombi automatically add the trailing `/` at the end of the webhook URL.

This will break existing setups that rely on Ombi to add an expected trailing `/` but without this, other setups cannot use webhooks where the endpoint expects no trailing `/`.