### PR TITLE
Only log error messages from Microsoft

### DIFF
--- a/src/Ombi/appsettings.json
+++ b/src/Ombi/appsettings.json
@@ -4,7 +4,7 @@
     "LogLevel": {
       "Default": "Warning",
       "System": "Warning",
-      "Microsoft": "Warning",
+      "Microsoft": "Error",
       "Hangfire": "None",
       "System.Net.Http.HttpClient.health-checks": "Warning",
       "HealthChecks": "Warning"


### PR DESCRIPTION
This will remove warnings that are only meant for developers and are misleading for users.