### PR TITLE
Upgrades nuget packages. Removes deprecated packages. Fixes build warnings.

### DIFF
--- a/src/Ombi.Api.Mattermost/Ombi.Api.Mattermost.csproj
+++ b/src/Ombi.Api.Mattermost/Ombi.Api.Mattermost.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Api.MusicBrainz/MusicBrainzApi.cs
+++ b/src/Ombi.Api.MusicBrainz/MusicBrainzApi.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Hqub.MusicBrainz.API;
 using Hqub.MusicBrainz.API.Entities;
-using Hqub.MusicBrainz.API.Entities.Collections;
 using Newtonsoft.Json;
 using Ombi.Api.MusicBrainz.Models;
 
@@ -14,28 +12,30 @@ namespace Ombi.Api.MusicBrainz
 {
     public class MusicBrainzApi : IMusicBrainzApi
     {
+        private readonly MusicBrainzClient _client;
         private readonly IApi _api;
 
-        public MusicBrainzApi(IApi api)
+        public MusicBrainzApi(MusicBrainzClient client, IApi api)
         {
+            _client = client;
             _api = api;
         }
 
         public Task<Release> GetAlbumInformation(string albumId)
         {
-            var album = Release.GetAsync(albumId);
+            var album = _client.Releases.GetAsync(albumId);
             return album;
         }
 
         public async Task<IEnumerable<Artist>> SearchArtist(string artistQuery)
         {
-            var artist = await Artist.SearchAsync(artistQuery, 10);
+            var artist = await _client.Artists.SearchAsync(artistQuery, 10);
             return artist.Items.Where(x => x.Type != null);
         }
 
         public async Task<Artist> GetArtistInformation(string artistId)
         {
-            var artist = await Artist.GetAsync(artistId, "artist-rels", "url-rels", "releases", "release-groups");
+            var artist = await _client.Artists.GetAsync(artistId, "artist-rels", "url-rels", "releases", "release-groups");
             return artist;
         }
 
@@ -49,8 +49,7 @@ namespace Ombi.Api.MusicBrainz
             };
 
             // Search for a release by title.
-            var releases = await Release.SearchAsync(query);
-
+            var releases = await _client.Releases.SearchAsync(query);
             return releases.Items;
         }
 
@@ -64,11 +63,6 @@ namespace Ombi.Api.MusicBrainz
                 return JsonConvert.DeserializeObject<ReleaseGroupArt>(jsonContent, Api.Settings);
             }
             return null;
-        }
-
-        private void AddHeaders(Request req)
-        {
-            req.AddHeader("Accept", "application/json");
         }
     }
 }

--- a/src/Ombi.Api.MusicBrainz/Ombi.Api.MusicBrainz.csproj
+++ b/src/Ombi.Api.MusicBrainz/Ombi.Api.MusicBrainz.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MusicBrainzAPI" Version="2.0.1" />
+    <PackageReference Include="MusicBrainzAPI" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Api.Notifications/Ombi.Api.Notifications.csproj
+++ b/src/Ombi.Api.Notifications/Ombi.Api.Notifications.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.4.2" />
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Api.Radarr/Ombi.Api.Radarr.csproj
+++ b/src/Ombi.Api.Radarr/Ombi.Api.Radarr.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Api.Twilio/Ombi.Api.Twilio.csproj
+++ b/src/Ombi.Api.Twilio/Ombi.Api.Twilio.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Twilio" Version="5.37.2" />
+    <PackageReference Include="Twilio" Version="5.80.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Ombi.Api/Ombi.Api.csproj
+++ b/src/Ombi.Api/Ombi.Api.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Polly" Version="7.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Core.Tests/Engine/MovieRequestEngineTests.cs
+++ b/src/Ombi.Core.Tests/Engine/MovieRequestEngineTests.cs
@@ -2,7 +2,6 @@
 using Moq;
 using Moq.AutoMock;
 using NUnit.Framework;
-using Ombi.Core.Authentication;
 using Ombi.Core.Engine;
 using Ombi.Core.Helpers;
 using Ombi.Core.Models.Requests;
@@ -52,7 +51,7 @@ namespace Ombi.Core.Tests.Engine
 
             _subject = _mocker.CreateInstance<MovieRequestEngine>();
             var list = DbHelper.GetQueryableMockDbSet(new RequestSubscription());
-            _mocker.Setup<IRepository<RequestSubscription>, IQueryable<RequestSubscription>>(x => x.GetAll()).Returns(new List<RequestSubscription>().AsQueryable().BuildMock().Object);
+            _mocker.Setup<IRepository<RequestSubscription>, IQueryable<RequestSubscription>>(x => x.GetAll()).Returns(new List<RequestSubscription>().AsQueryable().BuildMock());
         }
 
         [Test]

--- a/src/Ombi.Core.Tests/Engine/MovieRequestLimitsTests.cs
+++ b/src/Ombi.Core.Tests/Engine/MovieRequestLimitsTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using Moq.AutoMock;
 using NUnit.Framework;
 using Ombi.Core.Authentication;
-using Ombi.Core.Engine;
 using Ombi.Core.Helpers;
 using Ombi.Core.Models;
 using Ombi.Core.Services;
@@ -64,7 +63,7 @@ namespace Ombi.Core.Tests.Engine
             var user = new OmbiUser();
 
             var um = _mocker.GetMock<OmbiUserManager>();
-            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock().Object);
+            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock());
             
 
 
@@ -82,7 +81,7 @@ namespace Ombi.Core.Tests.Engine
             };
 
             var um = _mocker.GetMock<OmbiUserManager>();
-            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock().Object);
+            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock());
 
 
 
@@ -100,7 +99,7 @@ namespace Ombi.Core.Tests.Engine
                 MovieRequestLimit = 1
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(new List<RequestLog>().AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(new List<RequestLog>().AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -131,7 +130,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -206,7 +205,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -239,7 +238,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -272,7 +271,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -311,7 +310,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -344,7 +343,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user);
 
@@ -376,7 +375,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user, today);
 
@@ -415,7 +414,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user, today);
 
@@ -448,7 +447,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user, today);
 
@@ -481,7 +480,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user, today);
 
@@ -521,7 +520,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMovieRequests(user, today);
 

--- a/src/Ombi.Core.Tests/Engine/MusicRequestLimitTests.cs
+++ b/src/Ombi.Core.Tests/Engine/MusicRequestLimitTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using Moq.AutoMock;
 using NUnit.Framework;
 using Ombi.Core.Authentication;
-using Ombi.Core.Engine;
 using Ombi.Core.Helpers;
 using Ombi.Core.Models;
 using Ombi.Core.Services;
@@ -62,7 +61,7 @@ namespace Ombi.Core.Tests.Engine
             var user = new OmbiUser();
 
             var um = _mocker.GetMock<OmbiUserManager>();
-            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock().Object);
+            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock());
             
 
 
@@ -80,7 +79,7 @@ namespace Ombi.Core.Tests.Engine
             };
 
             var um = _mocker.GetMock<OmbiUserManager>();
-            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock().Object);
+            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock());
 
 
 
@@ -98,7 +97,7 @@ namespace Ombi.Core.Tests.Engine
                 MusicRequestLimit = 1
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(new List<RequestLog>().AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(new List<RequestLog>().AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -129,7 +128,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -204,7 +203,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -237,7 +236,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -270,7 +269,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -309,7 +308,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -342,7 +341,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -374,7 +373,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user, today);
 
@@ -413,7 +412,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -445,7 +444,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -478,7 +477,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user);
 
