### PR TITLE
Sync episodes played states from Emby

### DIFF
--- a/src/Ombi.Api.Emby/EmbyApi.cs
+++ b/src/Ombi.Api.Emby/EmbyApi.cs
@@ -249,15 +249,11 @@ namespace Ombi.Api.Emby
             req.AddHeader("Device", "Ombi");
         }
 
-        public async Task<EmbyItemContainer<EmbyMovie>> GetMoviesPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri)
-        {
-            return await GetPlayed<EmbyMovie>("Movie", apiKey, userId, baseUri, startIndex, count, parentIdFilder, "ProviderIds");
-        }
+        public async Task<EmbyItemContainer<EmbyMovie>> GetMoviesPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri) =>
+            await GetPlayed<EmbyMovie>("Movie", apiKey, userId, baseUri, startIndex, count, parentIdFilder, "ProviderIds");
 
-        public async Task<EmbyItemContainer<EmbyEpisodes>> GetTvPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri)
-        {
-            return await GetPlayed<EmbyEpisodes>("Episode", apiKey, userId, baseUri, startIndex, count, parentIdFilder);
-        }
+        public async Task<EmbyItemContainer<EmbyEpisodes>> GetTvPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri) =>
+           await GetPlayed<EmbyEpisodes>("Episode", apiKey, userId, baseUri, startIndex, count, parentIdFilder);
 
         private async Task<EmbyItemContainer<T>> GetPlayed<T>(
             string type,

--- a/src/Ombi.Api.Emby/EmbyApi.cs
+++ b/src/Ombi.Api.Emby/EmbyApi.cs
@@ -251,16 +251,32 @@ namespace Ombi.Api.Emby
 
         public async Task<EmbyItemContainer<EmbyMovie>> GetMoviesPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri)
         {
-            return await GetPlayed<EmbyMovie>("Movie", apiKey, userId, baseUri, startIndex, count, parentIdFilder);
+            return await GetPlayed<EmbyMovie>("Movie", apiKey, userId, baseUri, startIndex, count, parentIdFilder, "ProviderIds");
         }
 
-        private async Task<EmbyItemContainer<T>> GetPlayed<T>(string type, string apiKey, string userId, string baseUri, int startIndex, int count, string parentIdFilder = default)
+        public async Task<EmbyItemContainer<EmbyEpisodes>> GetTvPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri)
+        {
+            return await GetPlayed<EmbyEpisodes>("Episode", apiKey, userId, baseUri, startIndex, count, parentIdFilder);
+        }
+
+        private async Task<EmbyItemContainer<T>> GetPlayed<T>(
+            string type,
+            string apiKey,
+            string userId,
+            string baseUri,
+            int startIndex,
+            int count,
+            string parentIdFilder = default,
+            string fields = default)
         {
             var request = new Request($"emby/items", baseUri, HttpMethod.Get);
 
             request.AddQueryString("Recursive", true.ToString());
             request.AddQueryString("IncludeItemTypes", type);
-            request.AddQueryString("Fields", "ProviderIds");
+            if (!string.IsNullOrEmpty(fields))
+            {
+                request.AddQueryString("Fields", fields);
+            }
             request.AddQueryString("UserId", userId);
             request.AddQueryString("isPlayed", true.ToString());
 

--- a/src/Ombi.Api.Emby/IBaseEmbyApi.cs
+++ b/src/Ombi.Api.Emby/IBaseEmbyApi.cs
@@ -34,5 +34,6 @@ namespace Ombi.Api.Emby
         Task<EmbyItemContainer<EmbySeries>> RecentlyAddedShows(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri);
         
         Task<EmbyItemContainer<EmbyMovie>> GetMoviesPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri);
+        Task<EmbyItemContainer<EmbyEpisodes>> GetTvPlayed(string apiKey, string parentIdFilder, int startIndex, int count, string userId, string baseUri);
     }
 }

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -916,7 +916,7 @@ namespace Ombi.Core.Engine
             var theMovieDbIds = childRequests.Select(x => x.Id);
             foreach (var request in childRequests)
             {
-                var requestedEpisodes = getEpisodesKeys(request);
+                var requestedEpisodes = GetEpisodesKeys(request);
 
                 var playedEpisodes = _userPlayedEpisodeRepository
                     .GetAll()
@@ -934,7 +934,7 @@ namespace Ombi.Core.Engine
             }
         }
 
