### PR TITLE
Fix: Use season search when Sonarr has more episodes than requested

### DIFF
--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -545,10 +545,11 @@ namespace Ombi.Core.Senders
                 var sonarrEpCount = sonarrSeason.Count();
                 var ourRequestCount = season.Episodes.Count;
 
-                if (sonarrEpCount == ourRequestCount)
+                // We have the same amount of requests as all of the episodes in the season,
+                // or Sonarr has more episodes than Ombi (incomplete metadata).
+                // Do a season search in both cases.
+                if (sonarrEpCount >= ourRequestCount)
                 {
-                    // We have the same amount of requests as all of the episodes in the season.
-                    // Do a season search
                     await SonarrApi.SeasonSearch(existingSeries.id, season.SeasonNumber, s.ApiKey, s.FullUri);
                 }
                 else

--- a/src/Ombi.Helpers/EmbyHelper.cs
+++ b/src/Ombi.Helpers/EmbyHelper.cs
@@ -9,11 +9,9 @@ namespace Ombi.Helpers
             // app.emby.media only supports #!/item format, not #!/details or #!/itemdetails
             string path = "item";
             
-            // Check if targeting app.emby.media and use correct format
-            if (string.IsNullOrEmpty(customerServerUrl) || customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase))
-            {
-                path = "item";  // app.emby.media uses #!/item
-            }
+            // Check if targeting app.emby.media specifically
+            bool isAppEmbyMedia = !string.IsNullOrEmpty(customerServerUrl) &&
+                                  customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase);
             
             if (customerServerUrl.HasValue())
             {

--- a/src/Ombi.Helpers/EmbyHelper.cs
+++ b/src/Ombi.Helpers/EmbyHelper.cs
@@ -8,11 +8,13 @@ namespace Ombi.Helpers
         {
             // app.emby.media only supports #!/item format, not #!/details or #!/itemdetails
             string path = "item";
-
-            // Check if targeting app.emby.media specifically
-            bool isAppEmbyMedia = !string.IsNullOrEmpty(customerServerUrl) &&
-                                  customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase);
-
+            
+            // Check if targeting app.emby.media and use correct format
+            if (string.IsNullOrEmpty(customerServerUrl) || customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase))
+            {
+                path = "item";  // app.emby.media uses #!/item
+            }
+            
             if (customerServerUrl.HasValue())
             {
                 // app.emby.media doesn't use /web/index.html in URLs

--- a/src/Ombi.Helpers/EmbyHelper.cs
+++ b/src/Ombi.Helpers/EmbyHelper.cs
@@ -8,11 +8,11 @@ namespace Ombi.Helpers
         {
             // app.emby.media only supports #!/item format, not #!/details or #!/itemdetails
             string path = "item";
-            
+
             // Check if targeting app.emby.media specifically
             bool isAppEmbyMedia = !string.IsNullOrEmpty(customerServerUrl) &&
                                   customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase);
-            
+
             if (customerServerUrl.HasValue())
             {
                 // app.emby.media doesn't use /web/index.html in URLs


### PR DESCRIPTION
Resolves #5319

**Summary:**
Previously, Ombi would fall back to individual episode searches when Sonarr had more episodes than Ombi requested. This caused issues with older TV shows where backends don't support individual episode searches, resulting in silent failures.

**Changes:**
- Modified `SearchForRequest` to use season search when `sonarrEpCount >= ourRequestCount`
- This handles the common case where user requests full season and Sonarr has more metadata
- Individual episode search only used for edge case where Sonarr has fewer episodes

**Impact:**
Fixes silent failures on old shows with incomplete Ombi metadata while respecting partial episode requests.