### PR TITLE
feat: add Docker image publishing to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
         with:
           context: ./src
           file: ./src/dockerfile
-          push: true
+          push: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,51 @@ jobs:
             artifacts/**/*.tar.gz
             artifacts/**/*.zip
 
+  docker:
+    needs: [ unit-test, versioning ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=${{ needs.versioning.outputs.version }},enable=${{ needs.versioning.outputs.version != '' }}
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          file: ./src/dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   update-apt:
     needs: [ release, versioning ]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Docker Meta
         id: meta

--- a/src/dockerfile
+++ b/src/dockerfile
@@ -1,4 +1,12 @@
-# build stage
+# Stage 1: Build Angular frontend
+FROM node:20-bookworm-slim AS ui-build
+WORKDIR /source
+COPY Ombi/ClientApp/package.json Ombi/ClientApp/yarn.lock Ombi/ClientApp/
+RUN yarn --cwd Ombi/ClientApp install --frozen-lockfile
+COPY Ombi/ClientApp Ombi/ClientApp
+RUN yarn --cwd Ombi/ClientApp run build
+
+# Stage 2: Build and publish .NET backend
 FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
 ARG VERSION=1.0.0
 WORKDIR /source
@@ -50,26 +58,16 @@ COPY ["Ombi.TheMovieDbApi/Ombi.Api.TheMovieDb.csproj", "Ombi.TheMovieDbApi/"]
 COPY ["Ombi.Api.Twilio/Ombi.Api.Twilio.csproj", "Ombi.Api.Twilio/"]
 COPY ["Ombi.Updater/Ombi.Updater.csproj", "Ombi.Updater/"]
 RUN dotnet restore Ombi/Ombi.csproj
+
 COPY . .
+RUN dotnet publish Ombi/Ombi.csproj -c Release --no-restore -o /app/publish
 
-# copy and build app
-WORKDIR /source/Ombi
-COPY ["Ombi/", "."]
-RUN dotnet build "Ombi.csproj" -c release
-
-
-FROM build AS publish
-
-RUN dotnet publish "Ombi.csproj" -c release --no-restore --no-build -o /app/publish
-
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy as base
-WORKDIR /src/Ombi
+# Stage 3: Final runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy
+WORKDIR /opt/ombi
 EXPOSE 5000
 
-FROM base AS final
-WORKDIR /src/Ombi
-COPY --from=publish /app/publish .
-COPY ["Ombi/ClientApp/dist", "/src/Ombi/ClientApp/dist/"]
+COPY --from=build /app/publish .
+COPY --from=ui-build /source/Ombi/ClientApp/dist ./ClientApp/dist/
+
 ENTRYPOINT ["dotnet", "Ombi.dll"]
-
-


### PR DESCRIPTION
## Summary

- **Rewrites the Dockerfile** to be fully self-contained with a multi-stage build: Node 20 stage for Angular UI, .NET SDK stage for backend publish, and slim ASP.NET runtime stage for the final image
- **Adds a `docker` job** to the CI build workflow that builds multi-arch images (linux/amd64, linux/arm64, linux/arm/v7) and publishes to GitHub Container Registry (`ghcr.io`)
- **Tags images** with the semantic version on every build, plus `latest` for master and `develop` for develop — matching the existing binary release pattern

### What changed

**`src/dockerfile`** — The old Dockerfile had a broken `COPY` on line 72 that tried to pull Angular dist from the build context (which wouldn't exist in CI). The new Dockerfile builds everything inside Docker:
1. **Stage 1 (ui-build)**: `node:20-bookworm-slim` — installs deps with yarn and builds Angular
2. **Stage 2 (build)**: `dotnet/sdk:8.0-jammy` — restores NuGet, publishes .NET app
3. **Stage 3 (final)**: `dotnet/aspnet:8.0-jammy` — copies published app + Angular dist, runs on port 5000

**`.github/workflows/build.yml`** — New `docker` job runs after `unit-test` and `versioning`, using:
- `docker/metadata-action` for tag generation
- `docker/setup-qemu-action` + `docker/setup-buildx-action` for multi-arch builds
- `docker/build-push-action` with GHA cache for efficient layer caching
- `GITHUB_TOKEN` for GHCR auth (no additional secrets needed)

### Image usage

```bash
# Stable release (from master)
docker pull ghcr.io/ombi-app/ombi:latest
docker pull ghcr.io/ombi-app/ombi:4.55.7

# Pre-release (from develop)
docker pull ghcr.io/ombi-app/ombi:develop

# Run
docker run -d -p 5000:5000 ghcr.io/ombi-app/ombi:latest
```

## Test plan

- [ ] Verify the Dockerfile builds locally with `docker build -f src/dockerfile src/`
- [ ] Verify multi-arch build works via `docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7`
- [ ] Confirm CI workflow runs the `docker` job on push to develop/master
- [ ] Confirm images appear in the GitHub Packages tab after a successful workflow run
- [ ] Verify the published container starts correctly and serves the Ombi UI on port 5000

https://claude.ai/code/session_01KDhvnvXoLLSq4krH3n2SVe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker images published for multiple CPU architectures (amd64, arm64, arm/v7).
  * Automated image tagging for latest, versioned and development releases.

* **Chores**
  * Streamlined multi-stage container build separating frontend asset build from backend to produce smaller, more efficient images.
  * Simplified backend publish process and adjusted runtime layout and working directory for improved container efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->