### PR TITLE
fix: Correct EmbyHelper app.emby.media path detection

### DIFF
--- a/src/Ombi.Helpers.Tests/EmbyHelperTests.cs
+++ b/src/Ombi.Helpers.Tests/EmbyHelperTests.cs
@@ -24,6 +24,7 @@ namespace Ombi.Helpers.Tests
                 yield return new TestCaseData(mediaId.ToString(), "http://google.com/", "1").Returns($"http://google.com/web/index.html#!/item?id={mediaId}&serverId=1").SetName("EmbyHelper_GetMediaUrl_WithCustomDomain");
                 yield return new TestCaseData(mediaId.ToString(), "https://google.com/", "1").Returns($"https://google.com/web/index.html#!/item?id={mediaId}&serverId=1").SetName("EmbyHelper_GetMediaUrl_WithCustomDomain_Https");
                 yield return new TestCaseData(mediaId.ToString(), string.Empty, "1").Returns($"https://app.emby.media/web/index.html#!/item?id={mediaId}&serverId=1").SetName("EmbyHelper_GetMediaUrl_WithOutCustomDomain");
+                yield return new TestCaseData(mediaId.ToString(), "https://app.emby.media/", "1").Returns($"https://app.emby.media/#!/item?id={mediaId}&serverId=1").SetName("EmbyHelper_GetMediaUrl_AppEmbyMedia_UsesCorrectHashFormat");
             }
         }
     }

--- a/src/Ombi.Helpers/EmbyHelper.cs
+++ b/src/Ombi.Helpers/EmbyHelper.cs
@@ -6,24 +6,34 @@
         {
             // app.emby.media only supports #!/item format, not #!/details or #!/itemdetails
             string path = "item";
-            
-            // Check if targeting app.emby.media and use correct format
-            if (!string.IsNullOrEmpty(customerServerUrl) && customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase))
-            {
-                path = "item";  // app.emby.media uses #!/item
-            }
-            
+
+            // Check if targeting app.emby.media
+            bool isAppEmbyMedia = !string.IsNullOrEmpty(customerServerUrl) &&
+                                  customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase);
+
             if (customerServerUrl.HasValue())
             {
+                // app.emby.media doesn't use /web/index.html in URLs
+                if (isAppEmbyMedia)
+                {
+                    if (!customerServerUrl.EndsWith("/"))
+                    {
+                        return $"{customerServerUrl}/#!/{path}?id={mediaId}&serverId={serverId}";
+                    }
+                    return $"{customerServerUrl}#!/{path}?id={mediaId}&serverId={serverId}";
+                }
+
+                // Custom Emby servers use /web/index.html
                 if (!customerServerUrl.EndsWith("/"))
                 {
                     return $"{customerServerUrl}/web/index.html#!/{path}?id={mediaId}&serverId={serverId}";
                 }
-                    return $"{customerServerUrl}web/index.html#!/{path}?id={mediaId}&serverId={serverId}";
+                return $"{customerServerUrl}web/index.html#!/{path}?id={mediaId}&serverId={serverId}";
             }
             else
             {
-                return $"https://app.emby.media/web/index.html#!/{path}?id={mediaId}&serverId={serverId}";
+                // Default to app.emby.media without /web/index.html
+                return $"https://app.emby.media/#!/{path}?id={mediaId}&serverId={serverId}";
             }
         }
     }

--- a/src/Ombi.Helpers/EmbyHelper.cs
+++ b/src/Ombi.Helpers/EmbyHelper.cs
@@ -4,8 +4,15 @@
     {
         public static string GetEmbyMediaUrl(string mediaId, string serverId, string customerServerUrl = null)
         {
-            //web/index.html#!/details|item
+            // app.emby.media only supports #!/item format, not #!/details or #!/itemdetails
             string path = "item";
+            
+            // Check if targeting app.emby.media and use correct format
+            if (!string.IsNullOrEmpty(customerServerUrl) && customerServerUrl.Contains("app.emby.media", StringComparison.OrdinalIgnoreCase))
+            {
+                path = "item";  // app.emby.media uses #!/item
+            }
+            
             if (customerServerUrl.HasValue())
             {
                 if (!customerServerUrl.EndsWith("/"))


### PR DESCRIPTION
Fixes failing test in PR #689

The test expected app.emby.media URLs to NOT include /web/index.html,
but the helper was always adding it for all URLs.

Changes:
- app.emby.media URLs now omit /web/index.html (e.g., https://app.emby.media/#!/item?id=1)
- Custom Emby server URLs still include /web/index.html (e.g., http://google.com/web/index.html#!/item?id=1)
- Default URL (no custom server) now also uses app.emby.media format without /web/index.html