### PR TITLE
Hide watched status when request is not available

### DIFF
--- a/src/Ombi/ClientApp/src/app/requests-list/components/movies-grid/movies-grid.component.ts
+++ b/src/Ombi/ClientApp/src/app/requests-list/components/movies-grid/movies-grid.component.ts
@@ -24,7 +24,7 @@ export class MoviesGridComponent implements OnInit, AfterViewInit {
     public dataSource: MatTableDataSource<IMovieRequests>;
     public resultsLength: number;
     public isLoadingResults = true;
-    public displayedColumns: string[] = ['title', 'requestedUser.requestedBy',  'status', 'requestStatus','requestedDate'];
+    public displayedColumns: string[];
     public gridCount: string = "15";
     public isAdmin: boolean;
     public is4kEnabled = false;
@@ -61,14 +61,10 @@ export class MoviesGridComponent implements OnInit, AfterViewInit {
     public ngOnInit() {
         this.isAdmin = this.auth.hasRole("admin") || this.auth.hasRole("poweruser");
         this.manageOwnRequests = this.auth.hasRole("ManageOwnRequests")
-        if (this.isAdmin) {
-            this.displayedColumns.unshift('select');
-        }
 
         this.is4kEnabled = this.featureFacade.is4kEnabled();
         this.isPlayedSyncEnabled = this.featureFacade.isPlayedSyncEnabled();
 
-        this.addDynamicColumns();
 
         const defaultCount = this.storageService.get(this.storageKeyGridCount);
         const defaultSort = this.storageService.get(this.storageKey);
@@ -88,13 +84,21 @@ export class MoviesGridComponent implements OnInit, AfterViewInit {
         }
     }
 
-    addDynamicColumns() {
+    setDisplayedColumns() {
+      this.displayedColumns = ['title', 'requestedUser.requestedBy',  'status', 'requestStatus','requestedDate'];
+
+      if (this.isAdmin) {
+        this.displayedColumns.unshift('select');
+      }
+
       if ((this.isAdmin || this.auth.hasRole("Request4KMovie"))
           && this.is4kEnabled) {
           this.displayedColumns.splice(4, 0, 'has4kRequest');
       }
 
-      if (this.isPlayedSyncEnabled) {
+      if (this.isPlayedSyncEnabled
+        //  && this.currentFilter in (RequestFilterType.All, RequestFilterType.Available)
+        && ( this.currentFilter == RequestFilterType.All || this.currentFilter ==  RequestFilterType.Available ) ) {
           this.displayedColumns.push('watchedByRequestedUser');
       }
 
@@ -103,6 +107,8 @@ export class MoviesGridComponent implements OnInit, AfterViewInit {
     }
 
     public async ngAfterViewInit() {
+
+        this.setDisplayedColumns();
 
         this.storageService.save(this.storageKeyGridCount, this.gridCount);
         this.storageService.save(this.storageKeyCurrentFilter, (+this.currentFilter).toString());


### PR DESCRIPTION
This hides the unnecessary "Watched" column when filtering by request status.
![image](https://github.com/Ombi-app/Ombi/assets/34862846/09f67f35-2b70-4593-881d-d5ae8fbd4541)
![image](https://github.com/Ombi-app/Ombi/assets/34862846/737d6296-befd-4979-b5bb-3f95e1bdef26)
![image](https://github.com/Ombi-app/Ombi/assets/34862846/20eb2993-91fb-4ef0-827c-303ffd0fa394)
