### PR TITLE
Support duplicate movies in Jellyfin collections

### DIFF
--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -263,7 +263,12 @@ namespace Ombi.Schedule.Jobs.Emby
             // Check if it exists
             var existingMovie = await _repo.GetByEmbyId(movieInfo.Id);
             var alreadyGoingToAdd = content.Any(x => x.EmbyId == movieInfo.Id);
-            if (existingMovie == null && !alreadyGoingToAdd)
+            if (alreadyGoingToAdd)
+            {
+                _logger.LogDebug($"Detected duplicate for {movieInfo.Name}");
+                return;
+            }
+            if (existingMovie == null)
             {
                 if (!movieInfo.ProviderIds.Any())
                 {

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs
@@ -228,7 +228,12 @@ namespace Ombi.Schedule.Jobs.Jellyfin
             // Check if it exists
             var existingMovie = await _repo.GetByJellyfinId(movieInfo.Id);
             var alreadyGoingToAdd = content.Any(x => x.JellyfinId == movieInfo.Id);
-            if (existingMovie == null && !alreadyGoingToAdd)
+            if (alreadyGoingToAdd)
+            {
+                _logger.LogDebug($"Detected duplicate for {movieInfo.Name}");
+                return;
+            }
+            if (existingMovie == null)
             {
                 if (!movieInfo.ProviderIds.Any())
                 {


### PR DESCRIPTION
This addresses an issue raised on Discord where we would get the following error during Jellyfin sync:
```
[ERR] Exception when caching Jellyfin for server XXXXXXX
System.NullReferenceException: Object reference not set to an instance of an object.
   at Ombi.Schedule.Jobs.Jellyfin.JellyfinContentSync.ProcessMovies(JellyfinMovie movieInfo, ICollection`1 content, ICollection`1 toUpdate, JellyfinServers server) in /home/runner/work/Ombi/Ombi/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs:line 276
   at Ombi.Schedule.Jobs.Jellyfin.JellyfinContentSync.ProcessMovies(JellyfinServers server, String parentId) in /home/runner/work/Ombi/Ombi/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs:line 197
   at Ombi.Schedule.Jobs.Jellyfin.JellyfinContentSync.StartServerCache(JellyfinServers server) in /home/runner/work/Ombi/Ombi/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs:line 83
   at Ombi.Schedule.Jobs.Jellyfin.JellyfinContentSync.Execute(IJobExecutionContext job) in /home/runner/work/Ombi/Ombi/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinContentSync.cs:line 54
```
This error would happen if you have enabled a setting in Jellyfin to group movies into collections, and if a new movie appeared in more than one collection.
This would result in the sync failing consistently and new items not being detected as available by Ombi.

For the record, there is no such setting in Emby (or not anymore? at least not in 4.8.0.29), this option is handled by the frontend through an option in the API call (`GroupItemsIntoCollections`). Our API calls do not group movies into collections. 
For consistency sake, I still applied the same fix in Emby code.