@@ -518,7 +517,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingMusicRequests(user, today);
 

--- a/src/Ombi.Core.Tests/Engine/TvRequestLimitsTests.cs
+++ b/src/Ombi.Core.Tests/Engine/TvRequestLimitsTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using Moq.AutoMock;
 using NUnit.Framework;
 using Ombi.Core.Authentication;
-using Ombi.Core.Engine;
 using Ombi.Core.Helpers;
 using Ombi.Core.Models;
 using Ombi.Core.Services;
@@ -59,7 +58,7 @@ namespace Ombi.Core.Tests.Engine
             var user = new OmbiUser();
 
             var um = _mocker.GetMock<OmbiUserManager>();
-            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock().Object);
+            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock());
 
 
 
@@ -77,7 +76,7 @@ namespace Ombi.Core.Tests.Engine
             };
 
             var um = _mocker.GetMock<OmbiUserManager>();
-            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock().Object);
+            um.SetupGet(x => x.Users).Returns(new List<OmbiUser> { user }.AsQueryable().BuildMock());
 
 
 
@@ -95,7 +94,7 @@ namespace Ombi.Core.Tests.Engine
                 EpisodeRequestLimit = 1
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(new List<RequestLog>().AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(new List<RequestLog>().AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -126,7 +125,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -209,7 +208,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -243,7 +242,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -276,7 +275,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -317,7 +316,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -358,7 +357,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -380,7 +379,7 @@ namespace Ombi.Core.Tests.Engine
                 EpisodeRequestLimitType = RequestLimitType.Week,
                 Id = "id1"
             };
-            var lastWeek = DateTime.Now.AddDays(-8);
+            var lastWeek = DateTime.UtcNow.AddDays(-8);
             var log = new List<RequestLog>
             {
                 new RequestLog
@@ -392,7 +391,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -425,7 +424,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -466,7 +465,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -507,7 +506,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -541,7 +540,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -574,7 +573,7 @@ namespace Ombi.Core.Tests.Engine
                 }
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -615,7 +614,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 
@@ -656,7 +655,7 @@ namespace Ombi.Core.Tests.Engine
                 },
             };
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
-            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock().Object);
+            repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
             var result = await _subject.GetRemainingTvRequests(user);
 

--- a/src/Ombi.Core.Tests/Engine/VoteEngineTests.cs
+++ b/src/Ombi.Core.Tests/Engine/VoteEngineTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Security.Principal;
 using System.Threading.Tasks;
 using AutoFixture;
 using MockQueryable.Moq;
@@ -71,7 +70,7 @@ namespace Ombi.Core.Tests.Engine
 
             VoteRepository.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Votes>(votes)
                 .AsQueryable()
-                .BuildMock().Object);
+                .BuildMock());
             var result = new VoteEngineResult();
             if (type == VoteType.Downvote)
             {
@@ -118,7 +117,7 @@ namespace Ombi.Core.Tests.Engine
             });
             VoteRepository.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Votes>(votes)
                 .AsQueryable()
-                .BuildMock().Object);
+                .BuildMock());
             var result = new VoteEngineResult();
             if (type == VoteType.Downvote)
             {
@@ -163,7 +162,7 @@ namespace Ombi.Core.Tests.Engine
             });
             VoteRepository.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Votes>(votes)
                 .AsQueryable()
-                .BuildMock().Object);
+                .BuildMock());
 
             var result = new VoteEngineResult();
             if (type == VoteType.Downvote)

--- a/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
+++ b/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
@@ -8,18 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="Moq.AutoMock" Version="3.0.0" />
-    <PackageReference Include="Nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
+    <PackageReference Include="Nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="16.8.0"></packagereference>
+    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"></packagereference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Core.Tests/Rule/Request/ExistingMovieRequestRuleTests.cs
+++ b/src/Ombi.Core.Tests/Rule/Request/ExistingMovieRequestRuleTests.cs
@@ -1,21 +1,15 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Principal;
 using System.Threading.Tasks;
 using MockQueryable.Moq;
 using Moq;
 using NUnit.Framework;
-using Ombi.Core.Authentication;
-using Ombi.Core.Rule.Rules;
 using Ombi.Core.Rule.Rules.Request;
 using Ombi.Core.Services;
-using Ombi.Helpers;
 using Ombi.Settings.Settings.Models;
 using Ombi.Store.Entities;
 using Ombi.Store.Entities.Requests;
 using Ombi.Store.Repository.Requests;
-using Ombi.Test.Common;
 
 namespace Ombi.Core.Tests.Rule.Request
 {
@@ -45,7 +39,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     TheMovieDbId = 1,
                     RequestType = RequestType.Movie
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
             var o = new MovieRequests
             {
                 TheMovieDbId = 1,
@@ -67,7 +61,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     ImdbId = 1.ToString(),
                     RequestType = RequestType.Movie
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
             var o = new MovieRequests
             {
                 ImdbId = 1.ToString(),
@@ -89,7 +83,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     ImdbId = "2",
                     RequestType = RequestType.Movie
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
             var o = new MovieRequests
             {
                 TheMovieDbId = 1,
@@ -113,7 +107,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     RequestType = RequestType.Movie,
                     Is4kRequest = true
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
             var o = new MovieRequests
             {
                 TheMovieDbId = 2,
@@ -139,7 +133,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     RequestType = RequestType.Movie,
                     Is4kRequest = false
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
             var o = new MovieRequests
             {
                 TheMovieDbId = 2,
@@ -165,7 +159,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     RequestType = RequestType.Movie,
                     Is4kRequest = false
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
             var o = new MovieRequests
             {
                 TheMovieDbId = 2,

--- a/src/Ombi.Core.Tests/Rule/Request/ExistingPlexRequestRuleTests.cs
+++ b/src/Ombi.Core.Tests/Rule/Request/ExistingPlexRequestRuleTests.cs
@@ -7,10 +7,8 @@ using Ombi.Store.Entities;
 using Ombi.Store.Entities.Requests;
 using Ombi.Store.Repository;
 using Ombi.Store.Repository.Requests;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Ombi.Core.Tests.Rule.Request
@@ -31,7 +29,7 @@ namespace Ombi.Core.Tests.Rule.Request
         [Test]
         public async Task RequestShow_DoesNotExistAtAll_IsSuccessful()
         {
-            PlexContentRepo.Setup(x => x.GetAll()).Returns(new List<PlexServerContent>().AsQueryable().BuildMock().Object);
+            PlexContentRepo.Setup(x => x.GetAll()).Returns(new List<PlexServerContent>().AsQueryable().BuildMock());
             var req = new ChildRequests
             {
                 SeasonRequests = new List<SeasonRequests>
@@ -203,7 +201,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     TheMovieDbId = 123.ToString(),
                 }
             };
-            PlexContentRepo.Setup(x => x.GetAll()).Returns(content.AsQueryable().BuildMock().Object);
+            PlexContentRepo.Setup(x => x.GetAll()).Returns(content.AsQueryable().BuildMock());
 
             var req = new MovieRequests
             {
@@ -245,7 +243,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     }
                 }
             };
-            PlexContentRepo.Setup(x => x.GetAll()).Returns(childRequests.AsQueryable().BuildMock().Object);
+            PlexContentRepo.Setup(x => x.GetAll()).Returns(childRequests.AsQueryable().BuildMock());
         }
     }
 }

--- a/src/Ombi.Core.Tests/Rule/Request/ExistingTvRequestRuleTests.cs
+++ b/src/Ombi.Core.Tests/Rule/Request/ExistingTvRequestRuleTests.cs
@@ -5,10 +5,8 @@ using Ombi.Core.Rule.Rules.Request;
 using Ombi.Store.Entities;
 using Ombi.Store.Entities.Requests;
 using Ombi.Store.Repository.Requests;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Ombi.Core.Tests.Rule.Request
@@ -29,7 +27,7 @@ namespace Ombi.Core.Tests.Rule.Request
         [Test]
         public async Task RequestShow_DoesNotExistAtAll_IsSuccessful()
         {
-            TvRequestRepo.Setup(x => x.GetChild()).Returns(new List<ChildRequests>().AsQueryable().BuildMock().Object);
+            TvRequestRepo.Setup(x => x.GetChild()).Returns(new List<ChildRequests>().AsQueryable().BuildMock());
             var req = new ChildRequests
             {
                 SeasonRequests = new List<SeasonRequests>
@@ -209,7 +207,7 @@ namespace Ombi.Core.Tests.Rule.Request
                     }
                 }
             };
-            TvRequestRepo.Setup(x => x.GetChild()).Returns(childRequests.AsQueryable().BuildMock().Object);
+            TvRequestRepo.Setup(x => x.GetChild()).Returns(childRequests.AsQueryable().BuildMock());
         }
     }
 }

