### PR TITLE
Fix Cron Validation (#4842)

### DIFF
--- a/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
+++ b/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
@@ -1,5 +1,6 @@
-using Ombi.Helpers;
+﻿using Ombi.Helpers;
 using Quartz;
+using System;
 
 namespace Ombi.Settings.Settings.Models
 {

--- a/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
+++ b/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
@@ -1,4 +1,4 @@
-﻿using Ombi.Helpers;
+using Ombi.Helpers;
 using Quartz;
 
 namespace Ombi.Settings.Settings.Models
@@ -104,7 +104,9 @@ namespace Ombi.Settings.Settings.Models
 
         private static string ValidateCron(string cron)
         {
-            if (CronExpression.IsValidExpression(cron))
+            CronExpression expression = new CronExpression(cron);
+            DateTimeOffset? nextFireUTCTime = expression.GetNextValidTimeAfter(DateTime.Now);
+            if (CronExpression.IsValidExpression(cron) && nextFireUTCTime != null)
             {
                 return cron;
             }

--- a/src/Ombi/Controllers/V1/SettingsController.cs
+++ b/src/Ombi/Controllers/V1/SettingsController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/Ombi/Controllers/V1/SettingsController.cs
+++ b/src/Ombi/Controllers/V1/SettingsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -652,7 +652,9 @@ namespace Ombi.Controllers.V1
                 try
                 {
                     var isValid = CronExpression.IsValidExpression(expression);
-                    if (!isValid)
+                    CronExpression cron = new CronExpression(expression);
+                    DateTimeOffset? nextFireUTCTime = cron.GetNextValidTimeAfter(DateTime.Now);
+                    if (!isValid || nextFireUTCTime == null)
                     {
                         return new JobSettingsViewModel
                         {


### PR DESCRIPTION
The cron job can't be created if the year is more than 100 years in the future.
Getting the next valid time will return null if this is the case.

* add next-date cron validation to API
  * Prevents Ombi from crashing on startup by changing to default CRON expression
* add next-date cron validation to the job settings page
  *  Prevents the user from inputting a CRON job that won't trigger within 100 years

https://user-images.githubusercontent.com/15078358/232146846-80c8f416-da1a-4189-9621-2c3a3c537cdd.mov

Closes #4842 
