### PR TITLE
Linkify logo in newsletter

### DIFF
--- a/src/Ombi.Notifications.Templates/INewsletterTemplate.cs
+++ b/src/Ombi.Notifications.Templates/INewsletterTemplate.cs
@@ -2,6 +2,6 @@
 {
     public interface INewsletterTemplate
     {
-        string LoadTemplate(string subject, string intro, string tableHtml, string logo, string unsubscribeLink);
+        string LoadTemplate(string subject, string intro, string tableHtml, string logo, string unsubscribeLink, string applicationUrl);
     }
 }

--- a/src/Ombi.Notifications.Templates/NewsletterTemplate.cs
+++ b/src/Ombi.Notifications.Templates/NewsletterTemplate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using Ombi.I18n.Resources;
@@ -27,6 +27,7 @@ namespace Ombi.Notifications.Templates
         
         private const string SubjectKey = "{@SUBJECT}";
         private const string DateKey = "{@DATENOW}";
+        private const string AppUrl = "{@APPURL}";
         private const string Logo = "{@LOGO}";
         private const string TableLocation = "{@RECENTLYADDED}";
         private const string IntroText = "{@INTRO}";
@@ -35,13 +36,14 @@ namespace Ombi.Notifications.Templates
         private const string PoweredByText = "{@POWEREDBYTEXT}";
 
 
-        public string LoadTemplate(string subject, string intro, string tableHtml, string logo, string unsubscribeLink)
+        public string LoadTemplate(string subject, string intro, string tableHtml, string logo, string unsubscribeLink, string applicationUrl)
         {
             var sb = new StringBuilder(File.ReadAllText(TemplateLocation));
             sb.Replace(SubjectKey, subject);
             sb.Replace(TableLocation, tableHtml);
             sb.Replace(IntroText, intro);
             sb.Replace(DateKey, DateTime.Now.ToString("f"));
+            sb.Replace(AppUrl, applicationUrl);
             sb.Replace(Logo, string.IsNullOrEmpty(logo) ? OmbiLogo : logo);
             sb.Replace(Unsubscribe, string.IsNullOrEmpty(unsubscribeLink) ? string.Empty : unsubscribeLink);
             sb.Replace(UnsubscribeText, string.IsNullOrEmpty(unsubscribeLink) ? string.Empty : Texts.Unsubscribe);

--- a/src/Ombi.Notifications.Templates/Templates/NewsletterTemplate.html
+++ b/src/Ombi.Notifications.Templates/Templates/NewsletterTemplate.html
@@ -428,7 +428,7 @@
                                             <tbody>
                                                 <tr>
                                                     <td valign="top" style="font-family: 'Open Sans', Helvetica, Arial, sans-serif; vertical-align: top;">
-                                                        <img src="{@LOGO}" style="border: none; -ms-interpolation-mode: bicubic; max-width: 100%;">
+                                                        <a href="{@APPURL}"><img src="{@LOGO}" style="border: none; -ms-interpolation-mode: bicubic; max-width: 100%;"></a>
                                                     </td>
                                                 </tr>
                                                 <tr>

--- a/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
@@ -216,7 +216,7 @@ namespace Ombi.Schedule.Jobs.Ombi
 
                         var email = new NewsletterTemplate();
 
-                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, unsubscribeLink, customization.ApplicationUrl);
+                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, unsubscribeLink, customization.ApplicationUrl ?? string.Empty);
 
                         await _email.Send(
                             new NotificationMessage { Message = html, Subject = messageContent.Subject, To = a.Email },

--- a/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
@@ -174,7 +174,7 @@ namespace Ombi.Schedule.Jobs.Ombi
                         }
 
                         var url = GenerateUnsubscribeLink(customization.ApplicationUrl, user.Id);
-                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, url);
+                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, url, customization.ApplicationUrl);
 
                         var bodyBuilder = new BodyBuilder
                         {
@@ -216,7 +216,7 @@ namespace Ombi.Schedule.Jobs.Ombi
 
                         var email = new NewsletterTemplate();
 
-                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, unsubscribeLink);
+                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, unsubscribeLink, customization.ApplicationUrl);
 
                         await _email.Send(
                             new NotificationMessage { Message = html, Subject = messageContent.Subject, To = a.Email },

--- a/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
@@ -174,7 +174,7 @@ namespace Ombi.Schedule.Jobs.Ombi
                         }
 
                         var url = GenerateUnsubscribeLink(customization.ApplicationUrl, user.Id);
-                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, url, customization.ApplicationUrl);
+                        var html = email.LoadTemplate(messageContent.Subject, messageContent.Message, body, customization.Logo, url, customization.ApplicationUrl ?? string.Empty);
 
                         var bodyBuilder = new BodyBuilder
                         {


### PR DESCRIPTION
Makes changes to the newsletter to turn the logo image into a hyperlink to the application.
Requires that the _application url_ field is filled set in Settings/Customization. If the field is not set, the generated hyperlink will be self-referencing.