--- a/src/Ombi.Core.Tests/Senders/MassEmailSenderTests.cs
+++ b/src/Ombi.Core.Tests/Senders/MassEmailSenderTests.cs
@@ -54,7 +54,7 @@ namespace Ombi.Core.Tests.Senders
                     Id = "a",
                     Email = "Test@test.com"
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             var result = await _subject.SendMassEmail(model);
 
@@ -95,7 +95,7 @@ namespace Ombi.Core.Tests.Senders
                     Id = "b",
                     Email = "b@test.com"
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             var result = await _subject.SendMassEmail(model);
 
@@ -129,7 +129,7 @@ namespace Ombi.Core.Tests.Senders
                 {
                     Id = "a",
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             var result = await _subject.SendMassEmail(model);
             _mocker.Verify<ILogger<MassEmailSender>>(
@@ -177,7 +177,7 @@ namespace Ombi.Core.Tests.Senders
                     Id = "b",
                     Email = "b@test.com"
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             var result = await _subject.SendMassEmail(model);
 
@@ -217,7 +217,7 @@ namespace Ombi.Core.Tests.Senders
                 {
                     Id = "b",
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             var result = await _subject.SendMassEmail(model);
 

--- a/src/Ombi.Core.Tests/Services/PlexServiceTests.cs
+++ b/src/Ombi.Core.Tests/Services/PlexServiceTests.cs
@@ -59,7 +59,7 @@ namespace Ombi.Core.Tests.Services
             _subject = _mocker.CreateInstance<PlexService>();
 
             _mocker.Setup<IRepository<PlexWatchlistUserError>, IQueryable<PlexWatchlistUserError>>(x => x.GetAll())
-                .Returns(new List<PlexWatchlistUserError>().AsQueryable().BuildMock().Object);
+                .Returns(new List<PlexWatchlistUserError>().AsQueryable().BuildMock());
 
             var result = await _subject.GetWatchlistUsers(CancellationToken.None);
 
@@ -95,7 +95,7 @@ namespace Ombi.Core.Tests.Services
             _subject = _mocker.CreateInstance<PlexService>();
 
             _mocker.Setup<IRepository<PlexWatchlistUserError>, IQueryable<PlexWatchlistUserError>>(x => x.GetAll())
-                .Returns(new List<PlexWatchlistUserError>().AsQueryable().BuildMock().Object);
+                .Returns(new List<PlexWatchlistUserError>().AsQueryable().BuildMock());
 
             var result = await _subject.GetWatchlistUsers(CancellationToken.None);
 
@@ -132,7 +132,7 @@ namespace Ombi.Core.Tests.Services
                         UserId = "1",
                         MediaServerToken = "test",
                     }
-                }.AsQueryable().BuildMock().Object);
+                }.AsQueryable().BuildMock());
 
             var result = await _subject.GetWatchlistUsers(CancellationToken.None);
 

--- a/src/Ombi.Core.Tests/Services/RecentlyRequestedServiceTests.cs
+++ b/src/Ombi.Core.Tests/Services/RecentlyRequestedServiceTests.cs
@@ -15,7 +15,6 @@ using Ombi.Store.Repository.Requests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -70,9 +69,9 @@ namespace Ombi.Core.Tests.Services
             };
             var albums = new List<AlbumRequest>();
             var chilRequests = new List<ChildRequests>();
-            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock().Object);
-            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock().Object);
-            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock().Object);
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock());
+            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock());
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock());
 
             var result = await _subject.GetRecentlyRequested(CancellationToken.None);
 
@@ -132,9 +131,9 @@ namespace Ombi.Core.Tests.Services
             };
             var albums = new List<AlbumRequest>();
             var chilRequests = new List<ChildRequests>();
-            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock().Object);
-            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock().Object);
-            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock().Object);
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock());
+            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock());
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock());
 
             var result = await _subject.GetRecentlyRequested(CancellationToken.None);
 
@@ -163,9 +162,9 @@ namespace Ombi.Core.Tests.Services
             var albums = _fixture.CreateMany<AlbumRequest>(10);
             var chilRequests = _fixture.CreateMany<ChildRequests>(10);
 
-            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock().Object);
-            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock().Object);
-            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock().Object);
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock());
+            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock());
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock());
 
             var result = await _subject.GetRecentlyRequested(CancellationToken.None);
 
@@ -187,9 +186,9 @@ namespace Ombi.Core.Tests.Services
             var albums = _fixture.CreateMany<AlbumRequest>(10);
             var chilRequests = _fixture.CreateMany<ChildRequests>(10);
 
-            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock().Object);
-            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock().Object);
-            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock().Object);
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(movies.AsQueryable().BuildMock());
+            _mocker.Setup<IMusicRequestRepository, IQueryable<AlbumRequest>>(x => x.GetAll()).Returns(albums.AsQueryable().BuildMock());
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(chilRequests.AsQueryable().BuildMock());
             _mocker.Setup<ICurrentUser, Task<OmbiUser>>(x => x.GetUser()).ReturnsAsync(new OmbiUser { UserName = "test", Alias = "alias", UserType = UserType.LocalUser  });
             _mocker.Setup<ICurrentUser, string>(x => x.Username).Returns("test");
             _mocker.Setup<OmbiUserManager, Task<bool>>(x => x.IsInRoleAsync(It.IsAny<OmbiUser>(), It.IsAny<string>())).ReturnsAsync(false);

--- a/src/Ombi.Core/Ombi.Core.csproj
+++ b/src/Ombi.Core/Ombi.Core.csproj
@@ -11,14 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="MusicBrainzAPI" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
+    <PackageReference Include="MusicBrainzAPI" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.DependencyInjection/IocExtensions.cs
+++ b/src/Ombi.DependencyInjection/IocExtensions.cs
@@ -71,6 +71,8 @@ using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Ombi.Core.Services;
 using Ombi.Core.Helpers;
