### PR TITLE
fix: retrieves typo and use "Market with App Store" badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
             </li>
             <li>
               <b>3.</b>
-              DVR app retreives content and pushes to Plex/Emby
+              DVR app retrieves content and pushes to Plex/Emby
             </li>
             <li>
               <br>
@@ -136,8 +136,8 @@
         </div>
         <div class="center text-center">
           <h1>There's also a mobile app!</h1>
-          <a class="apple-badge badges" href="https://itunes.apple.com/us/app/ombi/id1335260043?mt=8">
-            <img alt='Get it on the App Store' src="https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg">
+          <a class="apple-badge badges" href="https://apps.apple.com/us/app/ombi/id1335260043?itscg=30200&itsct=apps_box_badge&mttnsubad=1335260043">
+            <img src="https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/en-us?releaseDate=1526601600" alt="Download on the App Store" />
           </a>
           <a class="google-badge badges" href='https://play.google.com/store/apps/details?id=com.tidusjar.Ombi&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
             <img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/>


### PR DESCRIPTION
Fixes #5103

- Fix retrieves typo
- Use "Market with App Store" badge ([official from Apple](https://toolbox.marketingtools.apple.com/en-us/app-store/us/app/1335260043))