### PR TITLE
fix: point the notification template logo to the site logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  
-![](https://ombi.io/img/logo-orange-small.png)   
+![Ombi logo](https://ombi.io/img/logo-orange-small.png)   
 ____ 
 [![Discord](https://img.shields.io/discord/270828201473736705.svg)](https://discord.gg/Sa7wNWb)
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/ombi.svg)](https://hub.docker.com/r/linuxserver/ombi/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  
-![](http://i.imgur.com/qQsN78U.png)   
+![](https://ombi.io/img/logo-orange-small.png)   
 ____ 
 [![Discord](https://img.shields.io/discord/270828201473736705.svg)](https://discord.gg/Sa7wNWb)
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/ombi.svg)](https://hub.docker.com/r/linuxserver/ombi/)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ____
 [![Discord](https://img.shields.io/discord/270828201473736705.svg)](https://discord.gg/Sa7wNWb)
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/ombi.svg)](https://hub.docker.com/r/linuxserver/ombi/)
 [![Github All Releases](https://img.shields.io/github/downloads/tidusjar/Ombi/total.svg)](https://github.com/ombi-app/Ombi)
-[![firsttimersonly](http://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
+[![firsttimersonly](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/ombi/localized.svg)](https://crowdin.com/project/ombi)
 [![Automation Tests](https://github.com/Ombi-app/Ombi/actions/workflows/automation-tests.yml/badge.svg)](https://github.com/Ombi-app/Ombi/actions/workflows/automation-tests.yml)
 

--- a/src/Ombi.Notifications.Templates/TemplateBase.cs
+++ b/src/Ombi.Notifications.Templates/TemplateBase.cs
@@ -3,6 +3,6 @@
     public abstract class TemplateBase
     {
         public abstract string TemplateLocation { get; }
-        public virtual string OmbiLogo => "http://i.imgur.com/7pqVq7W.png";
+        public virtual string OmbiLogo => "https://ombi.io/img/logo-orange-small.png";
     }
 }


### PR DESCRIPTION
## 📝 Description

The URLs used for Ombi logos (specifically in notification templates and `README.md`) have been changed from the Imgur-hosted images to those hosted on the Ombi website. A fix for the first timers-only badge URL scheme in `README.md` is also included.

## 🔗 Related Issues

Fixes #5290 

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [x] No breaking changes

## 📸 Screenshots (if applicable)

n/a

## 📋 Checklist

- [x] My code follows the project's coding standards
- [ ] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

There's another Imgur-hosted image in `README.md` that I can't update, it's [the 'preview' image](https://i.imgur.com/kBXIqer.png) which illustrates a screenshot of Ombi. The project team may wish to change that URL to another hosted image as it won't be visible in the UK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced header logo with a secure HTTPS Ombi-hosted logo and updated its alt text.
  * Migrated a "firsttimersonly" badge image URL from HTTP to HTTPS while preserving its destination link.
  * Updated internal notification template to reference the new HTTPS Ombi logo URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->