### PR TITLE
Search by decade

### DIFF
--- a/src/Ombi.Api.External/ExternalApis/TheMovieDb/Models/DiscoverModel.cs
+++ b/src/Ombi.Api.External/ExternalApis/TheMovieDb/Models/DiscoverModel.cs
@@ -10,6 +10,7 @@ namespace Ombi.Api.External.ExternalApis.TheMovieDb.Models
     {
         public string Type { get; set; }
         public int? ReleaseYear { get; set; }
+        public int? Decade { get; set; }
         public List<int> GenreIds { get; set; } = new List<int>();
         public List<int> KeywordIds { get; set; } = new List<int>();
         public List<int> WatchProviders { get; set; } = new List<int>();

--- a/src/Ombi.Api.External/ExternalApis/TheMovieDb/TheMovieDbApi.cs
+++ b/src/Ombi.Api.External/ExternalApis/TheMovieDb/TheMovieDbApi.cs
@@ -74,7 +74,24 @@ namespace Ombi.Api.External.ExternalApis.TheMovieDb
         {
             var request = new Request($"discover/{model.Type}", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
-            if (model.ReleaseYear.HasValue && model.ReleaseYear.Value > 1900)
+            if (model.Decade.HasValue)
+            {
+                var decade = model.Decade.Value;
+                var startDate = new DateTime(decade, 1, 1).ToString("yyyy-MM-dd");
+                var endDate = new DateTime(decade + 9, 12, 31).ToString("yyyy-MM-dd");
+
+                if (model.Type == "movie")
+                {
+                    request.FullUri = request.FullUri.AddQueryParameter("primary_release_date.gte", startDate);
+                    request.FullUri = request.FullUri.AddQueryParameter("primary_release_date.lte", endDate);
+                }
+                else if (model.Type == "tv")
+                {
+                    request.FullUri = request.FullUri.AddQueryParameter("first_air_date.gte", startDate);
+                    request.FullUri = request.FullUri.AddQueryParameter("first_air_date.lte", endDate);
+                }
+            }
+            else if (model.ReleaseYear.HasValue && model.ReleaseYear.Value > 1900)
             {
                 request.FullUri = request.FullUri.AddQueryParameter("year", model.ReleaseYear.Value.ToString());
             }

--- a/src/Ombi/ClientApp/src/app/interfaces/IMovieDb.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/IMovieDb.ts
@@ -12,6 +12,7 @@ export interface IWatchProvidersResults {
 export interface IDiscoverModel {
     type: string;
     releaseYear?: number|undefined;
+    decade?: number|undefined;
     genreIds?: number[];
     keywordIds?: number[];
     watchProviders?: number[];

--- a/src/Ombi/ClientApp/src/app/shared/advanced-search-dialog/advanced-search-dialog.component.html
+++ b/src/Ombi/ClientApp/src/app/shared/advanced-search-dialog/advanced-search-dialog.component.html
@@ -30,6 +30,15 @@
         <mat-label>{{ "Search.YearOfRelease" | translate }}</mat-label>
         <input matInput id="releaseYear" name="releaseYear" formControlName="releaseYear">
     </mat-form-field>
+    <mat-form-field appearance="outline" floatLabel=auto style="padding-left: 15px">
+      <mat-label>Decade</mat-label>
+      <mat-select formControlName="decade">
+        <mat-option [value]="null">None</mat-option>
+        <mat-option *ngFor="let d of decades" [value]="d">
+          {{d}}s
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
   </div>
 
 

--- a/src/Ombi/ClientApp/src/app/shared/advanced-search-dialog/advanced-search-dialog.component.ts
+++ b/src/Ombi/ClientApp/src/app/shared/advanced-search-dialog/advanced-search-dialog.component.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
 import { MatRadioModule } from "@angular/material/radio";
 import { TranslateModule } from "@ngx-translate/core";
 import { RequestType } from "../../interfaces";
@@ -26,6 +27,7 @@ import { WatchProvidersSelectComponent } from "../components/watch-providers-sel
         MatDialogModule,
         MatFormFieldModule,
         MatInputModule,
+        MatSelectModule,
         MatRadioModule,
         TranslateModule,
         GenreSelectComponent,
@@ -42,13 +44,20 @@ export class AdvancedSearchDialogComponent implements OnInit {
   ) {}
 
   public form: UntypedFormGroup;
+  public decades: number[] = [];
 
   public async ngOnInit() {
+    const currentYear = new Date().getFullYear();
+    const startDecade = Math.floor(currentYear / 10) * 10;
+    for (let i = startDecade; i >= 1900; i -= 10) {
+        this.decades.push(i);
+    }
 
     this.form = this.fb.group({
         keywordIds: [[]],
         genreIds: [[]],
         releaseYear: [],
+        decade: [],
         type: ['movie'],
         watchProviders: [[]],
     })
@@ -69,6 +78,7 @@ export class AdvancedSearchDialogComponent implements OnInit {
       genreIds: genres,
       keywordIds: keywords,
       releaseYear: formData.releaseYear,
+      decade: formData.decade,
       type: formData.type,
     }, 0, 30);
 


### PR DESCRIPTION
## 📝 Description

Additional "Discover" filter to search by decades

## 🔗 Related Issues

N/A

## 🧪 Testing

Ran Ombi locally with these changes, and I was able to search using the decade Discover filter.  

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] No breaking changes

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🎯 Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

AI reviewed, coded and tested by me.