-        private List<EpisodeKey> getEpisodesKeys(ChildRequests request)
+        private List<EpisodeKey> GetEpisodesKeys(ChildRequests request)
         {
             List<EpisodeKey> result = new List<EpisodeKey>();
             foreach(var season in request.SeasonRequests) 

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -35,7 +35,8 @@ namespace Ombi.Core.Engine
         public TvRequestEngine(ITvMazeApi tvApi, IMovieDbApi movApi, IRequestServiceMain requestService, ICurrentUser user,
             INotificationHelper helper, IRuleEvaluator rule, OmbiUserManager manager, ILogger<TvRequestEngine> logger,
             ITvSender sender, IRepository<RequestLog> rl, ISettingsService<OmbiSettings> settings, ICacheService cache,
-            IRepository<RequestSubscription> sub, IMediaCacheService mediaCacheService) : base(user, requestService, rule, manager, cache, settings, sub)
+            IRepository<RequestSubscription> sub, IMediaCacheService mediaCacheService,
+            IUserPlayedEpisodeRepository userPlayedEpisodeRepository) : base(user, requestService, rule, manager, cache, settings, sub)
         {
             TvApi = tvApi;
             MovieDbApi = movApi;
@@ -44,6 +45,7 @@ namespace Ombi.Core.Engine
             TvSender = sender;
             _requestLog = rl;
             _mediaCacheService = mediaCacheService;
+            _userPlayedEpisodeRepository = userPlayedEpisodeRepository;
         }
 
         private INotificationHelper NotificationHelper { get; }
@@ -54,6 +56,7 @@ namespace Ombi.Core.Engine
         private readonly ILogger<TvRequestEngine> _logger;
         private readonly IRepository<RequestLog> _requestLog;
         private readonly IMediaCacheService _mediaCacheService;
+        private readonly IUserPlayedEpisodeRepository _userPlayedEpisodeRepository;
 
         public async Task<RequestEngineResult> RequestTvShow(TvRequestViewModel tv)
         {
@@ -292,7 +295,7 @@ namespace Ombi.Core.Engine
                     .Skip(position).Take(count).ToListAsync();
 
             }
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
 
             return new RequestsViewModel<TvRequests>
             {
@@ -328,7 +331,7 @@ namespace Ombi.Core.Engine
                 return new RequestsViewModel<TvRequests>();
             }
 
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
 
             return new RequestsViewModel<TvRequests>
             {
@@ -351,7 +354,7 @@ namespace Ombi.Core.Engine
                 allRequests = await TvRepository.Get().ToListAsync();
             }
 
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
             return allRequests;
         }
 
@@ -396,7 +399,7 @@ namespace Ombi.Core.Engine
                 ? allRequests.OrderBy(x => prop.GetValue(x)).ToList()
                 : allRequests.OrderByDescending(x => prop.GetValue(x)).ToList();
             
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
 
             // Make sure we do not show duplicate child requests
             allRequests = allRequests.DistinctBy(x => x.ParentRequest.Title).ToList();
@@ -469,7 +472,7 @@ namespace Ombi.Core.Engine
                 ? allRequests.OrderBy(x => prop.GetValue(x)).ToList()
                 : allRequests.OrderByDescending(x => prop.GetValue(x)).ToList();
             
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
 
             // Make sure we do not show duplicate child requests
             allRequests = allRequests.DistinctBy(x => x.ParentRequest.Title).ToList();
@@ -523,7 +526,7 @@ namespace Ombi.Core.Engine
             allRequests = sortOrder.Equals("asc", StringComparison.InvariantCultureIgnoreCase)
                 ? allRequests.OrderBy(x => prop.GetValue(x)).ToList()
                 : allRequests.OrderByDescending(x => prop.GetValue(x)).ToList();
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
 
             // Make sure we do not show duplicate child requests
             allRequests = allRequests.DistinctBy(x => x.ParentRequest.Title).ToList();
@@ -551,7 +554,7 @@ namespace Ombi.Core.Engine
                 allRequests = await TvRepository.GetLite().ToListAsync();
             }
 
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
             return allRequests;
         }
 
@@ -570,7 +573,7 @@ namespace Ombi.Core.Engine
                 request = await TvRepository.Get().Where(x => x.Id == requestId).FirstOrDefaultAsync();
             }
 
