### PR TITLE
fix: set MarkedAsApproved on TV requests

### DIFF
--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -696,6 +696,8 @@ namespace Ombi.Core.Engine
                     ErrorMessage = "Child Request does not exist"
                 };
             }
+
+            request.MarkedAsApproved = DateTime.Now;
             request.Approved = true;
             request.Denied = false;
 


### PR DESCRIPTION
I want to use this field in a workflow, but it doesn't seem to be populated for TV requests like it does for [movie](https://github.com/Ombi-app/Ombi/blob/d2be48a9211c53b776d61eba3ce50e6d7c11255e/src/Ombi.Core/Engine/MovieRequestEngine.cs#L657) and [music](https://github.com/Ombi-app/Ombi/blob/d2be48a9211c53b776d61eba3ce50e6d7c11255e/src/Ombi.Core/Engine/MusicRequestEngine.cs#L363) requests.

Maybe there's a reason this isn't populated for a reason I'm not aware of?