### PR TITLE
Unable to Delete Jellyfin Server (#4705)

### DIFF
--- a/src/Ombi/ClientApp/src/app/settings/emby/emby.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/emby/emby.component.html
@@ -10,11 +10,11 @@
         <div class="row">
           <div class="col-md-6 col-6 col-sm-6">
                 <div class="md-form-field">
-                    <mat-slide-toggle [(ngModel)]="settings.enable" [checked]="settings.enable">Enable
+                    <mat-slide-toggle [(ngModel)]="settings.enable" (change)="toggle()" [checked]="settings.enable">Enable
                     </mat-slide-toggle>
                 </div>  </div>
         </div>
-        <mat-tab-group #tabGroup [selectedIndex]="selected.value" (selectedTabChange)="addTab($event)" (selectedIndexChange)="selected.setValue($event)" animationDuration="0ms" style="display:block;"> 
+        <mat-tab-group #tabGroup [selectedIndex]="selected.value" (selectedTabChange)="addTab($event)" (selectedIndexChange)="selected.setValue($event)" animationDuration="0ms" style="display:block;">
             <mat-tab *ngFor="let server of settings.servers" [label]="server.name">
                     <div class="col-md-6 col-6 col-sm-6" style="float: right; width:100%; text-align:right;">
                         <button type="button" (click)="removeServer(server)" class="mat-focus-indicator mat-flat-button mat-button-base mat-warn">Remove Server</button>
@@ -56,7 +56,7 @@
                                     <input matInput placeholder="Api Key" [(ngModel)]="server.apiKey" value="{{server.apiKey}}">
                                 </mat-form-field>
                             </div>
-                            <div class="md-form-field">        
+                            <div class="md-form-field">
                                 <mat-form-field appearance="outline" floatLabel=auto>
                                     <mat-label>Base URL</mat-label>
                                     <input matInput placeholder="Base Url" [(ngModel)]="server.subDir" value="{{server.subDir}}">
@@ -125,7 +125,7 @@
             </mat-tab>
             <mat-tab label="" disabled=true> </mat-tab>
             <mat-tab label="Add Server" position=100> </mat-tab>
-                  
+
         </mat-tab-group>
         <div class="row">
         <div class="col-md-2">

--- a/src/Ombi/ClientApp/src/app/settings/emby/emby.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/emby/emby.component.ts
@@ -72,6 +72,7 @@ export class EmbyComponent implements OnInit {
         if (index > -1) {
             this.settings.servers.splice(index, 1);
             this.selected.setValue(this.settings.servers.length - 1);
+            this.toggle();
         }
     }
 

--- a/src/Ombi/ClientApp/src/app/settings/jellyfin/jellyfin.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/jellyfin/jellyfin.component.html
@@ -10,13 +10,13 @@
         <div class="row">
             <div class="col-md-6 col-6 col-sm-6">
                 <div class="md-form-field">
-                    <mat-slide-toggle [(ngModel)]="settings.enable" [checked]="settings.enable">Enable
+                    <mat-slide-toggle [(ngModel)]="settings.enable" (change)="toggle()" [checked]="settings.enable">Enable
                     </mat-slide-toggle>
                 </div>
 
             </div>
         </div>
-        <mat-tab-group #tabGroup [selectedIndex]="selected.value" (selectedTabChange)="addTab($event)" (selectedIndexChange)="selected.setValue($event)" animationDuration="0ms" style="display:block;"> 
+        <mat-tab-group #tabGroup [selectedIndex]="selected.value" (selectedTabChange)="addTab($event)" (selectedIndexChange)="selected.setValue($event)" animationDuration="0ms" style="display:block;">
             <mat-tab *ngFor="let server of settings.servers" [label]="server.name">
                     <div class="col-md-6 col-6 col-sm-6" style="float: right; width:100%; text-align:right;">
                         <button type="button" (click)="removeServer(server)" class="mat-focus-indicator mat-flat-button mat-button-base mat-warn">Remove Server</button>

--- a/src/Ombi/ClientApp/src/app/settings/jellyfin/jellyfin.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/jellyfin/jellyfin.component.ts
@@ -73,6 +73,7 @@ export class JellyfinComponent implements OnInit {
         if (index > -1) {
             this.settings.servers.splice(index, 1);
             this.selected.setValue(this.settings.servers.length - 1);
+            this.toggle();
         }
     }
 


### PR DESCRIPTION
* Added the dirty toggle when server options are removed or disabled for Emby or Jellyfin
* It appears that the toggle was added for the Enable button in https://github.com/Ombi-app/Ombi/pull/3776, and then removed in https://github.com/Ombi-app/Ombi/pull/4252, but not sure if that was intentional.