+using Ombi.Hubs;
+using Hqub.MusicBrainz.API;
 
 namespace Ombi.DependencyInjection
 {
@@ -86,6 +88,7 @@ namespace Ombi.DependencyInjection
             services.RegisterServices();
             services.RegisterStore();
             services.RegisterJobs();
+            services.RegisterHubs();
         }
 
         public static void RegisterEngines(this IServiceCollection services)
@@ -171,6 +174,7 @@ namespace Ombi.DependencyInjection
             services.AddTransient<ILidarrApi, LidarrApi>();
             services.AddTransient<IGroupMeApi, GroupMeApi>();
             services.AddTransient<IMusicBrainzApi, MusicBrainzApi>();
+            services.AddTransient(_ => new MusicBrainzClient());
             services.AddTransient<IWhatsAppApi, WhatsAppApi>();
             services.AddTransient<ICloudMobileNotification, CloudMobileNotification>();
             services.AddTransient<IEmbyApiFactory, EmbyApiFactory>();
@@ -231,7 +235,7 @@ namespace Ombi.DependencyInjection
             services.AddTransient<IRecentlyRequestedService, RecentlyRequestedService>();
             services.AddTransient<IPlexService, PlexService>();
         }
-
+        
         public static void RegisterJobs(this IServiceCollection services)
         {
             services.AddSingleton<QuartzJobRunner>();
@@ -267,6 +271,11 @@ namespace Ombi.DependencyInjection
             services.AddTransient<IMediaDatabaseRefresh, MediaDatabaseRefresh>();
             services.AddTransient<IArrAvailabilityChecker, ArrAvailabilityChecker>();
             services.AddTransient<IAutoDeleteRequests, AutoDeleteRequests>();
+        }
+
+        public static void RegisterHubs(this IServiceCollection services)
+        {
+            services.AddScoped<INotificationHubService, NotificationHubService>();
         }
     }
 }

--- a/src/Ombi.DependencyInjection/Ombi.DependencyInjection.csproj
+++ b/src/Ombi.DependencyInjection/Ombi.DependencyInjection.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/src/Ombi.HealthChecks/Ombi.HealthChecks.csproj
+++ b/src/Ombi.HealthChecks/Ombi.HealthChecks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="3.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>

--- a/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
+++ b/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Helpers/AssemblyHelper.cs
+++ b/src/Ombi.Helpers/AssemblyHelper.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.PlatformAbstractions;
-using System.Linq;
-using System.Reflection;
+﻿using System;
 
 namespace Ombi.Helpers
 {
@@ -8,9 +6,8 @@ namespace Ombi.Helpers
     {
         public static string GetRuntimeVersion()
         {
-            ApplicationEnvironment app = PlatformServices.Default.Application;
-            var split = app.ApplicationVersion.Split('.');
-            return string.Join('.', split.Take(3));
+            Version version = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version;
+            return version == null ? "1.0.0" : $"{version.Major}.{version.Minor}.{version.Build}";
         }
     }
 }

--- a/src/Ombi.Helpers/Ombi.Helpers.csproj
+++ b/src/Ombi.Helpers/Ombi.Helpers.csproj
@@ -11,15 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyCrypto" Version="3.3.2" />
-    <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
+    <PackageReference Include="EasyCrypto" Version="4.5.0" />
+    <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
-    <PackageReference Include="Quartz" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageReference Include="Quartz" Version="3.5.0" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Ombi.Hubs/INotificationHubService.cs
+++ b/src/Ombi.Hubs/INotificationHubService.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ombi.Hubs;
+
+public interface INotificationHubService
+{
+    IEnumerable<NotificationHubUser> GetOnlineUsers();
+    Task SendNotificationToAdmins(string data, CancellationToken token = default);
+    Task SendNotificationToAll(string data, CancellationToken token = default);
+}

--- a/src/Ombi.Hubs/NotificationHubService.cs
+++ b/src/Ombi.Hubs/NotificationHubService.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Ombi.Helpers;
+
+namespace Ombi.Hubs;
+
+public class NotificationHubService : INotificationHubService
+{
+    public const string NotificationEvent = "Notification";
+
+    private readonly IHubContext<NotificationHub> _hubContext;
+
+    public NotificationHubService(IHubContext<NotificationHub> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public IEnumerable<NotificationHubUser> GetOnlineUsers()
+    {
+        return NotificationHub.UsersOnline.Values;
+    }
+
+    public Task SendNotificationToAdmins(string data, CancellationToken token = default)
+    {
+        return _hubContext.Clients
+            .Clients(GetConnectionIdsWithRole(OmbiRoles.Admin))
+            .SendAsync(NotificationEvent, data, token);
+    }
+
+    public Task SendNotificationToAll(string data, CancellationToken token = default)
+    {
+        return _hubContext.Clients.All.SendAsync(NotificationEvent, data, token);
+    }
+    
+    private static List<string> GetConnectionIdsWithRole(string role)
+    {
+        return NotificationHub.UsersOnline
+            .Where(x => x.Value.Roles.Contains(role))
+            .Select(x => x.Key).ToList();
+    }
+}

--- a/src/Ombi.Hubs/NotificationHubUser.cs
+++ b/src/Ombi.Hubs/NotificationHubUser.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Ombi.Hubs;
+
+public class NotificationHubUser
+{
+    public string UserId { get; set; }
+    public IList<string> Roles { get; init; } = new List<string>();
+}

--- a/src/Ombi.Hubs/Ombi.Hubs.csproj
+++ b/src/Ombi.Hubs/Ombi.Hubs.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.SignalR" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Mapping/Ombi.Mapping.csproj
+++ b/src/Ombi.Mapping/Ombi.Mapping.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Collection" Version="7.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper.Collection" Version="8.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
+++ b/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="Nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="16.8.0"></packagereference>
-    <PackageReference Include="Moq" Version="4.10.0" />
-	  <PackageReference Include="Moq.AutoMock" Version="0.4.0" />
+    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"></packagereference>
+    <PackageReference Include="Moq" Version="4.18.2" />
+	  <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Notifications/Ombi.Notifications.csproj
+++ b/src/Ombi.Notifications/Ombi.Notifications.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ensure.That" Version="7.0.0-pre32" />
-    <PackageReference Include="MailKit" Version="2.5.0" />
+    <PackageReference Include="Ensure.That" Version="10.1.0" />
+    <PackageReference Include="MailKit" Version="3.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Schedule.Tests/AvailabilityCheckerTests.cs
+++ b/src/Ombi.Schedule.Tests/AvailabilityCheckerTests.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using MockQueryable.Moq;
 using Moq;
 using Moq.AutoMock;
@@ -83,7 +82,7 @@ namespace Ombi.Schedule.Tests
                     EpisodeNumber = 2,
                     SeasonNumber = 1,
                 },
-            }.AsQueryable().BuildMock().Object;
+            }.AsQueryable().BuildMock();
 
             await _subject.ProcessTvShow(databaseEpisodes, request);
 
@@ -160,7 +159,7 @@ namespace Ombi.Schedule.Tests
                     EpisodeNumber = 3,
                     SeasonNumber = 1,
                 },
-            }.AsQueryable().BuildMock().Object;
+            }.AsQueryable().BuildMock();
 
             await _subject.ProcessTvShow(databaseEpisodes, request);
 
