### PR TITLE
Remove old trending source

### DIFF
--- a/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
@@ -138,17 +138,13 @@ namespace Ombi.Core.Engine.V2
         public async Task<IEnumerable<SearchTvShowViewModel>> Trending(int currentlyLoaded, int amountToLoad)
         {           
             var langCode = await DefaultLanguageCode(null);
-            var isOldTrendingSourceEnabled = await _feature.FeatureEnabled(FeatureNames.OldTrendingSource); 
 
             var pages = PaginationHelper.GetNextPages(currentlyLoaded, amountToLoad, ResultLimit);
             var results = new List<MovieDbSearchResult>();
             foreach (var pagesToLoad in pages)
             {
-                var search = ( async () => (isOldTrendingSourceEnabled) ?
-                                await _movieApi.TopRatedTv(langCode, pagesToLoad.Page) 
-                                : await _movieApi.TrendingTv(langCode, pagesToLoad.Page));
                 var apiResult = await Cache.GetOrAddAsync(nameof(Trending) + langCode + pagesToLoad.Page,
-                    search, DateTimeOffset.Now.AddHours(12));
+                    () => _movieApi.TrendingTv(langCode, pagesToLoad.Page), DateTimeOffset.Now.AddHours(12));
                 results.AddRange(apiResult.Skip(pagesToLoad.Skip).Take(pagesToLoad.Take));
             }
 

--- a/src/Ombi.Settings/Settings/Models/FeatureSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/FeatureSettings.cs
@@ -20,7 +20,6 @@ namespace Ombi.Settings.Settings.Models
     public static class FeatureNames
     {
         public const string Movie4KRequests = nameof(Movie4KRequests);
-        public const string OldTrendingSource = nameof(OldTrendingSource);
         public const string PlayedSync = nameof(PlayedSync);
     }
 }


### PR DESCRIPTION
#4624 brought a new algorithm to populate the Trending section on the Discover page. We've had no major negative feedback on the new algorithm since then.
It was still possible to use the old way the Trending section was populated. This decommissions the toggle that allowed it.