### PR TITLE
Bugfix: Allow RequestOnBehalf if requested from the API

### DIFF
--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -77,7 +77,8 @@ namespace Ombi.Core.Engine
             var userDetails = await GetUser();
             var canRequestOnBehalf = model.RequestOnBehalf.HasValue();
 
-            var isAdmin = await UserManager.IsInRoleAsync(userDetails, OmbiRoles.PowerUser)
+            var isAdmin = Username.Equals("API", StringComparison.CurrentCultureIgnoreCase)
+                || await UserManager.IsInRoleAsync(userDetails, OmbiRoles.PowerUser)
                 || await UserManager.IsInRoleAsync(userDetails, OmbiRoles.Admin);
             if (canRequestOnBehalf && !isAdmin)
             {

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -161,7 +161,7 @@ namespace Ombi.Core.Engine
             var user = await GetUser();
             var canRequestOnBehalf = tv.RequestOnBehalf.HasValue();
 
-            var isAdmin = await UserManager.IsInRoleAsync(user, OmbiRoles.PowerUser) || await UserManager.IsInRoleAsync(user, OmbiRoles.Admin);
+            var isAdmin = Username.Equals("API", StringComparison.CurrentCultureIgnoreCase) || await UserManager.IsInRoleAsync(user, OmbiRoles.PowerUser) || await UserManager.IsInRoleAsync(user, OmbiRoles.Admin);
             if (tv.RequestOnBehalf.HasValue() && !isAdmin)
             {
                 return new RequestEngineResult


### PR DESCRIPTION
This is a fix for a bug I found with the RequestOnBehalf. https://github.com/Ombi-app/Ombi/issues/4915
Issue 4915 - Can't request on behalf with the API. 

Username.Equals("API", StringComparison.CurrentCultureIgnoreCase) is used in BaseEngine so I figured it's probably the best way to check for API unless a special role is created in OmbiRoles. I tried to keep the changes as minimal as possible but could rework this if needed.

This only works if requestOnBehalf value is a valid user Id or the API user id. This fix mirrors the behavior of the UI where you also need to select an existing user.
