### PR TITLE
fix: remove unsupported linux/arm/v7 from Docker build platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
           context: ./src
           file: ./src/dockerfile
           push: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary\n- Remove `linux/arm/v7` from the Docker build-push-action platforms list\n- The .NET 8 jammy base images (`mcr.microsoft.com/dotnet/sdk:8.0-jammy` and `mcr.microsoft.com/dotnet/aspnet:8.0-jammy`) only support `linux/amd64` and `linux/arm64`\n- This was causing the Docker build job to fail immediately (4s) when buildx couldn't resolve the base images for the arm/v7 platform\n\n## Test plan\n- [ ] Verify the `docker` job in CI passes after merge\n- [ ] Confirm images are pushed to GHCR for amd64 and arm64 architectures\n\nhttps://claude.ai/code/session_01KDhvnvXoLLSq4krH3n2SVe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker build configuration updated. Support for ARMv7 architecture has been removed from multi-platform Docker image builds. The application now builds Docker images for AMD64 and ARM64 architectures only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->