### PR TITLE
Fix Plex user import to exclude users without server access

### DIFF
--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: '18'
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           '**/node_modules'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: '18'
 
       - name: NodeModules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: node_modules-${{ hashFiles('**/yarn.lock') }}
@@ -42,7 +42,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Nuget Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -112,7 +112,7 @@ jobs:
           dotnet-version: '5.0.x'
 
       - name: Nuget Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,7 +17,7 @@
 #           fetch-depth: 0
 
 #       - name: NodeModules Cache
-#         uses: actions/cache@v2
+#         uses: actions/cache@v4
 #         with:
 #           path: '**/node_modules'
 #           key: node_modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '18'
 
       - name: NodeModules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: node_modules-${{ hashFiles('**/yarn.lock') }}
@@ -41,7 +41,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Nuget Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -101,7 +101,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Nuget Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}

--- a/src/Ombi.Schedule/Jobs/Plex/PlexUserImporter.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexUserImporter.cs
@@ -143,6 +143,14 @@ namespace Ombi.Schedule.Jobs.Plex
                         _log.LogWarning($"Cannot add user {plexUser.Username} because their email address is already in Ombi, skipping this user");
                         continue;
                     }
+
+                    // Check if the user has a <Server> entry
+                    if (plexUser.Server == null || !plexUser.Server.Any())
+                    {
+                        _log.LogInformation($"Skipping user {plexUser.Username} because they do not have access to any servers.");
+                        continue;
+                    }
+
                     // Create this users
                     // We do not store a password against the user since they will authenticate via Plex
                     var newUser = new OmbiUser


### PR DESCRIPTION
Fixes #5064

Add a condition to filter out users without a `<Server>` entry in the `ImportPlexUsers` method.

* Update the `ImportPlexUsers` method to check for the presence of a `<Server>` entry before importing a user.
* Log a message when skipping a user due to lack of server access.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ombi-app/Ombi/pull/5218?shareId=5225767a-fa38-405e-af2a-63f3a5525c42).