### PR TITLE
Consistently reset loading flag when requesting movies on discover page.

### DIFF
--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
@@ -8,7 +8,7 @@ import { IDiscoverCardResult } from "../../interfaces";
 import { ISearchMovieResultV2 } from "../../../interfaces/ISearchMovieResultV2";
 import { ISearchTvResultV2 } from "../../../interfaces/ISearchTvResultV2";
 import { MatDialog } from "@angular/material/dialog";
-import { RequestType } from "../../../interfaces";
+import { IMovieRequestModel, RequestType } from "../../../interfaces";
 import { TranslateService } from "@ngx-translate/core";
 
 @Component({
@@ -130,43 +130,73 @@ export class DiscoverCardComponent implements OnInit {
         event.preventDefault();
         this.loading = true;
         switch (this.result.type) {
-            case RequestType.tvShow:
-                const dia = this.dialog.open(EpisodeRequestComponent, { width: "700px", data: { series: this.tvSearchResult, isAdmin: this.isAdmin }, panelClass: 'modal-panel' });
-                dia.afterClosed().subscribe(x => this.loading = false);
-                return;
-            case RequestType.movie:
-                if (this.isAdmin) {
-                    const dialog = this.dialog.open(AdminRequestDialogComponent, { width: "700px", data: { type: RequestType.movie, id: this.result.id,  }, panelClass: 'modal-panel' });
-                    dialog.afterClosed().subscribe((result) => {
-                        if (result) {
-                                this.requestService.requestMovie({ theMovieDbId: +this.result.id,
-                                    languageCode: this.translate.currentLang,
-                                    qualityPathOverride: result.radarrPathId,
-                                    requestOnBehalf: result.username?.id,
-                                    rootFolderOverride: result.radarrFolderId,
-                                    is4KRequest: is4k }).subscribe(x => {
-                                if (x.result) {
-                                    this.result.requested = true;
-                                    this.messageService.send(this.translate.instant("Requests.RequestAddedSuccessfully", { title: this.result.title }), "Ok");
-                                } else {
-                                    this.messageService.sendRequestEngineResultError(x);
-                                }
-                            });
-                        }
-                    });
-                } else {
-                this.requestService.requestMovie({ theMovieDbId: +this.result.id, languageCode: this.translate.currentLang, requestOnBehalf: null, qualityPathOverride: null, rootFolderOverride: null, is4KRequest: is4k }).subscribe(x => {
-                    if (x.result) {
-                        this.result.requested = true;
-                        this.messageService.send(this.translate.instant("Requests.RequestAddedSuccessfully", { title: this.result.title }), "Ok");
-                    } else {
-                        this.messageService.sendRequestEngineResultError(x);
-                    }
-                    this.loading = false;
-                });
-                return;
+          case RequestType.tvShow:
+            const dialog = this.dialog.open(EpisodeRequestComponent, {
+              width: "700px",
+              data: { series: this.tvSearchResult, isAdmin: this.isAdmin },
+              panelClass: "modal-panel",
+            });
+            dialog.afterClosed().subscribe(() => (this.loading = false));
+            break;
+          case RequestType.movie:
+            const movieRequest: IMovieRequestModel = {
+              theMovieDbId: +this.result.id,
+              languageCode: this.translate.currentLang,
+              requestOnBehalf: null,
+              qualityPathOverride: null,
+              rootFolderOverride: null,
+              is4KRequest: is4k,
+            };
+
+            if (!this.isAdmin) {
+              this.requestMovie(movieRequest);
+              break;
             }
+
+            const adminRequestDialog = this.dialog.open(
+              AdminRequestDialogComponent,
+              {
+                width: "700px",
+                data: { type: RequestType.movie, id: this.result.id },
+                panelClass: "modal-panel",
+              }
+            );
+            adminRequestDialog.afterClosed().subscribe((result) => {
+              if (!result) {
+                this.loading = false;
+                return;
+              }
+
+              movieRequest.requestOnBehalf = result.username?.id;
+              movieRequest.qualityPathOverride = result.radarrPathId;
+              movieRequest.rootFolderOverride = result.radarrFolderId;
+              this.requestMovie(movieRequest);
+            });
+            break;
         }
+    }
+
+    private requestMovie(movieRequest: IMovieRequestModel) {
+        this.requestService.requestMovie(movieRequest).subscribe({
+          next: (response) => {
+            if (response.result) {
+              this.result.requested = true;
+              const message = this.translate.instant(
+                "Requests.RequestAddedSuccessfully",
+                { title: this.result.title }
+              );
+              this.messageService.send(message, "Ok");
+            } else {
+              this.messageService.sendRequestEngineResultError(response);
+            }
+
+            this.loading = false;
+          },
+          error: (error) => {
+            this.messageService.sendRequestEngineResultError(error);
+            this.loading = false;
+          },
+        });
     }
 
     public onImageError(event: any) {

--- a/src/Ombi/ClientApp/src/app/discover/components/collections/discover-collections.component.html
+++ b/src/Ombi/ClientApp/src/app/discover/components/collections/discover-collections.component.html
@@ -16,7 +16,7 @@
 </div>
     <div *ngIf="discoverResults" class="row full-height">
         <div class="col-xl-2 col-lg-3 col-md-3 col-6 col-sm-4 small-padding" *ngFor="let result of discoverResults">
-            <discover-card [isAdmin]="isAdmins" [result]="result" [is4kEnabled]="is4kEnabled"></discover-card>
+            <discover-card [isAdmin]="isAdmin" [result]="result" [is4kEnabled]="is4kEnabled"></discover-card>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes an issue with loading flag getting stuck in true state in the following cases:
- Admin closes dialog without submitting the request.
- Request fails due to network or internal error.