### PR TITLE
bugfix (mutliple servers): attempting to cache the Plex Content in se…

### DIFF
--- a/src/Ombi.Schedule/Jobs/Plex/PlexContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexContentSync.cs
@@ -278,6 +278,10 @@ namespace Ombi.Schedule.Jobs.Plex
                 await Repo.AddRange(contentToAdd);
                 foreach (var c in contentToAdd)
                 {
+                    if (contentProcessed.ContainsKey(c.Id)) {
+                        continue;
+                    }
+
                     contentProcessed.Add(c.Id, c.Key);
                 }
             }


### PR DESCRIPTION
### Propose fixing multiple servers sync.

Hi

I have a problem with muliple Plex servers implementation on sync.
I think it's because we have same movies/series on both remote servers.

I don't know dotnet, but I give you an idea about the problem under the PR file changes.

![image](https://github.com/Ombi-app/Ombi/assets/82907030/f947fa28-3cb1-41d1-bc80-9ccdc2b1d73e)


```shell
Base Url: /ombi
Wrote new baseurl at /app/ombi/ClientApp/dist/index.html
We are running on http://*:3579
/app/ombi
[ls.io-init] done.
warn: Ombi.Schedule.Jobs.Plex.PlexContentSync[2008]
      Exception thrown when attempting to cache the Plex Content in server Antonin
      System.InvalidOperationException: The instance of entity type 'PlexServerContent' cannot be tracked because another instance with the same key value for {'Key'} is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting key values.
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IdentityMap`1.ThrowIdentityConflict(InternalEntityEntry entry)
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IdentityMap`1.Add(TKey key, InternalEntityEntry entry, Boolean updateDuplicate)
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.StartTracking(InternalEntityEntry entry)
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState oldState, EntityState newState, Boolean acceptChanges, Boolean modifyProperties)
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityGraphAttacher.PaintAction(EntityEntryGraphNode`1 node)
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityEntryGraphIterator.TraverseGraph[TState](EntityEntryGraphNode`1 node, Func`2 handleNode)
         at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityGraphAttacher.AttachGraph(InternalEntityEntry rootEntry, EntityState targetState, EntityState storeGeneratedWithKeySetTargetState, Boolean forceStateWhenUnknownKey)
         at Microsoft.EntityFrameworkCore.Internal.InternalDbSet`1.SetEntityStates(IEnumerable`1 entities, EntityState entityState)
         at Microsoft.EntityFrameworkCore.Internal.InternalDbSet`1.AddRange(IEnumerable`1 entities)
         at Ombi.Store.Repository.BaseRepository`2.AddRange(IEnumerable`1 content, Boolean save) in /home/runner/work/Ombi/Ombi/src/Ombi.Store/Repository/BaseRepository.cs:line 49
         at Ombi.Schedule.Jobs.Plex.PlexContentSync.ProcessServer(PlexServers servers, Boolean recentlyAddedSearch) in /home/runner/work/Ombi/Ombi/src/Ombi.Schedule/Jobs/Plex/PlexContentSync.cs:line 278
         at Ombi.Schedule.Jobs.Plex.PlexContentSync.StartTheCache(PlexSettings plexSettings, Boolean recentlyAddedSearch) in /home/runner/work/Ombi/Ombi/src/Ombi.Schedule/Jobs/Plex/PlexContentSync.cs:line 153
```