-            await CheckForSubscription(shouldHide, new List<TvRequests>{request});
+            await FillAdditionalFields(shouldHide, new List<TvRequests>{request});
             return request;
         }
 
@@ -624,7 +627,7 @@ namespace Ombi.Core.Engine
                 allRequests = await TvRepository.GetChild().Include(x => x.SeasonRequests).Where(x => x.ParentRequestId == tvId).ToListAsync();
             }
 
-            await CheckForSubscription(shouldHide, allRequests);
+            await FillAdditionalFields(shouldHide, allRequests);
 
             return allRequests;
         }
@@ -643,7 +646,7 @@ namespace Ombi.Core.Engine
             }
             var results = await allRequests.Where(x => x.Title.Contains(search, CompareOptions.IgnoreCase)).ToListAsync();
 
-            await CheckForSubscription(shouldHide, results);
+            await FillAdditionalFields(shouldHide, results);
             return results;
         }
 
@@ -864,12 +867,18 @@ namespace Ombi.Core.Engine
             }
         }
 
-        private async Task CheckForSubscription(HideResult shouldHide, List<TvRequests> x)
+        private async Task FillAdditionalFields(HideResult shouldHide, List<TvRequests> x)
         {
             foreach (var tvRequest in x)
             {
-                await CheckForSubscription(shouldHide, tvRequest.ChildRequests);
+                await FillAdditionalFields(shouldHide, tvRequest.ChildRequests);
             }
+        }
+
+        private async Task FillAdditionalFields(HideResult shouldHide, List<ChildRequests> childRequests)
+        {
+            await CheckForSubscription(shouldHide, childRequests);
+            CheckForPlayed(shouldHide, childRequests);
         }
 
         private async Task CheckForSubscription(HideResult shouldHide, List<ChildRequests> childRequests)
@@ -894,6 +903,30 @@ namespace Ombi.Core.Engine
                     x.Subscribed = result != null;
                 }
             }
+        }
+
+        private void CheckForPlayed(HideResult shouldHide, List<ChildRequests> childRequests)
+        {
+            var theMovieDbIds = childRequests.Select(x => x.Id);
+            foreach (var request in childRequests)
+            {
+                // TODO: consider only episodes that are part of the request (request.SeasonRequests.Episodes)
+                var playedCount = _userPlayedEpisodeRepository.GetAll().Count(x => x.TheMovieDbId == request.Id && x.UserId == request.RequestedUserId);
+                    
+                var toWatchCount = countRequestedEpisodes(request);
+                request.RequestedUserPlayedProgress = 100 * playedCount / toWatchCount;
+                
+            }
+        }
+
+        private int countRequestedEpisodes(ChildRequests request)
+        {
+            int result = 0;
+            foreach(var season in request.SeasonRequests) 
+            {
+                result += season.Episodes.Count();
+            }
+            return result;
         }
 
         private async Task<RequestEngineResult> AddExistingRequest(ChildRequests newRequest, TvRequests existingRequest, string requestOnBehalf, int rootFolder, int qualityProfile)

--- a/src/Ombi.DependencyInjection/IocExtensions.cs
+++ b/src/Ombi.DependencyInjection/IocExtensions.cs
@@ -198,6 +198,7 @@ namespace Ombi.DependencyInjection
             services.AddScoped<IJellyfinContentRepository, JellyfinContentRepository>();
             services.AddScoped<INotificationTemplatesRepository, NotificationTemplatesRepository>();
             services.AddScoped<IUserPlayedMovieRepository, UserPlayedMovieRepository>();
+            services.AddScoped<IUserPlayedEpisodeRepository, UserPlayedEpisodeRepository>();
 
             services.AddScoped<ITvRequestRepository, TvRequestRepository>();
             services.AddScoped<IMovieRequestRepository, MovieRequestRepository>();

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
@@ -178,7 +178,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 return;
             }
 
