### PR TITLE
Fix Emby played sync running a full sync during recently added sync

### DIFF
--- a/src/Ombi.Schedule/Jobs/Emby/EmbyLibrarySync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyLibrarySync.cs
@@ -35,7 +35,7 @@ namespace Ombi.Schedule.Jobs.Emby
         public virtual async Task Execute(IJobExecutionContext context)
         {
             
-            JobDataMap dataMap = context.JobDetail.JobDataMap;
+            JobDataMap dataMap = context.MergedJobDataMap;
             if (dataMap.TryGetValue(JobDataKeys.EmbyRecentlyAddedSearch, out var recentlyAddedObj))
             {
                 recentlyAdded = Convert.ToBoolean(recentlyAddedObj);


### PR DESCRIPTION
It seems that context.JobDetail.JobDataMap does not contain any data when the job is triggered manually by the content sync.
This resulted in the Played sync always running a full sync instead of a recently played sync.