### PR TITLE
Fix bug preventing ApiAlias header from appearing in Ombi request list

### DIFF
--- a/src/Ombi/ClientApp/src/app/requests-list/components/movies-grid/movies-grid.component.html
+++ b/src/Ombi/ClientApp/src/app/requests-list/components/movies-grid/movies-grid.component.html
@@ -52,7 +52,7 @@
 
         <ng-container matColumnDef="requestedUser.requestedBy">
             <th mat-header-cell *matHeaderCellDef> {{'Requests.RequestedBy' | translate}} </th>
-            <td mat-cell id="requestedBy{{element.id}}" *matCellDef="let element"> {{element.requestedUser?.userAlias}} </td>
+            <td mat-cell id="requestedBy{{element.id}}" *matCellDef="let element"> {{element.requestedByAlias ? element.requestedByAlias : element.requestedUser?.userAlias}} </td>
         </ng-container>
 
 

--- a/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.html
+++ b/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.html
@@ -38,7 +38,7 @@
 
         <ng-container matColumnDef="requestedBy">
             <th mat-header-cell *matHeaderCellDef> {{'Requests.RequestedBy' | translate}} </th>
-            <td mat-cell id="requestedBy{{element.id}}" *matCellDef="let element"> {{element.requestedUser.userAlias}} </td>
+            <td mat-cell id="requestedBy{{element.id}}" *matCellDef="let element"> {{element.requestedByAlias ? element.requestedByAlias : element.requestedUser.userAlias}} </td>
         </ng-container>
 
         <ng-container matColumnDef="requestedDate">


### PR DESCRIPTION
This pull request fixes a bug where the ApiAlias was not being displayed in the Ombi request list, even though it was included in the API request. The bug was caused by a missing piece of code in the section responsible for generating the request list.
This is the documentation that explain the use of ApiAlias: https://docs.ombi.app/info/api-information/#api-key 

To fix the bug, I added logic to the request list generation code to check for the presence of the ApiAlias header in API requests, and to include it in the request list when it is present. If the ApiAlias is not set(null) the old value of userAlias is used. This won't impact user that aren't using ApiAlias but will add a very useful feature for users that do.

This image show the changes. Test cases:
1. Where it shows phil, this is my Ombi username, those are requests done through the web UI. No changes from the previous code.
2. Api, this is request done with the API but without any value for ApiAlias. No changes from the previous code.
3. This is using the ApiAlias, this is done with the API and the value "This is using the ApiAlias" for the ApiAlias field. 

![ombi_ApiAlias](https://user-images.githubusercontent.com/60622768/236364376-d3ccb73b-b3bb-407a-949e-7b053f2b5dc8.PNG)
