### PR TITLE
Plex OAuth: fix X-Plex-Client-Identifier mismatch causing PIN 1020 er…

### DIFF
--- a/src/Ombi.Api.External/MediaServers/Plex/PlexApi.cs
+++ b/src/Ombi.Api.External/MediaServers/Plex/PlexApi.cs
@@ -248,8 +248,8 @@ namespace Ombi.Api.External.MediaServers.Plex
             request.AddQueryString("context[device][platform]", "Web");
             request.AddQueryString("context[device][device]", "Ombi");
 
-            var s = await GetSettings();
-            await CheckInstallId(s);
+            // Always fetch current settings to ensure we use the same client identifier as the UI
+            var s = await _plexSettings.GetSettingsAsync();
             request.AddQueryString("clientID", s.InstallId.ToString("N"));
 
             if (request.FullUri.Fragment.Equals("#"))
@@ -362,8 +362,8 @@ namespace Ombi.Api.External.MediaServers.Plex
         /// <param name="request"></param>
         private async Task AddHeaders(Request request)
         {
-            var s = await GetSettings();
-            await CheckInstallId(s);
+            // Always fetch current settings to ensure a consistent X-Plex-Client-Identifier
+            var s = await _plexSettings.GetSettingsAsync();
             request.AddHeader("X-Plex-Client-Identifier", s.InstallId.ToString("N"));
             request.AddHeader("X-Plex-Product", ApplicationName);
             request.AddHeader("X-Plex-Version", "3");
@@ -378,19 +378,8 @@ namespace Ombi.Api.External.MediaServers.Plex
             request.AddHeader("X-Plex-Container-Start", from.ToString());
             request.AddHeader("X-Plex-Container-Size", to.ToString());
         }
-        private async Task CheckInstallId(PlexSettings s)
-        {
-            if (s?.InstallId == Guid.Empty || s.InstallId == Guid.Empty)
-            {
-                s.InstallId = Guid.NewGuid();
-                await _plexSettings.SaveSettingsAsync(s);
-            }
-        }
-
-        private PlexSettings _settings;
-        private async Task<PlexSettings> GetSettings()
-        {
-            return _settings ?? (_settings = await _plexSettings.GetSettingsAsync());
-        }
+        // Intentionally removed InstallId generation and settings caching from this layer.
+        // InstallId is generated and persisted via SettingsController.GetClientId so that
+        // both the UI (PIN creation) and server (PIN polling) use the same identifier.
     }
 }

--- a/src/Ombi.Core.Tests/Authentication/PlexOAuthManagerTests.cs
+++ b/src/Ombi.Core.Tests/Authentication/PlexOAuthManagerTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Microsoft.Extensions.Logging;
+using Ombi.Api.External.MediaServers.Plex;
+using Ombi.Api.External.MediaServers.Plex.Models.OAuth;
+using Ombi.Core.Authentication;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Settings.Settings.Models;
+
+namespace Ombi.Core.Tests.Authentication
+{
+    [TestFixture]
+    public class PlexOAuthManagerTests
+    {
+        private AutoMocker _mocker;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mocker = new AutoMocker();
+        }
+
+        private PlexOAuthManager CreateSubject()
+        {
+            return _mocker.CreateInstance<PlexOAuthManager>();
+        }
+
+        [Test]
+        public async Task GetAccessTokenFromPin_ReturnsToken_WhenPinValid_AndClientIdMatches()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var clientId = guid.ToString("N");
+
+            _mocker.GetMock<IPlexApi>()
+                .Setup(x => x.GetPin(It.IsAny<int>()))
+                .ReturnsAsync(new OAuthContainer
+                {
+                    Result = new OAuthPin
+                    {
+                        id = 123,
+                        code = "code",
+                        trusted = true,
+                        clientIdentifier = clientId,
+                        expiresIn = 60,
+                        authToken = "auth-token"
+                    }
+                });
+
+            _mocker.GetMock<ISettingsService<CustomizationSettings>>()
+                .Setup(x => x.GetSettingsAsync())
+                .ReturnsAsync(new CustomizationSettings());
+
+            _mocker.GetMock<ISettingsService<PlexSettings>>()
+                .Setup(x => x.GetSettingsAsync())
+                .ReturnsAsync(new PlexSettings { InstallId = guid });
+
+            _mocker.Use(Mock.Of<ILogger<PlexOAuthManager>>());
+
+            var subject = CreateSubject();
+
+            // Act
+            var token = await subject.GetAccessTokenFromPin(123);
+
+            // Assert
+            Assert.AreEqual("auth-token", token);
+        }
+
+        [Test]
+        public async Task GetAccessTokenFromPin_ReturnsToken_WhenPinValid_AndClientIdMismatch()
+        {
+            // Arrange
+            var serverGuid = Guid.NewGuid();
+            var pinGuid = Guid.NewGuid();
+
+            _mocker.GetMock<IPlexApi>()
+                .Setup(x => x.GetPin(It.IsAny<int>()))
+                .ReturnsAsync(new OAuthContainer
+                {
+                    Result = new OAuthPin
+                    {
+                        id = 456,
+                        code = "code",
+                        trusted = true,
+                        clientIdentifier = pinGuid.ToString("N"),
+                        expiresIn = 60,
+                        authToken = "auth-token-2"
+                    }
+                });
+
+            _mocker.GetMock<ISettingsService<CustomizationSettings>>()
+                .Setup(x => x.GetSettingsAsync())
+                .ReturnsAsync(new CustomizationSettings());
+
+            _mocker.GetMock<ISettingsService<PlexSettings>>()
+                .Setup(x => x.GetSettingsAsync())
+                .ReturnsAsync(new PlexSettings { InstallId = serverGuid });
+
+            _mocker.Use(Mock.Of<ILogger<PlexOAuthManager>>());
+
+            var subject = CreateSubject();
+
+            // Act
+            var token = await subject.GetAccessTokenFromPin(456);
+
+            // Assert
+            Assert.AreEqual("auth-token-2", token);
+        }
+    }
+}