-            await addToContent(content, new UserPlayedEpisode()
+            await AddToContent(content, new UserPlayedEpisode()
             {
                 TheMovieDbId = int.Parse(parent.TheMovieDbId),
                 SeasonNumber = episode.ParentIndexNumber,
@@ -194,7 +194,7 @@ namespace Ombi.Schedule.Jobs.Emby
                     _logger.LogDebug($"Multiple-episode file detected. Adding episode ${episodeNumber}");
                     episodeNumber++;
 
-                    await addToContent(content, new UserPlayedEpisode()
+                    await AddToContent(content, new UserPlayedEpisode()
                     {
                         TheMovieDbId = int.Parse(parent.TheMovieDbId),
                         SeasonNumber = episode.ParentIndexNumber,
@@ -208,7 +208,7 @@ namespace Ombi.Schedule.Jobs.Emby
             }
         }
 
-        private async Task addToContent(ICollection<UserPlayedEpisode> content, UserPlayedEpisode episode)
+        private async Task AddToContent(ICollection<UserPlayedEpisode> content, UserPlayedEpisode episode)
         {
 
             // Check if it exists

--- a/src/Ombi.Schedule/Jobs/Ombi/MediaDatabaseRefresh.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/MediaDatabaseRefresh.cs
@@ -21,7 +21,8 @@ namespace Ombi.Schedule.Jobs.Ombi
             IPlexContentRepository plexRepo, 
             IEmbyContentRepository embyRepo, 
             IJellyfinContentRepository jellyfinRepo,
-            IUserPlayedMovieRepository userPlayedRepo,
+            IUserPlayedMovieRepository userPlayedMovieRepo,
+            IUserPlayedEpisodeRepository userPlayedEpisodeRepo,
             ISettingsService<EmbySettings> embySettings, 
             ISettingsService<JellyfinSettings> jellyfinSettings)
         {
@@ -30,7 +31,8 @@ namespace Ombi.Schedule.Jobs.Ombi
             _plexRepo = plexRepo;
             _embyRepo = embyRepo;
             _jellyfinRepo = jellyfinRepo;
-            _userPlayedRepo = userPlayedRepo;
+            _userPlayedMovieRepo = userPlayedMovieRepo;
+            _userPlayedEpisodeRepo = userPlayedEpisodeRepo;
             _embySettings = embySettings;
             _jellyfinSettings = jellyfinSettings;
             _plexSettings.ClearCache();
@@ -41,7 +43,8 @@ namespace Ombi.Schedule.Jobs.Ombi
         private readonly IPlexContentRepository _plexRepo;
         private readonly IEmbyContentRepository _embyRepo;
         private readonly IJellyfinContentRepository _jellyfinRepo;
-        private readonly IUserPlayedMovieRepository _userPlayedRepo;
+        private readonly IUserPlayedMovieRepository _userPlayedMovieRepo;
+        private readonly IUserPlayedEpisodeRepository _userPlayedEpisodeRepo;
         private readonly ISettingsService<EmbySettings> _embySettings;
         private readonly ISettingsService<JellyfinSettings> _jellyfinSettings;
 
@@ -66,7 +69,10 @@ namespace Ombi.Schedule.Jobs.Ombi
             try
             {
                 const string movieSql = "DELETE FROM UserPlayedMovie";
-                await _userPlayedRepo.ExecuteSql(movieSql);
+                await _userPlayedMovieRepo.ExecuteSql(movieSql);
+
+                const string episodeSql = "DELETE FROM UserPlayedEpisode";
+                await _userPlayedEpisodeRepo.ExecuteSql(episodeSql);
             }
             catch (Exception e)
             {

--- a/src/Ombi.Store/Context/ExternalContext.cs
+++ b/src/Ombi.Store/Context/ExternalContext.cs
@@ -42,6 +42,7 @@ namespace Ombi.Store.Context
         public DbSet<SickRageCache> SickRageCache { get; set; }
         public DbSet<SickRageEpisodeCache> SickRageEpisodeCache { get; set; }
         public DbSet<UserPlayedMovie> UserPlayedMovie { get; set; }
+        public DbSet<UserPlayedEpisode> UserPlayedEpisode { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/src/Ombi.Store/Entities/Requests/ChildRequests.cs
+++ b/src/Ombi.Store/Entities/Requests/ChildRequests.cs
@@ -59,6 +59,9 @@ namespace Ombi.Store.Entities.Requests
                 return string.Empty;
             }
         }
+
+        [NotMapped]
+        public int RequestedUserPlayedProgress { get; set; }
     }
 
     public enum SeriesType

--- a/src/Ombi.Store/Entities/UserPlayedEpisode.cs
+++ b/src/Ombi.Store/Entities/UserPlayedEpisode.cs
@@ -1,0 +1,10 @@
+﻿namespace Ombi.Store.Entities
+{
+    public class UserPlayedEpisode : Entity
+    {
+        public int TheMovieDbId { get; set; }
+        public int SeasonNumber { get; set; }
+        public int EpisodeNumber { get; set; }
+        public string UserId { get; set; }
+    }
+}

--- a/src/Ombi.Store/Migrations/ExternalMySql/20230515182204_MovieEpisodePlayed.Designer.cs
+++ b/src/Ombi.Store/Migrations/ExternalMySql/20230515182204_MovieEpisodePlayed.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ombi.Store.Context.MySql;
 
@@ -10,9 +11,10 @@ using Ombi.Store.Context.MySql;
 namespace Ombi.Store.Migrations.ExternalMySql
 {
     [DbContext(typeof(ExternalMySqlContext))]
-    partial class ExternalMySqlContextModelSnapshot : ModelSnapshot
+    [Migration("20230515182204_MovieEpisodePlayed")]
+    partial class MovieEpisodePlayed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ombi.Store/Migrations/ExternalMySql/20230515182204_MovieEpisodePlayed.cs
+++ b/src/Ombi.Store/Migrations/ExternalMySql/20230515182204_MovieEpisodePlayed.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombi.Store.Migrations.ExternalMySql
+{
+    public partial class MovieEpisodePlayed : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserPlayedEpisode",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    TheMovieDbId = table.Column<int>(type: "int", nullable: false),
+                    SeasonNumber = table.Column<int>(type: "int", nullable: false),
+                    EpisodeNumber = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserPlayedEpisode", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserPlayedEpisode");
+        }
+    }
+}

--- a/src/Ombi.Store/Migrations/ExternalSqlite/20230515161757_EpisodeUserPlayed.Designer.cs
+++ b/src/Ombi.Store/Migrations/ExternalSqlite/20230515161757_EpisodeUserPlayed.Designer.cs
@@ -2,31 +2,31 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Ombi.Store.Context.MySql;
+using Ombi.Store.Context.Sqlite;
 
 #nullable disable
 
-namespace Ombi.Store.Migrations.ExternalMySql
+namespace Ombi.Store.Migrations.ExternalSqlite
 {
-    [DbContext(typeof(ExternalMySqlContext))]
-    partial class ExternalMySqlContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(ExternalSqliteContext))]
+    [Migration("20230515161757_EpisodeUserPlayed")]
+    partial class EpisodeUserPlayed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "6.0.9")
-                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+            modelBuilder.HasAnnotation("ProductVersion", "6.0.9");
 
             modelBuilder.Entity("Ombi.Store.Entities.CouchPotatoCache", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TheMovieDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -37,41 +37,41 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("AddedAt")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EmbyId")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Has4K")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ImdbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Quality")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TheMovieDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TvDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Url")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -82,37 +82,37 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("AddedAt")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EmbyId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("EpisodeNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ImdbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ParentId")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("TheMovieDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TvDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -125,41 +125,41 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("AddedAt")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Has4K")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ImdbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JellyfinId")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Quality")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TheMovieDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TvDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Url")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -170,37 +170,37 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("AddedAt")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("EpisodeNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ImdbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JellyfinId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ParentId")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("TheMovieDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TvDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -213,31 +213,31 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("AddedAt")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ArtistId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ForeignAlbumId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Monitored")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<decimal>("PercentOfTracks")
