### PR TITLE
fix: SonarrSync now deletes episodes per-series to prevent incomplete cache (#5306)

### DIFF
--- a/src/Ombi.Schedule/Jobs/Sonarr/SonarrSync.cs
+++ b/src/Ombi.Schedule/Jobs/Sonarr/SonarrSync.cs
@@ -92,13 +92,6 @@ namespace Ombi.Schedule.Jobs.Sonarr
                     await _ctx.SonarrCache.AddRangeAsync(sonarrCacheToSave);
                     await _ctx.SaveChangesAsync();
                     sonarrCacheToSave.Clear();
-                    strat = _ctx.Database.CreateExecutionStrategy();
-                    await strat.ExecuteAsync(async () =>
-                    {
-                        using var tran = await _ctx.Database.BeginTransactionAsync();
-                        await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM SonarrEpisodeCache");
-                        await tran.CommitAsync();
-                    });
 
                     foreach (var s in ids)
                     {
@@ -110,6 +103,15 @@ namespace Ombi.Schedule.Jobs.Sonarr
                         _log.LogDebug($"Syncing series: {s.Title}");
                         var episodes = await _api.GetEpisodes(s.Id, settings.ApiKey, settings.FullUri);
                         var monitoredEpisodes = episodes.Where(x => x.monitored || x.hasFile);
+
+                        // Delete existing episodes for this series before adding new ones
+                        strat = _ctx.Database.CreateExecutionStrategy();
+                        await strat.ExecuteAsync(async () =>
+                        {
+                            using var tran = await _ctx.Database.BeginTransactionAsync();
+                            await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM SonarrEpisodeCache WHERE TvDbId = {0}", s.TvDbId);
+                            await tran.CommitAsync();
+                        });
 
                         //var allExistingEpisodes = await _ctx.SonarrEpisodeCache.Where(x => x.TvDbId == s.tvdbId).ToListAsync();
                         // Add to DB


### PR DESCRIPTION
Fixes #5306 - Sonarr items are not showing as available

Root Cause:
SonarrSync was deleting ALL episodes from SonarrEpisodeCache at the start of the job, then re-adding them one series at a time. If the job failed partway through (API timeout, network issue, etc.), the cache would be left incomplete with only some series' episodes.

This caused shows to be incorrectly marked as unavailable even though they were fully available in Sonarr.

Changes:
- Moved DELETE FROM SonarrEpisodeCache inside the series loop
- Now deletes episodes per series (by TvDbId) before adding new ones
- If job fails mid-way, cache for already-processed series remains intact

Impact:
This ensures that partial failures don't result in a completely empty or incomplete cache. Users who request a show that's already in Sonarr but was processed before the failure will correctly see it as available.