### PR TITLE
Feature/add force recheck watchlist

### DIFF
--- a/src/Ombi.Core.Tests/Services/PlexServiceTests.cs
+++ b/src/Ombi.Core.Tests/Services/PlexServiceTests.cs
@@ -249,6 +249,45 @@ namespace Ombi.Core.Tests.Services
             Assert.That(result.First().SyncStatus, Is.EqualTo(WatchlistSyncStatus.NotEnabled));
         }
 
+        [Test]
+        public async Task ForceRevalidateWatchlistUsers_WithExistingErrors_DeletesAllErrors()
+        {
+            // Arrange
+            var users = CreateUsers(2, UserType.PlexUser);
+            var userErrors = CreateUserErrors(users.Select(u => u.Id).ToList());
+
+            SetupUserManager(users);
+            SetupWatchlistUserErrors(userErrors);
+            _watchlistUserErrorsRepositoryMock
+                .Setup(x => x.DeleteRange(It.IsAny<IEnumerable<PlexWatchlistUserError>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await _subject.ForceRevalidateWatchlistUsers(CancellationToken.None);
+
+            // Assert
+            _watchlistUserErrorsRepositoryMock.Verify(
+                x => x.DeleteRange(It.Is<IEnumerable<PlexWatchlistUserError>>(errors =>
+                    errors.Select(e => e.UserId).OrderBy(id => id).SequenceEqual(userErrors.Select(e => e.UserId).OrderBy(id => id)))),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task ForceRevalidateWatchlistUsers_NoErrors_DoesNotCallDeleteRange()
+        {
+            // Arrange
+            SetupUserManager(CreateUsers(1, UserType.PlexUser));
+            SetupWatchlistUserErrors(new List<PlexWatchlistUserError>());
+
+            // Act
+            await _subject.ForceRevalidateWatchlistUsers(CancellationToken.None);
+
+            // Assert
+            _watchlistUserErrorsRepositoryMock.Verify(
+                x => x.DeleteRange(It.IsAny<IEnumerable<PlexWatchlistUserError>>()),
+                Times.Never);
+        }
+
         private void SetupUserManager(List<OmbiUser> users)
         {
             var userQueryable = users.AsQueryable().BuildMock();

--- a/src/Ombi.Core/Services/IPlexService.cs
+++ b/src/Ombi.Core/Services/IPlexService.cs
@@ -8,5 +8,6 @@ namespace Ombi.Core.Services
     public interface IPlexService
     {
         Task<List<PlexUserWatchlistModel>> GetWatchlistUsers(CancellationToken cancellationToken);
+        Task ForceRevalidateWatchlistUsers(CancellationToken cancellationToken);
     }
 }

--- a/src/Ombi.Core/Services/PlexService.cs
+++ b/src/Ombi.Core/Services/PlexService.cs
@@ -43,6 +43,15 @@ namespace Ombi.Core.Services
             return model;
         }
 
+        public async Task ForceRevalidateWatchlistUsers(CancellationToken cancellationToken)
+        {
+            var existingErrors = await _watchlistUserErrors.GetAll().ToListAsync(cancellationToken);
+            if (existingErrors.Any())
+            {
+                await _watchlistUserErrors.DeleteRange(existingErrors);
+            }
+        }
+
         private static WatchlistSyncStatus GetWatchlistSyncStatus(OmbiUser user, List<PlexWatchlistUserError> userErrors)
         {
             if (string.IsNullOrWhiteSpace(user.MediaServerToken))

--- a/src/Ombi/ClientApp/src/app/services/applications/plex.service.ts
+++ b/src/Ombi/ClientApp/src/app/services/applications/plex.service.ts
@@ -49,4 +49,8 @@ export class PlexService extends ServiceHelpers {
     public getWatchlistUsers(): Observable<IPlexWatchlistUsers[]> {
         return this.http.get<IPlexWatchlistUsers[]>(`${this.url}WatchlistUsers`,  {headers: this.headers});
     }
+
+    public revalidateWatchlistUsers(): Observable<void> {
+        return this.http.post<void>(`${this.url}WatchlistUsers/revalidate`, {}, {headers: this.headers});
+    }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.html
@@ -11,6 +11,7 @@
           If this happens the user needs to re-login to Ombi.
         </span>
       </div>
+      <mat-progress-bar *ngIf="isReloading" mode="indeterminate"></mat-progress-bar>
       <div class="watchlist-legend">
         <span><mat-icon color="primary">check_circle</mat-icon> Successfully syncing the watchlist</span>
         <span><mat-icon color="warn">cancel</mat-icon> Authentication error syncing the watchlist</span>
@@ -34,6 +35,10 @@
       </table>
     </mat-card-content>
     <mat-card-actions align="end">
+      <button mat-flat-button color="primary" (click)="forceRecheck()" [disabled]="isReloading">
+        <mat-icon>cached</mat-icon>
+        Force recheck
+      </button>
       <button mat-stroked-button mat-dialog-close color="accent">Close</button>
     </mat-card-actions>
   </mat-card>

--- a/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.ts
@@ -8,6 +8,7 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatCardModule } from "@angular/material/card";
 import { CommonModule } from "@angular/common";
 import { MatDialogModule } from "@angular/material/dialog";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
 
 @Component({
         standalone: true,
@@ -19,19 +20,44 @@ import { MatDialogModule } from "@angular/material/dialog";
         MatCardModule,
         MatButtonModule,
         MatDialogModule,
-        MatTableModule
+        MatTableModule,
+        MatProgressBarModule
     ]
 })
 export class PlexWatchlistComponent implements OnInit{
 
     public dataSource: MatTableDataSource<IPlexWatchlistUsers> = new MatTableDataSource();
     public displayedColumns: string[] = ['userName','syncStatus'];
+    public isReloading = false;
 
     public WatchlistSyncStatus = WatchlistSyncStatus;
 
     constructor(private plexService: PlexService) { }
 
     public ngOnInit() {
+        this.loadWatchlistUsers();
+    }
+
+    public forceRecheck(): void {
+        if (this.isReloading) {
+            return;
+        }
+
+        this.isReloading = true;
+        this.plexService.revalidateWatchlistUsers().pipe(take(1)).subscribe({
+            next: () => {
+                setTimeout(() => {
+                    this.loadWatchlistUsers();
+                    this.isReloading = false;
+                }, 3000);
+            },
+            error: () => {
+                this.isReloading = false;
+            }
+        });
+    }
+
+    private loadWatchlistUsers(): void {
         this.plexService.getWatchlistUsers().pipe(take(1)).subscribe((x: IPlexWatchlistUsers[]) => {
             this.dataSource = new MatTableDataSource(x);
         });

--- a/src/Ombi/Controllers/V1/External/PlexController.cs
+++ b/src/Ombi/Controllers/V1/External/PlexController.cs
@@ -16,6 +16,7 @@ using Ombi.Core.Settings.Models.External;
 using Ombi.Helpers;
 using Ombi.Models;
 using Ombi.Models.External;
+using Ombi.Schedule.Jobs.Plex;
 
 namespace Ombi.Controllers.V1.External
 {
@@ -308,5 +309,14 @@ namespace Ombi.Controllers.V1.External
         [Admin]
         [HttpGet("WatchlistUsers")]
         public async Task<List<PlexUserWatchlistModel>> GetPlexWatchlistUsers() => await _plexService.GetWatchlistUsers(HttpContext.RequestAborted);
+
+        [Admin]
+        [HttpPost("WatchlistUsers/revalidate")]
+        public async Task<IActionResult> RevalidatePlexWatchlistUsers()
+        {
+            await _plexService.ForceRevalidateWatchlistUsers(HttpContext.RequestAborted);
+            await OmbiQuartz.TriggerJob(nameof(IPlexWatchlistImport), "Plex");
+            return Accepted();
+        }
     }
 }


### PR DESCRIPTION
## 📝 Description

Added an admin “Force recheck” action that clears Plex watchlist errors, triggers an immediate import, and tests the new service logic.

## 🔗 Related Issues

https://github.com/Ombi-app/Ombi/issues/5246#issuecomment-3369331226

## 🧪 Testing



- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] No breaking changes

## 📸 Screenshots (if applicable)

<img width="1515" height="1437" alt="image" src="https://github.com/user-attachments/assets/3a79e512-de50-4f44-937a-36b8761a9a1a" />

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🎯 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

This change was AI assisted but reviewed and validated by me.