-                        .HasColumnType("decimal(65,30)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ReleaseDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("TrackCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -248,19 +248,19 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ArtistId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ArtistName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ForeignArtistId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Monitored")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -271,25 +271,25 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("EpisodeNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("GrandparentKey")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Key")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ParentKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -302,22 +302,22 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ParentKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PlexContentId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("PlexServerContentId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SeasonKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -330,44 +330,44 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("AddedAt")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Has4K")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ImdbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Key")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Quality")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ReleaseYear")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("RequestId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("TheMovieDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TvDbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Url")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -378,10 +378,10 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("TmdbId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -392,19 +392,19 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("Has4K")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("HasFile")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("HasRegular")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TheMovieDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -415,10 +415,10 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TvDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -429,16 +429,16 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("EpisodeNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TvDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -449,13 +449,13 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TheMovieDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TvDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -466,22 +466,22 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("EpisodeNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("HasFile")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("MovieDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TvDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -492,19 +492,19 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("EpisodeNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SeasonNumber")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TheMovieDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("UserId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -515,13 +515,13 @@ namespace Ombi.Store.Migrations.ExternalMySql
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TheMovieDbId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("UserId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 

--- a/src/Ombi.Store/Migrations/ExternalSqlite/20230515161757_EpisodeUserPlayed.cs
+++ b/src/Ombi.Store/Migrations/ExternalSqlite/20230515161757_EpisodeUserPlayed.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombi.Store.Migrations.ExternalSqlite
+{
+    public partial class EpisodeUserPlayed : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserPlayedEpisode",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    TheMovieDbId = table.Column<int>(type: "INTEGER", nullable: false),
+                    SeasonNumber = table.Column<int>(type: "INTEGER", nullable: false),
+                    EpisodeNumber = table.Column<int>(type: "INTEGER", nullable: false),
+                    UserId = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserPlayedEpisode", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserPlayedEpisode");
+        }
+    }
+}

--- a/src/Ombi.Store/Migrations/ExternalSqlite/ExternalSqliteContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/ExternalSqlite/ExternalSqliteContextModelSnapshot.cs
@@ -486,6 +486,29 @@ namespace Ombi.Store.Migrations.ExternalSqlite
                     b.ToTable("SonarrEpisodeCache");
                 });
 