--- a/src/Ombi.Core/Authentication/PlexOAuthManager.cs
+++ b/src/Ombi.Core/Authentication/PlexOAuthManager.cs
@@ -6,6 +6,7 @@ using Ombi.Api.External.MediaServers.Plex;
 using Ombi.Api.External.MediaServers.Plex.Models;
 using Ombi.Api.External.MediaServers.Plex.Models.OAuth;
 using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
 using Ombi.Helpers;
 using Ombi.Settings.Settings.Models;
 
@@ -13,15 +14,17 @@ namespace Ombi.Core.Authentication
 {
     public class PlexOAuthManager : IPlexOAuthManager
     {
-        public PlexOAuthManager(IPlexApi api, ISettingsService<CustomizationSettings> settings, ILogger<PlexOAuthManager> logger)
+        public PlexOAuthManager(IPlexApi api, ISettingsService<CustomizationSettings> settings, ISettingsService<PlexSettings> plexSettings, ILogger<PlexOAuthManager> logger)
         {
             _api = api;
             _customizationSettingsService = settings;
+            _plexSettingsService = plexSettings;
             _logger = logger;
         }
 
         private readonly IPlexApi _api;
         private readonly ISettingsService<CustomizationSettings> _customizationSettingsService;
+        private readonly ISettingsService<PlexSettings> _plexSettingsService;
         private readonly ILogger _logger;
 
         public async Task<string> GetAccessTokenFromPin(int pinId)
@@ -41,6 +44,31 @@ namespace Ombi.Core.Authentication
             {
                 _logger.LogError("Pin has expired");
                 return string.Empty;
+            }
+
+            // Sanity log: compare the PIN clientIdentifier with our current InstallId used for X-Plex-Client-Identifier
+            try
+            {
+                var plexSettings = await _plexSettingsService.GetSettingsAsync();
+                var installId = plexSettings?.InstallId.ToString("N");
+                var pinClientId = pin.Result.clientIdentifier;
+
+                if (string.IsNullOrWhiteSpace(installId))
+                {
+                    _logger.LogWarning("Plex OAuth sanity check: InstallId is empty. The UI must call /api/v1/settings/clientid before starting OAuth.");
+                }
+                else if (!string.Equals(installId, pinClientId, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning($"Plex OAuth sanity check: Mismatch between server InstallId '{installId}' and PIN.clientIdentifier '{pinClientId}'. This can cause Plex PIN polling failures (code 1020).");
+                }
+                else
+                {
+                    _logger.LogDebug($"Plex OAuth sanity check: Client identifier matches ({installId}).");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Plex OAuth sanity check logging failed");
             }
 
             return pin.Result.authToken;

--- a/src/Ombi.Core/Authentication/PlexOAuthManager.cs
+++ b/src/Ombi.Core/Authentication/PlexOAuthManager.cs
@@ -63,7 +63,7 @@ namespace Ombi.Core.Authentication
                 }
                 else
                 {
-                    _logger.LogDebug($"Plex OAuth sanity check: Client identifier matches ({installId}).");
+                    _logger.LogDebug("Plex OAuth sanity check: Client identifier matches.");
                 }
             }
             catch (Exception ex)

--- a/src/Ombi.Core/Authentication/PlexOAuthManager.cs
+++ b/src/Ombi.Core/Authentication/PlexOAuthManager.cs
@@ -59,7 +59,7 @@ namespace Ombi.Core.Authentication
                 }
                 else if (!string.Equals(installId, pinClientId, StringComparison.OrdinalIgnoreCase))
                 {
-                    _logger.LogWarning($"Plex OAuth sanity check: Mismatch between server InstallId '{installId}' and PIN.clientIdentifier '{pinClientId}'. This can cause Plex PIN polling failures (code 1020).");
+                    _logger.LogWarning($"Plex OAuth sanity check: Mismatch between server InstallId '{(installId?.Length >= 6 ? installId.Substring(0, 6) : installId)}' and PIN.clientIdentifier '{(pinClientId?.Length >= 6 ? pinClientId.Substring(0, 6) : pinClientId)}'. This can cause Plex PIN polling failures (code 1020).");
                 }
                 else
                 {


### PR DESCRIPTION
…rors and failing watchlist import; add sanity logging

Root cause:
- UI created Plex OAuth PIN using PlexSettings.InstallId A, while server polled PIN using a different InstallId B due to settings caching and duplicate InstallId generation in PlexApi.
- Plex treats mismatched client identifiers as a different device, returning NotFound/1020 ("Code not found or expired"). This blocked token refresh and watchlist sync, showing red X for users.

Changes:
- PlexApi: remove InstallId generation and cached settings; always read current PlexSettings and use its InstallId for X-Plex-Client-Identifier and OAuth clientID.
- PlexOAuthManager: inject PlexSettings and add sanity log comparing PIN.clientIdentifier vs server InstallId to flag mismatches.

Impact:
- Ensures UI and server use the same client identifier throughout OAuth, restoring PIN polling and watchlist import.
- Provides actionable logs if configuration drifts.

Tests:
- Added PlexOAuthManagerTests covering GetAccessTokenFromPin with matching and mismatching client identifiers (behavior preserved; logs warn on mismatch).

Potential fix for #5246.