### PR TITLE
Add the option for header authentication to create users

### DIFF
--- a/src/Ombi.Settings/Settings/Models/AuthenticationSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/AuthenticationSettings.cs
@@ -15,5 +15,6 @@ namespace Ombi.Settings.Settings.Models
         public bool EnableOAuth { get; set; } // Plex OAuth
         public bool EnableHeaderAuth { get; set; } // Header SSO
         public string HeaderAuthVariable { get; set; } // Header SSO
+        public bool HeaderAuthCreateUser { get; set; } // Header SSO
     }
 }

--- a/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
@@ -245,6 +245,7 @@ export interface IAuthenticationSettings extends ISettings {
   enableOAuth: boolean;
   enableHeaderAuth: boolean;
   headerAuthVariable: string;
+  headerAuthCreateUser: boolean;
 }
 
 export interface ICustomPage extends ISettings {

--- a/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.html
@@ -32,6 +32,12 @@
         </div>
       </div>
 
+      <div class="form-group" *ngIf="form.controls.enableHeaderAuth.value">
+        <div class="checkbox">
+          <mat-slide-toggle id="headerAuthCreateUser" name="headerAuthCreateUser" formControlName="headerAuthCreateUser">SSO creates new users automatically</mat-slide-toggle>
+        </div>
+      </div>
+
 
       <div class="form-group">
         <div>

--- a/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.html
@@ -23,6 +23,9 @@
         <div class="checkbox">
           <mat-slide-toggle id="enableHeaderAuth" name="enableHeaderAuth" formControlName="enableHeaderAuth">Enable Authentication with Header Variable</mat-slide-toggle>
         </div>
+        <div class="alert warning-box">
+          Enabling Header Authentication will allow anyone to bypass authentication unless you are using a properly configured reverse proxy. Use with caution!
+        </div>
       </div>
 
       <div class="form-group" *ngIf="form.controls.enableHeaderAuth.value">
@@ -35,6 +38,9 @@
       <div class="form-group" *ngIf="form.controls.enableHeaderAuth.value">
         <div class="checkbox">
           <mat-slide-toggle id="headerAuthCreateUser" name="headerAuthCreateUser" formControlName="headerAuthCreateUser">SSO creates new users automatically</mat-slide-toggle>
+        </div>
+        <div class="alert warning-box" *ngIf="form.controls.headerAuthCreateUser.value">
+          If the user in the Header Authentication variable does not exist, a new user will be created. You can configure the default permissions for new users in the <a target="_blank" href="/Settings/UserManagement">User Management settings</a>.
         </div>
       </div>
 

--- a/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.scss
@@ -13,3 +13,10 @@
     box-shadow: 0 5px 11px 0 rgba(255, 255, 255, 0.18), 0 4px 15px 0 rgba(255, 255, 255, 0.15);
     color: inherit;
 }
+
+.warning-box {
+    margin: 16px 0;
+    color: white;
+    background-color: $ombi-background-accent;
+    border-color: $warn;
+}

--- a/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/authentication/authentication.component.ts
@@ -28,6 +28,7 @@ export class AuthenticationComponent implements OnInit {
                 enableOAuth: [x.enableOAuth],
                 enableHeaderAuth: [x.enableHeaderAuth],
                 headerAuthVariable: [x.headerAuthVariable],
+                headerAuthCreateUser: [x.headerAuthCreateUser],
             });
             this.form.controls.enableHeaderAuth.valueChanges.subscribe(x => {
                 if (x) {

--- a/src/Ombi/Controllers/V1/TokenController.cs
+++ b/src/Ombi/Controllers/V1/TokenController.cs
@@ -305,7 +305,20 @@ namespace Ombi.Controllers.V1
                     var user = await _userManager.FindByNameAsync(username);
                     if (user == null)
                     {
-                        return new UnauthorizedResult();
+                        if (authSettings.HeaderAuthCreateUser)
+                        {
+                            user = new OmbiUser {
+                                UserName = username,
+                                UserType = UserType.LocalUser,
+                                StreamingCountry = "US",
+                            };
+
+                            await _userManager.CreateAsync(user);
+                        }
+                        else
+                        {
+                            return new UnauthorizedResult();
+                        }
                     }
 
                     return await CreateToken(true, user);


### PR DESCRIPTION
Since I manage my users externally using authentik, manually adding every user to Ombi is not feasable for me.

This PR adds a toggle to the authentication settings, and if enabled, a new user will be created if no existing user can be found when header authentication is being used. The default user settings defined in the User Management tab (roles, request limit, streaming country) will be applied.

![image](https://user-images.githubusercontent.com/26145882/210438408-90a35fc2-49d5-4ee3-b8f4-6b95665a0706.png)