+            modelBuilder.Entity("Ombi.Store.Entities.UserPlayedEpisode", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("EpisodeNumber")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("SeasonNumber")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("TheMovieDbId")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("UserId")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("UserPlayedEpisode");
+                });
+
             modelBuilder.Entity("Ombi.Store.Entities.UserPlayedMovie", b =>
                 {
                     b.Property<int>("Id")

--- a/src/Ombi.Store/Repository/IUserPlayedEpisodeRepository.cs
+++ b/src/Ombi.Store/Repository/IUserPlayedEpisodeRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Ombi.Store.Entities;
+
+namespace Ombi.Store.Repository
+{
+    public interface IUserPlayedEpisodeRepository : IExternalRepository<UserPlayedEpisode>
+    {
+        Task<UserPlayedEpisode> Get(int theMovieDbId, int seasonNumber, int episodeNumber, string userId);
+    }
+}

--- a/src/Ombi.Store/Repository/UserPlayedEpisodeRepository.cs
+++ b/src/Ombi.Store/Repository/UserPlayedEpisodeRepository.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Ombi.Store.Context;
+using Ombi.Store.Entities;
+
+namespace Ombi.Store.Repository
+{
+    public class UserPlayedEpisodeRepository : ExternalRepository<UserPlayedEpisode>, IUserPlayedEpisodeRepository
+    {
+        protected ExternalContext Db { get; }
+        public UserPlayedEpisodeRepository(ExternalContext db) : base(db)
+        {
+            Db = db;
+        }
+
+        public async Task<UserPlayedEpisode> Get(int theMovieDbId, int seasonNumber, int episodeNumber, string userId)
+        {
+            return await Db.UserPlayedEpisode.FirstOrDefaultAsync(x => x.TheMovieDbId == theMovieDbId && x.SeasonNumber == seasonNumber && x.EpisodeNumber == episodeNumber && x.UserId == userId);
+        }
+    }
+}

--- a/src/Ombi/ClientApp/src/app/app.module.ts
+++ b/src/Ombi/ClientApp/src/app/app.module.ts
@@ -46,6 +46,7 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { MatPaginatorI18n } from "./localization/MatPaginatorI18n";
 import { MatPaginatorIntl } from "@angular/material/paginator";
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatSnackBarModule } from '@angular/material/snack-bar';
@@ -150,6 +151,7 @@ export function JwtTokenGetter() {
         OverlayModule,
         MatCheckboxModule,
         MatProgressSpinnerModule,
+        MatProgressBarModule,
         JwtModule.forRoot({
             config: {
                 tokenGetter: JwtTokenGetter,

--- a/src/Ombi/ClientApp/src/app/interfaces/IRequestModel.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/IRequestModel.ts
@@ -132,6 +132,7 @@ export interface ITvRequests {
   background: any;
   totalSeasons: number;
   tvDbId: number; // NO LONGER USED
+  requestedUserPlayedProgress: number;
 
   open: boolean; // THIS IS FOR THE UI
 

--- a/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.html
+++ b/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.html
@@ -65,7 +65,7 @@
             mat-header-cell
             *matHeaderCellDef
             disableClear
-            matTooltip="{{ 'Requests.WatchedTooltip' | translate}}">
+            matTooltip="{{ 'Requests.WatchedProgressTooltip' | translate}}">
             {{ 'Requests.Watched' | translate}}
           </th>
           <td mat-cell id="requestedUserPlayedProgress{{element.id}}"  *matCellDef="let element">

--- a/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.html
+++ b/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.html
@@ -60,10 +60,23 @@
             </td>
         </ng-container>
 
+        <ng-container matColumnDef="watchedByRequestedUser">
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            disableClear
+            matTooltip="{{ 'Requests.WatchedTooltip' | translate}}">
+            {{ 'Requests.Watched' | translate}}
+          </th>
+          <td mat-cell id="requestedUserPlayedProgress{{element.id}}"  *matCellDef="let element">
+            <mat-progress-bar mode="determinate" value="{{element.requestedUserPlayedProgress}}" class="played-progress"></mat-progress-bar>
+          </td>
+      </ng-container>
+
         <ng-container matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef> </th>
             <td mat-cell *matCellDef="let element">
-                <a id="detailsButton{{element.id}}" mat-raised-button color="accent" [routerLink]="'/details/tv/' + element.parentRequest.externalProviderId">{{'Requests.Details' | translate}}</a> 
+                <a id="detailsButton{{element.id}}" mat-raised-button color="accent" [routerLink]="'/details/tv/' + element.parentRequest.externalProviderId">{{'Requests.Details' | translate}}</a>
                 <button id="optionsButton{{element.id}}" mat-raised-button color="warn" (click)="openOptions(element)" *ngIf="isAdmin">{{'Requests.Options' | translate}}</button>
             </td>
         </ng-container>

--- a/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.scss
+++ b/src/Ombi/ClientApp/src/app/requests-list/components/tv-grid/tv-grid.component.scss
@@ -1,0 +1,6 @@
+@import "./styles/variables.scss";
+
+.played-progress {
+  width: 5rem;
+  height: 1rem;
+}

--- a/src/Ombi/ClientApp/src/app/shared/shared.module.ts
+++ b/src/Ombi/ClientApp/src/app/shared/shared.module.ts
@@ -23,6 +23,7 @@ import {MatMenuModule} from '@angular/material/menu';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
 import {MatRadioModule} from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
@@ -66,6 +67,7 @@ import { WatchProvidersSelectComponent } from "./components/watch-providers-sele
     MomentModule,
     MatCardModule,
     MatProgressSpinnerModule,
+    MatProgressBarModule,
     MatAutocompleteModule,
     MatInputModule,
     MatTabsModule,
@@ -99,6 +101,7 @@ import { WatchProvidersSelectComponent } from "./components/watch-providers-sele
       TranslateModule,
       SidebarModule,
       MatProgressSpinnerModule,
+      MatProgressBarModule,
       IssuesReportComponent,
       EpisodeRequestComponent,
       AdminRequestDialogComponent,

--- a/src/Ombi/wwwroot/translations/en.json
+++ b/src/Ombi/wwwroot/translations/en.json
@@ -161,6 +161,7 @@
         "RequestStatus": "Request status",
         "Watched": "Watched",
         "WatchedTooltip": "The user who made the request has watched it",
+        "WatchedProgressTooltip": "Shows how much the user who made the request has watched it",
         "WatchedByUsersCount": "{{count}} users have watched this.",
         "Denied": " Denied:",
         "TheatricalRelease": "Theatrical Release: {{date}}",


### PR DESCRIPTION
This is the TV equivalent of https://github.com/Ombi-app/Ombi/pull/4881

![image](https://github.com/Ombi-app/Ombi/assets/34862846/0b36e721-913f-4a18-82ac-3bdc8ce220b8)
A tooltip on the column header explains its meaning:
![image](https://github.com/Ombi-app/Ombi/assets/34862846/59b72b90-790e-41e7-a608-29ae9303ccb8)

I'm curious to know if there's a more elegant way to do what I did in src/Ombi.Core/Engine/TvRequestEngine.cs, I'm not sure I'm using the most of C# capabilities here.

Once this PR is merged, I'm planning to work on bringing these features to Jellyfin and Plex sync.