### PR TITLE
Fix issue #5311: Allow re-adding items to Plex watchlist

### DIFF
--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -182,6 +182,9 @@ namespace Ombi.Schedule.Jobs.Plex
 
                     var items = watchlist.MediaContainer.Metadata;
                     _logger.LogDebug($"Items found in watchlist: {watchlist.MediaContainer.totalSize}");
+                    
+                    // First pass: Build a HashSet of all current Plex watchlist items
+                    var currentWatchlistTmdbIds = new HashSet<string>();
                     foreach (var item in items)
                     {
                         _logger.LogDebug($"Processing {item.title} {item.type}");
@@ -198,10 +201,34 @@ namespace Ombi.Schedule.Jobs.Plex
                             }
 
                             providerIds.TheMovieDb = movieDbId;
+                            currentWatchlistTmdbIds.Add(movieDbId);
                         }
-
-                        // Check to see if we have already imported this item
-                        var alreadyImported = _watchlistRepo.GetAll().Any(x => x.TmdbId == providerIds.TheMovieDb && x.UserId == user.Id);
+                    }
+                    
+                    // Second pass: Remove old watchlist history entries that are no longer in current Plex watchlist
+                    var historyEntries = await _watchlistRepo.GetAll().Where(x => x.UserId == user.Id).ToListAsync();
+                    foreach (var historyEntry in historyEntries)
+                    {
+                        // If this item is not in the current Plex watchlist, remove from history
+                        if (!currentWatchlistTmdbIds.Contains(historyEntry.TmdbId))
+                        {
+                            _logger.LogDebug($"Removing old history entry for TMDB ID {historyEntry.TmdbId} (no longer in Plex watchlist)");
+                            await _watchlistRepo.Delete(historyEntry);
+                        }
+                    }
+                    
+                    // Third pass: Process items, skipping if already imported and still in current watchlist
+                    foreach (var item in items)
+                    {
+                        // Get provider IDs again (we cached them in first pass, but need fresh for this iteration)
+                        var providerIds = await GetProviderIds(user.MediaServerToken, item, context?.CancellationToken ?? CancellationToken.None);
+                        if (!providerIds.TheMovieDb.HasValue())
+                        {
+                            continue;  // Skip items we couldn't get TMDB ID for
+                        }
+                        
+                        // Check to see if we have already imported this item (and it's still in watchlist)
+                        var alreadyImported = await _watchlistRepo.GetAll().AnyAsync(x => x.TmdbId == providerIds.TheMovieDb && x.UserId == user.Id);
                         if (alreadyImported)
                         {
                             _logger.LogDebug($"{item.title} already imported via Plex WatchList, skipping");


### PR DESCRIPTION
When a user removes an item from their Plex watchlist and then re-adds it, the sync job should import it into Ombi's request queue. However, current code checks for previously imported items in PlexWatchlistHistory, which prevents re-importing even when the item is currently in Plex watchlist.

**Root Cause:**
The existing code checked if an item was EVER imported:
```csharp
var alreadyImported = _watchlistRepo.GetAll().Any(x => x.TmdbId == ...);
```

This meant that once an item was imported into Ombi, it could never be re-imported even if the user had deleted it from Plex and re-added it to their watchlist.

**Fix:**
Three-pass approach to properly handle watchlist synchronization:

1. **First pass:** Build a HashSet of all TMDB IDs currently in the user's Plex watchlist
2. **Second pass:** Remove old PlexWatchlistHistory entries for items no longer in the watchlist
3. **Third pass:** Process items, only skipping if a history entry exists for the CURRENT items

This ensures that items currently in the watchlist will be imported (if not already requested), while items that were deleted and re-added can be imported correctly.

**Example Flow:**
- User adds "Movie A" to Plex watchlist → Sync job imports to Ombi ✓
- User deletes "Movie A" from Plex watchlist
- User re-adds "Movie A" to Plex watchlist
- Before fix: Skipped because history exists for "Movie A" ❌
- After fix: Old history cleared, item re-imported ✓

Fixes #5311