### PR TITLE
New version available even just upgraded to the last one (#4719)

### DIFF
--- a/src/Ombi.Schedule/Processor/ChangeLogProcessor.cs
+++ b/src/Ombi.Schedule/Processor/ChangeLogProcessor.cs
@@ -40,6 +40,8 @@ namespace Ombi.Schedule.Processor
 
         private UpdateModel TransformUpdate(Release release)
         {
+            Version updateVersion = Version.Parse(release.Version.TrimStart('v'));
+            Version currentVersion = Version.Parse(AssemblyHelper.GetRuntimeVersion());
             var newUpdate = new UpdateModel
             {
                 UpdateVersionString = release.Version,
@@ -47,7 +49,7 @@ namespace Ombi.Schedule.Processor
                 UpdateDate = DateTime.Now,
                 ChangeLogs = release.Description,
                 Downloads = new List<Downloads>(),
-                UpdateAvailable = release.Version != "v" + AssemblyHelper.GetRuntimeVersion()
+                UpdateAvailable = updateVersion > currentVersion
             };
 
             foreach (var dl in release.Downloads)


### PR DESCRIPTION
* Use .NET Version class to compare the versions, and only show update as available when version is greater