@@ -183,7 +182,7 @@ namespace Ombi.Schedule.Tests
 
     public class TestAvailabilityChecker : AvailabilityChecker
     {
-        public TestAvailabilityChecker(ITvRequestRepository tvRequest, INotificationHelper notification, ILogger log, IHubContext<NotificationHub> hub) : base(tvRequest, notification, log, hub)
+        public TestAvailabilityChecker(ITvRequestRepository tvRequest, INotificationHelper notification, ILogger log, INotificationHubService notificationHubService) : base(tvRequest, notification, log, notificationHubService)
         {
         }
 

--- a/src/Ombi.Schedule.Tests/IssuesPurgeTests.cs
+++ b/src/Ombi.Schedule.Tests/IssuesPurgeTests.cs
@@ -9,7 +9,6 @@ using Ombi.Settings.Settings.Models;
 using Ombi.Store.Entities.Requests;
 using Ombi.Store.Repository;
 using System.Threading.Tasks;
-using MockQueryable;
 using MockQueryable.Moq;
 
 namespace Ombi.Schedule.Tests
@@ -51,7 +50,7 @@ namespace Ombi.Schedule.Tests
             };
 
             Settings.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new IssueSettings { DeleteIssues = true, DaysAfterResolvedToDelete = 5 });
-            Repo.Setup(x => x.GetAll()).Returns(new List<Issues>(issues).AsQueryable().BuildMock().Object);
+            Repo.Setup(x => x.GetAll()).Returns(new List<Issues>(issues).AsQueryable().BuildMock());
             await Job.Execute(null);
 
             Assert.That(issues.First().Status, Is.EqualTo(IssueStatus.Deleted));
@@ -76,7 +75,7 @@ namespace Ombi.Schedule.Tests
             };
 
             Settings.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new IssueSettings { DeleteIssues = true, DaysAfterResolvedToDelete = 5 });
-            Repo.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Issues>(issues).AsQueryable().BuildMock().Object);
+            Repo.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Issues>(issues).AsQueryable().BuildMock());
             await Job.Execute(null);
 
             Assert.That(issues[0].Status, Is.Not.EqualTo(IssueStatus.Deleted));
@@ -102,7 +101,7 @@ namespace Ombi.Schedule.Tests
             };
 
             Settings.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new IssueSettings { DeleteIssues = true, DaysAfterResolvedToDelete = 5 });
-            Repo.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Issues>(issues).AsQueryable().BuildMock().Object);
+            Repo.Setup(x => x.GetAll()).Returns(new EnumerableQuery<Issues>(issues).AsQueryable().BuildMock());
             await Job.Execute(null);
 
             Assert.That(issues[0].Status, Is.Not.EqualTo(IssueStatus.Deleted));

--- a/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
+++ b/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
@@ -7,14 +7,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="MockQueryable.Moq" Version="5.0.0-preview.7" />
-    <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="Moq.AutoMock" Version="0.4.0" />
-    <PackageReference Include="Nunit" Version="3.11.0" />
+    <PackageReference Include="MockQueryable.Moq" Version="6.0.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
+    <PackageReference Include="Nunit" Version="3.13.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"></packagereference>
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"></packagereference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Schedule.Tests/PlexAvailabilityCheckerTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexAvailabilityCheckerTests.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Threading;
 using System.Threading.Tasks;
 using Castle.Components.DictionaryAdapter;
-using Microsoft.AspNetCore.SignalR;
 using Moq;
 using MockQueryable.Moq;
 using NUnit.Framework;
 using Ombi.Core;
-using Ombi.Core.Notifications;
 using Ombi.Hubs;
 using Ombi.Schedule.Jobs.Plex;
 using Ombi.Store.Entities;
@@ -50,7 +45,7 @@ namespace Ombi.Schedule.Tests
             {
                 ImdbId = "test"
             };
-            _mocker.Setup<IMovieRequestRepository>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
             _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x => x.Get("test", ProviderType.ImdbId)).ReturnsAsync(new PlexServerContent());
 
             await _subject.Execute(null);
@@ -77,7 +72,7 @@ namespace Ombi.Schedule.Tests
                 ImdbId = null,
                 TheMovieDbId = 33
             };
-            _mocker.Setup<IMovieRequestRepository>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
             _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x => x.Get(It.IsAny<string>(), ProviderType.ImdbId)).ReturnsAsync((PlexServerContent)null);
             _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x => x.Get("33", ProviderType.TheMovieDbId)).ReturnsAsync(new PlexServerContent());
 
@@ -105,7 +100,7 @@ namespace Ombi.Schedule.Tests
             {
                 ImdbId = "test"
             };
-            _mocker.Setup<IMovieRequestRepository>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
             _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x => x.Get("test", ProviderType.ImdbId)).ReturnsAsync(new PlexServerContent {  Quality = "1080p" });
 
             await _subject.Execute(null);
@@ -134,7 +129,7 @@ namespace Ombi.Schedule.Tests
                 Is4kRequest = true,
                 Has4KRequest = true,
             };
-            _mocker.Setup<IMovieRequestRepository>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
             _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x => x.Get("test", ProviderType.ImdbId)).ReturnsAsync(new PlexServerContent { Has4K = true });
 
             await _subject.Execute(null);
@@ -162,7 +157,7 @@ namespace Ombi.Schedule.Tests
             {
                 ImdbId = "test"
             };
-            _mocker.Setup<IMovieRequestRepository>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
+            _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll()).Returns(new List<MovieRequests> { request }.AsQueryable());
 
             await _subject.Execute(null);
 
