### PR TITLE
Fix issue #5259: Correctly handle 4K vs non-4K duplicate requests

### DIFF
--- a/src/Ombi.Core/Rule/Rules/Request/ExistingMovieRequestRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Request/ExistingMovieRequestRule.cs
@@ -62,13 +62,26 @@ namespace Ombi.Core.Rule.Rules.Request
         private async Task<bool> Check4KRequests(MovieRequests movie, MovieRequests existing)
         {
             var featureEnabled = await _featureService.FeatureEnabled(FeatureNames.Movie4KRequests);
-            if (movie.Is4kRequest && existing.Has4KRequest && featureEnabled)
+            
+            // If requesting 4K and 4K feature is enabled, check if 4K request already exists
+            if (movie.Is4kRequest && featureEnabled)
             {
-               return true;
+               return existing.Has4KRequest;
             }
-            if (!movie.Is4kRequest && !existing.Has4KRequest || !featureEnabled)
+            
+            // If requesting non-4K
+            if (!movie.Is4kRequest)
             {
-                return true;
+                // If 4K feature is disabled, any existing request (4K or non-4K) is a duplicate
+                if (!featureEnabled)
+                {
+                    return existing.RequestedDate.HasValue() || existing.Has4KRequest;
+                }
+                // If 4K feature is enabled, only reject if non-4K request exists
+                else
+                {
+                    return existing.RequestedDate.HasValue();
+                }
             }
 
             return false;


### PR DESCRIPTION
When 4K requests feature is enabled, users should be able to request both a standard (non-4K) and 4K version of the same movie, as they go to different Radarr instances.

**Root Cause:**
Bug in `ExistingMovieRequestRule.Check4KRequests` method had incorrect operator precedence and logic for determining when to reject non-4K requests.

The old logic:
```csharp
if (!movie.Is4kRequest && !existing.Has4KRequest || !featureEnabled)
{
    return true;
}
```

Due to C# operator precedence, this evaluated as:
```csharp
if ((!movie.Is4kRequest && !existing.Has4KRequest) || !featureEnabled)
```

This caused non-4K requests to be incorrectly rejected when a movie already had a non-4K request AND 4K feature was enabled.

**Fix:**
Properly checks for existing non-4K requests using `RequestedDate.HasValue()` and correctly respects the 4K feature flag:

- When 4K feature enabled: Allow both 4K and non-4K requests for same movie
- When 4K feature disabled: Treat them as the same request (allow duplicates between 4K instances)

Fixes #5259