### PR TITLE
Fix issue #5215: Validate user root paths exist in Sonarr

### DIFF
--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -163,8 +163,18 @@ namespace Ombi.Core.Senders
                 {
                     if (profiles.SonarrRootPathAnime > 0)
                     {
-                        Logger.LogInformation("Using user's anime root path override: {RootPath}", profiles.SonarrRootPathAnime);
-                        rootFolderPath = await GetSonarrRootPath(profiles.SonarrRootPathAnime, s);
+                        Logger.LogInformation("Checking user's anime root path override: {RootPath}", profiles.SonarrRootPathAnime);
+                        var userAnimeRootPath = await GetSonarrRootPath(profiles.SonarrRootPathAnime, s);
+                        // Only use the user's root path if it's valid (exists in Sonarr)
+                        if (!string.IsNullOrEmpty(userAnimeRootPath))
+                        {
+                            Logger.LogInformation("Using user's anime root path override: {RootPath}", profiles.SonarrRootPathAnime);
+                            rootFolderPath = userAnimeRootPath;
+                        }
+                        else
+                        {
+                            Logger.LogWarning("User's anime root path ID {RootPath} no longer exists in Sonarr, falling back to global default", profiles.SonarrRootPathAnime);
+                        }
                     }
                     if (profiles.SonarrQualityProfileAnime > 0)
                     {
@@ -185,8 +195,18 @@ namespace Ombi.Core.Senders
                 {
                     if (profiles.SonarrRootPath > 0)
                     {
-                        Logger.LogInformation("Using user's standard root path override: {RootPath}", profiles.SonarrRootPath);
-                        rootFolderPath = await GetSonarrRootPath(profiles.SonarrRootPath, s);
+                        Logger.LogInformation("Checking user's standard root path override: {RootPath}", profiles.SonarrRootPath);
+                        var userRootPath = await GetSonarrRootPath(profiles.SonarrRootPath, s);
+                        // Only use the user's root path if it's valid (exists in Sonarr)
+                        if (!string.IsNullOrEmpty(userRootPath))
+                        {
+                            Logger.LogInformation("Using user's standard root path override: {RootPath}", profiles.SonarrRootPath);
+                            rootFolderPath = userRootPath;
+                        }
+                        else
+                        {
+                            Logger.LogWarning("User's standard root path ID {RootPath} no longer exists in Sonarr, falling back to global default", profiles.SonarrRootPath);
+                        }
                     }
                     if (profiles.SonarrQualityProfile > 0)
                     {


### PR DESCRIPTION
When users have a root path override set in their profile that no longer exists in Sonarr, requests would fail with 'Root Folder Path must not be empty' error.

This fix adds validation to check if user's configured root path ID still exists in Sonarr before using it. If path doesn't exist, a warning is logged and global default path is used instead.

**Changes:**
- Added validation for user's standard Sonarr root path override
- Added validation for user's anime Sonarr root path override  
- Added detailed logging for fallback scenarios

**Root Cause:**
When a user's profile has a root path ID configured, and that root path is subsequently deleted from Sonarr, TvSender would pass an empty string to Sonarr's API, causing a BadRequest error. The user's database record still contained old ID but Sonarr no longer recognized it.

**Fix:**
Before using a user's root path override, we now query Sonarr's API to verify path ID is valid. If not found, we fall back to global default and log a warning.

Fixes #5215