### PR TITLE
Disable Autocomplete for Plex Server Dialog

### DIFF
--- a/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.html
@@ -5,21 +5,21 @@
 
     <mat-form-field appearance="outline" floatLabel=auto>
       <mat-label>Server Name</mat-label>
-      <input matInput id="serverName" placeholder="Server Name" name="name" [(ngModel)]="this.data.server.name" value="{{this.data.server.name}}">
+      <input matInput id="serverName" placeholder="Server Name" name="name" [(ngModel)]="this.data.server.name" value="{{this.data.server.name}}" autocomplete="off">
     </mat-form-field>
 
     <div class="row">
       <mat-form-field class="col-md-6 col-12" appearance="outline" floatLabel=auto>
         <mat-label>Hostname / IP</mat-label>
         <input matInput id="ip" placeholder="Hostname or IP" name="ip" [(ngModel)]="this.data.server.ip" value="{{this.data.server.ip}}"
-           #serverHostnameIpControl="ngModel" required>
+           #serverHostnameIpControl="ngModel" required autocomplete="off">
         <mat-error *ngIf="serverHostnameIpControl.hasError('required')">Must be specified.</mat-error>
       </mat-form-field>
 
       <mat-form-field class="col-md-4 col-7" appearance="outline" floatLabel=auto>
         <mat-label>Port</mat-label>
         <input id="port" matInput placeholder="Port" name="port" [(ngModel)]="this.data.server.port" value="{{this.data.server.port}}"
-           #serverPortControl="ngModel" required pattern="^[0-9]*$">
+           #serverPortControl="ngModel" required pattern="^[0-9]*$" autocomplete="off">
         <mat-error *ngIf="serverPortControl.hasError('required')">Must be specified.</mat-error>
         <mat-error *ngIf="serverPortControl.hasError('pattern')">Must be a number.</mat-error>
       </mat-form-field>
@@ -32,21 +32,21 @@
     <mat-form-field appearance="outline" floatLabel=auto>
       <mat-label>Plex Authorization Token</mat-label>
       <input id="authToken" matInput placeholder="Plex Authorization Token" name="authToken" [(ngModel)]="this.data.server.plexAuthToken" value="{{this.data.server.plexAuthToken}}"
-         #serverApiKeyControl="ngModel" required>
+         #serverApiKeyControl="ngModel" required autocomplete="off">
       <mat-error *ngIf="serverApiKeyControl.hasError('required')">Must be specified.</mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" floatLabel=auto>
       <mat-label>Machine Identifier</mat-label>
       <input id="machineId" matInput placeholder="Machine Identifier" name="MachineIdentifier" [(ngModel)]="this.data.server.machineIdentifier" value="{{this.data.server.machineIdentifier}}"
-         #serverApiKeyControl="ngModel" required>
+         #serverApiKeyControl="ngModel" required autocomplete="off">
       <mat-error *ngIf="serverApiKeyControl.hasError('required')">Must be specified.</mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" floatLabel=auto>
       <mat-label>Externally Facing Hostname</mat-label>
       <input id="externalHostname" matInput placeholder="e.g. https://emby.this.data.server.com/" name="serverHostname" name="hostname"
-        [(ngModel)]="this.data.server.serverHostname" value="{{this.data.server.serverHostname}}" >
+        [(ngModel)]="this.data.server.serverHostname" value="{{this.data.server.serverHostname}}" autocomplete="off">
       <mat-hint>
         This will be the external address that users will navigate to when they press the 'View On Plex' button
 <br>
@@ -58,7 +58,7 @@
 
     <mat-form-field appearance="outline" floatLabel=auto>
       <mat-label>Episode Batch Size</mat-label>
-      <input id="batchSize" matInput placeholder="150" name="MachineIdentifier" [(ngModel)]="this.data.server.episodeBatchSize" value="{{this.data.server.episodeBatchSize}}">
+      <input id="batchSize" matInput placeholder="150" name="MachineIdentifier" [(ngModel)]="this.data.server.episodeBatchSize" value="{{this.data.server.episodeBatchSize}}" autocomplete="off">
       <mat-hint>
         150 by default, you shouldn't need to change this, this sets how many episodes we request from Plex at a single time.
       </mat-hint>


### PR DESCRIPTION
I have observed an issue where certain password/form-fill managers will automatically fill in old plex server details (such as authentication token or machine identifier). For example, my lastpass seems to be remembering an old authentication token, and without my noticing will auto-fill in those details even when I haven't explicitly told it to. I imagine this happens with other password managers, and I don't see a particular need to autocomplete/auto-fill these details.

I have confirmed that the `autocomplete="off"` is an industry standard for inputs and modern managers will respect it (optionally). 

Switching to a different browser without lastpass, I have no issues. This might be a Chrome issue, but I don't see any data in my auto-fill settings where this data is being kept. Either way, native browser auto-fill or password manager extension, this causes issues.

There should probably a separate initiative to add this to other input forms throughout at least the settings area of the front end.

Thank you!