@@ -173,7 +168,7 @@ namespace Ombi.Schedule.Tests
         public async Task ProcessTv_ShouldMark_Episode_Available_WhenInPlex_MovieDbId()
         {
             var request = CreateChildRequest(null, 33, 99);
-            _mocker.Setup<ITvRequestRepository>(x => x.GetChild()).Returns(new List<ChildRequests> { request }.AsQueryable().BuildMock().Object);
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(new List<ChildRequests> { request }.AsQueryable().BuildMock());
             _mocker.Setup<IPlexContentRepository, IQueryable<IMediaServerEpisode>>(x => x.GetAllEpisodes()).Returns(new List<PlexEpisode>
             {
                 new PlexEpisode
@@ -186,7 +181,7 @@ namespace Ombi.Schedule.Tests
                     EpisodeNumber = 1,
                     SeasonNumber = 2,
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             await _subject.Execute(null);
 
@@ -199,7 +194,7 @@ namespace Ombi.Schedule.Tests
         public async Task ProcessTv_ShouldMark_Episode_Available_WhenInPlex_ImdbId()
         {
             var request = CreateChildRequest("abc", -1, 99);
-            _mocker.Setup<ITvRequestRepository>(x => x.GetChild()).Returns(new List<ChildRequests> { request }.AsQueryable().BuildMock().Object);
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(new List<ChildRequests> { request }.AsQueryable().BuildMock());
             _mocker.Setup<IPlexContentRepository, IQueryable<IMediaServerEpisode>>(x => x.GetAllEpisodes()).Returns(new List<PlexEpisode>
             {
                 new PlexEpisode
@@ -211,7 +206,7 @@ namespace Ombi.Schedule.Tests
                     EpisodeNumber = 1,
                     SeasonNumber = 2,
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             await _subject.Execute(null);
 
@@ -224,7 +219,7 @@ namespace Ombi.Schedule.Tests
         public async Task ProcessTv_ShouldMark_Episode_Available_By_TitleMatch()
         {
             var request = CreateChildRequest("abc", -1, 99);
-            _mocker.Setup<ITvRequestRepository>(x => x.GetChild()).Returns(new List<ChildRequests> { request }.AsQueryable().BuildMock().Object);
+            _mocker.Setup<ITvRequestRepository, IQueryable<ChildRequests>>(x => x.GetChild()).Returns(new List<ChildRequests> { request }.AsQueryable().BuildMock());
             _mocker.Setup<IPlexContentRepository, IQueryable<IMediaServerEpisode>>(x => x.GetAllEpisodes()).Returns(new List<PlexEpisode>
             {
                 new PlexEpisode
@@ -237,7 +232,7 @@ namespace Ombi.Schedule.Tests
                     EpisodeNumber = 1,
                     SeasonNumber = 2,
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             await _subject.Execute(null);
 

--- a/src/Ombi.Schedule.Tests/PlexContentSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexContentSyncTests.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.AutoMock;
 using NUnit.Framework;
@@ -48,7 +46,7 @@ namespace Ombi.Schedule.Tests
             };
             var contentToAdd = new HashSet<PlexServerContent>();
             var contentProcessed = new Dictionary<int, string>();
-            _mocker.Setup<IPlexContentRepository>(x =>
+            _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x =>
                     x.GetFirstContentByCustom(It.IsAny<Expression<Func<PlexServerContent, bool>>>()))
                 .Returns(Task.FromResult(new PlexServerContent()));
 
@@ -108,7 +106,7 @@ namespace Ombi.Schedule.Tests
             };
             var contentToAdd = new HashSet<PlexServerContent>();
             var contentProcessed = new Dictionary<int, string>();
-            _mocker.Setup<IPlexApi>(x => x.GetMetadata(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            _mocker.Setup<IPlexApi, Task<PlexMetadata>>(x => x.GetMetadata(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(new PlexMetadata
                 {
                     MediaContainer = new Mediacontainer
@@ -166,7 +164,7 @@ namespace Ombi.Schedule.Tests
             };
             var contentToAdd = new HashSet<PlexServerContent>();
             var contentProcessed = new Dictionary<int, string>();
-            _mocker.Setup<IPlexContentRepository>(x =>
+            _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x =>
                     x.GetFirstContentByCustom(It.IsAny<Expression<Func<PlexServerContent, bool>>>()))
                 .Returns(Task.FromResult(new PlexServerContent
                 {
@@ -204,7 +202,7 @@ namespace Ombi.Schedule.Tests
             };
             var contentToAdd = new HashSet<PlexServerContent>();
             var contentProcessed = new Dictionary<int, string>();
-            _mocker.Setup<IPlexContentRepository>(x =>
+            _mocker.Setup<IPlexContentRepository, Task<PlexServerContent>>(x =>
                     x.GetFirstContentByCustom(It.IsAny<Expression<Func<PlexServerContent, bool>>>()))
                 .Returns(Task.FromResult(new PlexServerContent
                 {

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -9,7 +9,6 @@ using Ombi.Core.Engine.Interfaces;
 using Ombi.Core.Models.Requests;
 using Ombi.Core.Settings;
 using Ombi.Core.Settings.Models.External;
-using Ombi.Core.Tests;
 using Ombi.Schedule.Jobs.Plex;
 using Ombi.Store.Entities;
 using Ombi.Store.Repository;
@@ -39,7 +38,7 @@ namespace Ombi.Schedule.Tests
             _context = _mocker.GetMock<IJobExecutionContext>();
             _context.Setup(x => x.CancellationToken).Returns(CancellationToken.None);
             _subject = _mocker.CreateInstance<PlexWatchlistImport>();
-            _mocker.Setup<IRepository<PlexWatchlistUserError>, IQueryable<PlexWatchlistUserError>>(x => x.GetAll()).Returns(new List<PlexWatchlistUserError>().AsQueryable().BuildMock().Object);
+            _mocker.Setup<IRepository<PlexWatchlistUserError>, IQueryable<PlexWatchlistUserError>>(x => x.GetAll()).Returns(new List<PlexWatchlistUserError>().AsQueryable().BuildMock());
         }
 
         [Test]
@@ -104,7 +103,7 @@ namespace Ombi.Schedule.Tests
                     UserId = "abc",
                     MediaServerToken = "dead"
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             _mocker.Setup<ISettingsService<PlexSettings>, Task<PlexSettings>>(x => x.GetSettingsAsync()).ReturnsAsync(new PlexSettings { Enable = true, EnableWatchlistImport = true });
             _mocker.Setup<IPlexApi, Task<PlexWatchlistContainer>>(x => x.GetWatchlist(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PlexWatchlistContainer { AuthError = false });
@@ -128,7 +127,7 @@ namespace Ombi.Schedule.Tests
                     UserId = "abc",
                     MediaServerToken = "token1"
                 }
-            }.AsQueryable().BuildMock().Object);
+            }.AsQueryable().BuildMock());
 
             _mocker.Setup<ISettingsService<PlexSettings>, Task<PlexSettings>>(x => x.GetSettingsAsync()).ReturnsAsync(new PlexSettings { Enable = true, EnableWatchlistImport = true });
             _mocker.Setup<IPlexApi, Task<PlexWatchlistContainer>>(x => x.GetWatchlist(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PlexWatchlistContainer { AuthError = false });

--- a/src/Ombi.Schedule/Jobs/ArrAvailabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/ArrAvailabilityChecker.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ombi.Core;
@@ -32,12 +31,12 @@ namespace Ombi.Schedule.Jobs.Radarr
             IExternalRepository<RadarrCache> radarrRepo,
             IExternalRepository<SonarrCache> sonarrRepo,
             IExternalRepository<SonarrEpisodeCache> sonarrEpisodeRepo,
-            INotificationHelper notification, IHubContext<NotificationHub> hub,
+            INotificationHelper notification, INotificationHubService notificationHubService,
             ITvRequestRepository tvRequest, IMovieRequestRepository movies,
             ILogger<ArrAvailabilityChecker> log,
             ISettingsService<RadarrSettings> radarrSettings,
             ISettingsService<SonarrSettings> sonarrSettings)
-             : base(tvRequest, notification, log, hub)
+             : base(tvRequest, notification, log, notificationHubService)
         {
             _radarrRepo = radarrRepo;
             _sonarrRepo = sonarrRepo;
@@ -101,9 +100,9 @@ namespace Ombi.Schedule.Jobs.Radarr
 
             if (itemsForAvailability.Any())
             {
-                await _hub.Clients.Clients(NotificationHub.AdminConnectionIds)
-                    .SendAsync(NotificationHub.NotificationEvent, "Radarr Availability Checker found some new available movies!");
+                await NotificationHubService.SendNotificationToAdmins("Radarr Availability Checker found some new available movies!");
             }
+
             foreach (var item in itemsForAvailability)
             {
                 await _notificationService.Notify(new NotificationOptions

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyAvaliabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyAvaliabilityChecker.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ombi.Core;
@@ -20,7 +19,7 @@ namespace Ombi.Schedule.Jobs.Emby
     public class EmbyAvaliabilityChecker : AvailabilityChecker, IEmbyAvaliabilityChecker
     {
         public EmbyAvaliabilityChecker(IEmbyContentRepository repo, ITvRequestRepository t, IMovieRequestRepository m,
-            INotificationHelper n, ILogger<EmbyAvaliabilityChecker> log, IHubContext<NotificationHub> notification, IFeatureService featureService)
+            INotificationHelper n, ILogger<EmbyAvaliabilityChecker> log, INotificationHubService notification, IFeatureService featureService)
             : base(t, n, log, notification)
         {
             _repo = repo;
@@ -35,14 +34,12 @@ namespace Ombi.Schedule.Jobs.Emby
         public async Task Execute(IJobExecutionContext job)
         {
             _log.LogInformation("Starting Emby Availability Check");
-            await _hub.Clients.Clients(NotificationHub.AdminConnectionIds)
-                .SendAsync(NotificationHub.NotificationEvent, "Emby Availability Checker Started");
+            await NotificationHubService.SendNotificationToAdmins("Emby Availability Checker Started");
             await ProcessMovies();
             await ProcessTv();
 
             _log.LogInformation("Finished Emby Availability Check");
-            await _hub.Clients.Clients(NotificationHub.AdminConnectionIds)
-                .SendAsync(NotificationHub.NotificationEvent, "Emby Availability Checker Finished");
+            await NotificationHubService.SendNotificationToAdmins("Emby Availability Checker Finished");
         }
 
         private async Task ProcessMovies()

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinAvaliabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinAvaliabilityChecker.cs
@@ -28,7 +28,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ombi.Core;
@@ -47,7 +46,7 @@ namespace Ombi.Schedule.Jobs.Jellyfin
     public class JellyfinAvaliabilityChecker : AvailabilityChecker, IJellyfinAvaliabilityChecker
     {
         public JellyfinAvaliabilityChecker(IJellyfinContentRepository repo, ITvRequestRepository t, IMovieRequestRepository m,
-            INotificationHelper n, ILogger<JellyfinAvaliabilityChecker> log, IHubContext<NotificationHub> notification, IFeatureService featureService)
+            INotificationHelper n, ILogger<JellyfinAvaliabilityChecker> log, INotificationHubService notification, IFeatureService featureService)
              : base(t, n, log, notification)
         {
             _repo = repo;
@@ -62,14 +61,12 @@ namespace Ombi.Schedule.Jobs.Jellyfin
         public async Task Execute(IJobExecutionContext job)
         {
             _log.LogInformation("Starting Jellyfin Availability Check");
-            await _hub.Clients.Clients(NotificationHub.AdminConnectionIds)
-                .SendAsync(NotificationHub.NotificationEvent, "Jellyfin Availability Checker Started");
+            await NotificationHubService.SendNotificationToAdmins("Jellyfin Availability Checker Started");
             await ProcessMovies();
             await ProcessTv();
 
             _log.LogInformation("Finished Jellyfin Availability Check");
-            await _hub.Clients.Clients(NotificationHub.AdminConnectionIds)
-                .SendAsync(NotificationHub.NotificationEvent, "Jellyfin Availability Checker Finished");
+            await NotificationHubService.SendNotificationToAdmins("Jellyfin Availability Checker Finished");
         }
 
         private async Task ProcessMovies()

--- a/src/Ombi.Schedule/Jobs/Lidarr/LidarrAlbumSync.cs
+++ b/src/Ombi.Schedule/Jobs/Lidarr/LidarrAlbumSync.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 using Ombi.Api.Lidarr;
 using Ombi.Core.Settings;
@@ -21,7 +19,7 @@ namespace Ombi.Schedule.Jobs.Lidarr
     public class LidarrAlbumSync : ILidarrAlbumSync
     {
         public LidarrAlbumSync(ISettingsService<LidarrSettings> lidarr, ILidarrApi lidarrApi, ILogger<LidarrAlbumSync> log, ExternalContext ctx,
-             IHubContext<NotificationHub> notification)
+             INotificationHubService notification)
         {
             _lidarrSettings = lidarr;
             _lidarrApi = lidarrApi;
@@ -34,7 +32,7 @@ namespace Ombi.Schedule.Jobs.Lidarr
         private readonly ILidarrApi _lidarrApi;
         private readonly ILogger _logger;
         private readonly ExternalContext _ctx;
-        private readonly IHubContext<NotificationHub> _notification;
+        private readonly INotificationHubService _notification;
 
         public async Task Execute(IJobExecutionContext ctx)
         {
@@ -44,8 +42,7 @@ namespace Ombi.Schedule.Jobs.Lidarr
                 if (settings.Enabled)
                 {
 
-                    await _notification.Clients.Clients(NotificationHub.AdminConnectionIds)
-                        .SendAsync(NotificationHub.NotificationEvent, "Lidarr Album Sync Started");
+                    await _notification.SendNotificationToAdmins("Lidarr Album Sync Started");
                     try
                     {
                         var albums = await _lidarrApi.GetAllAlbums(settings.ApiKey, settings.FullUri);
@@ -95,13 +92,11 @@ namespace Ombi.Schedule.Jobs.Lidarr
                     }
                     catch (System.Exception ex)
                     {
-                        await _notification.Clients.Clients(NotificationHub.AdminConnectionIds)
-                            .SendAsync(NotificationHub.NotificationEvent, "Lidarr Album Sync Failed");
+                        await _notification.SendNotificationToAdmins("Lidarr Album Sync Failed");
                         _logger.LogError(LoggingEvents.Cacher, ex, "Failed caching queued items from Lidarr Album");
                     }
 
-                    await _notification.Clients.Clients(NotificationHub.AdminConnectionIds)
-                        .SendAsync(NotificationHub.NotificationEvent, "Lidarr Album Sync Finished");
+                    await _notification.SendNotificationToAdmins("Lidarr Album Sync Finished");
 
                     await OmbiQuartz.TriggerJob(nameof(ILidarrAvailabilityChecker), "DVR");
                 }

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ombi.Api.Plex;
 using Ombi.Api.Plex.Models;
@@ -30,13 +29,13 @@ namespace Ombi.Schedule.Jobs.Plex
         private readonly OmbiUserManager _ombiUserManager;
         private readonly IMovieRequestEngine _movieRequestEngine;
         private readonly ITvRequestEngine _tvRequestEngine;
-        private readonly IHubContext<NotificationHub> _hub;
+        private readonly INotificationHubService _notificationHubService;
         private readonly ILogger _logger;
         private readonly IExternalRepository<PlexWatchlistHistory> _watchlistRepo;
         private readonly IRepository<PlexWatchlistUserError> _userError;
 
         public PlexWatchlistImport(IPlexApi plexApi, ISettingsService<PlexSettings> settings, OmbiUserManager ombiUserManager,
-            IMovieRequestEngine movieRequestEngine, ITvRequestEngine tvRequestEngine, IHubContext<NotificationHub> hub,
+            IMovieRequestEngine movieRequestEngine, ITvRequestEngine tvRequestEngine, INotificationHubService notificationHubService,
             ILogger<PlexWatchlistImport> logger, IExternalRepository<PlexWatchlistHistory> watchlistRepo, IRepository<PlexWatchlistUserError> userError)
         {
             _plexApi = plexApi;
@@ -44,7 +43,7 @@ namespace Ombi.Schedule.Jobs.Plex
             _ombiUserManager = ombiUserManager;
             _movieRequestEngine = movieRequestEngine;
             _tvRequestEngine = tvRequestEngine;
-            _hub = hub;
+            _notificationHubService = notificationHubService;
             _logger = logger;
             _watchlistRepo = watchlistRepo;
             _userError = userError;
@@ -228,13 +227,9 @@ namespace Ombi.Schedule.Jobs.Plex
 
         private async Task NotifyClient(string message)
         {
-            if (_hub?.Clients == null)
-            {
-                return;
-            }
-            await _hub?.Clients?.Clients(NotificationHub.AdminConnectionIds)?
-                .SendAsync(NotificationHub.NotificationEvent, $"Plex Watchlist Import - {message}");
+            await _notificationHubService.SendNotificationToAdmins($"Plex Watchlist Import - {message}");
         }
+
         public void Dispose() { }
     }
 }

--- a/src/Ombi.Schedule/Ombi.Schedule.csproj
+++ b/src/Ombi.Schedule/Ombi.Schedule.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Quartz" Version="3.1.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="SharpCompress" Version="0.30.0" />
+    <PackageReference Include="Quartz" Version="3.5.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.6.13" />
-    <PackageReference Include="Markdig" Version="0.14.8" />
-    <PackageReference Include="Octokit" Version="0.28.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="Markdig" Version="0.30.4" />
+    <PackageReference Include="Octokit" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
+++ b/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Settings/Ombi.Settings.csproj
+++ b/src/Ombi.Settings/Ombi.Settings.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Quartz" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Quartz" Version="3.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Store/Ombi.Store.csproj
+++ b/src/Ombi.Store/Ombi.Store.csproj
@@ -12,16 +12,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
-    <PackageReference Include="Polly" Version="7.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageReference Include="Polly" Version="7.2.3" />
     <!--<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.9" />-->
   </ItemGroup>
   <ItemGroup>

--- a/src/Ombi.Test.Common/MockHelper.cs
+++ b/src/Ombi.Test.Common/MockHelper.cs
@@ -20,7 +20,7 @@ namespace Ombi.Test.Common
 
             var userMock = ls.AsQueryable().BuildMock();
 
-            mgr.Setup(x => x.Users).Returns(userMock.Object);
+            mgr.Setup(x => x.Users).Returns(userMock);
             mgr.Setup(x => x.DeleteAsync(It.IsAny<OmbiUser>())).ReturnsAsync(IdentityResult.Success);
             mgr.Setup(x => x.CreateAsync(It.IsAny<OmbiUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success).Callback<OmbiUser, string>((x, y) => ls.Add(x));
             mgr.Setup(x => x.UpdateAsync(It.IsAny<OmbiUser>())).ReturnsAsync(IdentityResult.Success);

--- a/src/Ombi.Test.Common/Ombi.Test.Common.csproj
+++ b/src/Ombi.Test.Common/Ombi.Test.Common.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="MockQueryable.Moq" Version="5.0.0-preview.7" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="MockQueryable.Moq" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Tests/Ombi.Tests.csproj
+++ b/src/Ombi.Tests/Ombi.Tests.csproj
@@ -2,21 +2,19 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <Configurations>Debug;Release;NonUiBuild</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="Nunit" Version="3.11.0" />
-    <PackageReference Include="Hangfire" Version="1.7.1" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.9" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Nunit" Version="3.13.3" />
+    <PackageReference Include="Hangfire" Version="1.7.31" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="16.8.0"></packagereference>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"></packagereference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Tests/SignalRHelper.cs
+++ b/src/Ombi.Tests/SignalRHelper.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using Moq;
+﻿using Moq;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.SignalR;
 
 namespace Ombi.Tests
 {

--- a/src/Ombi.TheMovieDbApi/Models/MovieDbSearchResult.cs
+++ b/src/Ombi.TheMovieDbApi/Models/MovieDbSearchResult.cs
@@ -9,7 +9,7 @@ namespace Ombi.Api.TheMovieDb.Models
         public bool Adult { get; set; }
         public string Overview { get; set; }
         public string ReleaseDate { get; set; }
-        public int?[] GenreIds { get; set; }
+        public int[] GenreIds { get; set; }
         public int Id { get; set; }
         public string OriginalTitle { get; set; }
         public string OriginalLanguage { get; set; }

--- a/src/Ombi.TheMovieDbApi/Ombi.Api.TheMovieDb.csproj
+++ b/src/Ombi.TheMovieDbApi/Ombi.Api.TheMovieDb.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Updater/Ombi.Updater.csproj
+++ b/src/Ombi.Updater/Ombi.Updater.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
@@ -21,9 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.1-dev-00771" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ombi.Updater/Program.cs
+++ b/src/Ombi.Updater/Program.cs
@@ -3,7 +3,6 @@ using System.IO;
 using CommandLine;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Serilog;
 
 namespace Ombi.Updater
@@ -40,7 +39,7 @@ namespace Ombi.Updater
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .WriteTo.RollingFile(Path.Combine("Logs", "log-{Date}.txt"))
+                .WriteTo.File(Path.Combine("Logs", "log.txt"), rollingInterval: RollingInterval.Day)
                 .Enrich.FromLogContext()
                 .CreateLogger();
             

--- a/src/Ombi/Ombi.csproj
+++ b/src/Ombi/Ombi.csproj
@@ -57,34 +57,31 @@
 
  
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="3.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="3.0.0" />
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="6.0.2" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="ncrontab" Version="3.3.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.3.1" />
+    <PackageReference Include="ncrontab" Version="3.3.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.4.0" />
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="5.0.0-preview.8.20414.8" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi/Startup.cs
+++ b/src/Ombi/Startup.cs
@@ -1,10 +1,8 @@
-﻿using AutoMapper;
-using AutoMapper.EquivalencyExpression;
+﻿using AutoMapper.EquivalencyExpression;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,12 +18,10 @@ using Ombi.Schedule;
 using Ombi.Settings.Settings.Models;
 using Ombi.Store.Context;
 using Ombi.Store.Entities;
-using Ombi.Store.Repository;
 using Serilog;
 using System;
 using System.IO;
 using Microsoft.AspNetCore.StaticFiles.Infrastructure;
-using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using ILogger = Serilog.ILogger;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -50,7 +46,7 @@ namespace Ombi
 
             ILogger config = new LoggerConfiguration()
                 .ReadFrom.Configuration(Configuration)
-                .WriteTo.RollingFile(Path.Combine(StoragePath.StoragePath.IsNullOrEmpty() ? env.ContentRootPath : StoragePath.StoragePath, "Logs", "log-{Date}.txt"))
+                .WriteTo.File(Path.Combine(StoragePath.StoragePath.IsNullOrEmpty() ? env.ContentRootPath : StoragePath.StoragePath, "Logs", "log.txt"), rollingInterval: RollingInterval.Day)
                 .CreateLogger();
 
             Log.Logger = config;
@@ -112,7 +108,6 @@ namespace Ombi
             services.AddMvc();
             services.AddSignalR();
             services.AddSpaStaticFiles(configuration => configuration.RootPath = "ClientApp/dist");
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
This PR upgrades all nuget packages and removes usages of obsolete methods. 
The only 4 warning remaining are due to https://github.com/AutoMapper/AutoMapper.Collection/pull/171 not being released yet.

Notable changes:
MusicBrainzClient client is used instead of calling obsolete static methods.
Microsoft.Extensions.PlatformAbstractions is removed and the code that retrieves a runtime version has changed but should return identical result.
Microsoft.AspNetCore.SignalR is consistently used across the solution instead of a mix of Microsoft.AspNet.SignalR and Microsoft.AspNetCore.SignalR references.
INotificationHubService provides an abstraction from SignalR. NotificationHubService wraps NotificationHub and exposes all required functionality.
GenreIds property on MovieDbSearchResult model changed from int?[] to int[]. This was done due to AutoMapper error. I didnt see any existing usages of that property or a reason why it needs to be int?[].
Serilog.Sinks.RollingFile is removed. Same rolling log functionality now exists in Serilog.Sinks.File package.