### PR TITLE
Fix TV availability filter, discovery scroll, and remove stale news section

### DIFF
--- a/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
@@ -245,7 +245,7 @@ namespace Ombi.Core.Engine.V2
                 }
 
                 var result = await ProcessResult(tvMazeSearch);
-                if (result == null || settings.HideAvailableFromDiscover && result.FullyAvailable)
+                if (result == null || settings.HideAvailableFromDiscover && result.Available)
                 {
                     continue;
                 }

--- a/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
@@ -36,9 +36,9 @@ namespace Ombi.Core.Rule.Rules.Search
                     x.Episodes.Any(c => !c.Available && c.AirDate <= DateTime.Now.Date && c.AirDate != DateTime.MinValue));
                 if (!airedButNotAvailable)
                 {
-                    var unairedEpisodes = search.SeasonRequests.Any(x =>
+                    var hasUnairedEpisodes = search.SeasonRequests.Any(x =>
                         x.Episodes.Any(c => !c.Available && c.AirDate > DateTime.Now.Date && c.AirDate != DateTime.MinValue));
-                    if (unairedEpisodes)
+                    if (hasUnairedEpisodes || search.PartlyAvailable)
                     {
                         search.FullyAvailable = true;
                     }

--- a/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
@@ -37,7 +37,7 @@ namespace Ombi.Core.Rule.Rules.Search
                 if (!airedButNotAvailable)
                 {
                     var unairedEpisodes = search.SeasonRequests.Any(x =>
-                        x.Episodes.Any(c => !c.Available && c.AirDate > DateTime.Now.Date || c.AirDate != DateTime.MinValue));
+                        x.Episodes.Any(c => !c.Available && c.AirDate > DateTime.Now.Date && c.AirDate != DateTime.MinValue));
                     if (unairedEpisodes)
                     {
                         search.FullyAvailable = true;

--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.ts
@@ -272,7 +272,7 @@ export class DiscoverCardComponent implements OnInit {
         this.result.url = updated.imdbId;
         this.result.overview = updated.overview;
         this.result.approved = updated.approved;
-        this.result.available = updated.fullyAvailable;
+        this.result.available = updated.fullyAvailable || updated.partlyAvailable;
         this.result.denied = updated.denied;
 
         this.fullyLoaded = true;

--- a/src/Ombi/ClientApp/src/app/discover/components/carousel-list/carousel-list.component.ts
+++ b/src/Ombi/ClientApp/src/app/discover/components/carousel-list/carousel-list.component.ts
@@ -74,7 +74,7 @@ export class CarouselListComponent {
         return "DiscoverOptions" + this.discoverType().toString();
     };
     
-    private amountToLoad = 10;
+    private amountToLoad = 20;
     private currentlyLoaded = 0;
     public responsiveOptions: any;
 
@@ -186,7 +186,7 @@ export class CarouselListComponent {
         await this.loadData(false);
         
         // If we don't have enough results to fill the carousel, load one more batch
-        if (this.discoverResults().length < 10) {
+        if (this.discoverResults().length < 20) {
             await this.loadData(false);
         }
     }
@@ -352,7 +352,7 @@ export class CarouselListComponent {
         const tempResults = <IDiscoverCardResult[]>[];
         this.tvShows().forEach(m => {
             tempResults.push({
-                available: m.fullyAvailable,
+                available: m.fullyAvailable || m.partlyAvailable,
                 posterPath: m.backdropPath ? `https://image.tmdb.org/t/p/w500/${m.backdropPath}` :  this.baseUrl + "/images/default_tv_poster.png",
                 requested: m.requested,
                 title: m.title,

--- a/src/Ombi/ClientApp/src/app/settings/about/about.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/about/about.component.html
@@ -104,8 +104,6 @@
       <a target="_blank" href='https://play.google.com/store/apps/details?id=com.tidusjar.Ombi&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img width="200px" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png'/></a>
       <a target="_blank" href='https://apps.apple.com/us/app/ombi/id1335260043'><img width="155px" alt='Get it on App Store' [src]="appstoreImage"/></a>
     </div>
-    <h2>News</h2>
-    <div [innerHTML]="newsHtml"></div>
   </div>
   </div>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/about/about.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/about/about.component.ts
@@ -9,7 +9,7 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { HubService, SettingsService, SystemService } from "../../services";
+import { HubService, SettingsService } from "../../services";
 import { IAbout, IUpdateModel } from "../../interfaces/ISettings";
 
 import { IConnectedUser } from "../../interfaces";
@@ -41,7 +41,7 @@ export class AboutComponent implements OnInit {
     public about: IAbout;
     public newUpdate: boolean;
     public connectedUsers: IConnectedUser[];
-    public newsHtml: string;
+
     public appstoreImage: string;
 
     public get usingSqliteDatabase() {
@@ -58,7 +58,6 @@ export class AboutComponent implements OnInit {
     constructor(private readonly settingsService: SettingsService,
         private readonly jobService: UpdateService,
         private readonly hubService: HubService,
-        private readonly systemService: SystemService,
         private readonly dialog: MatDialog,
         @Inject(APP_BASE_HREF) private readonly href:string) { }
 
@@ -69,8 +68,6 @@ export class AboutComponent implements OnInit {
             this.appstoreImage = "../../.." + base + "/images/appstore.svg";
         }
         this.settingsService.about().subscribe(x => this.about = x);
-        this.newsHtml = await this.systemService.getNews().toPromise();
-
         this.jobService.checkForUpdate().subscribe(x => {
             this.update = x;
             if (x.updateAvailable) {


### PR DESCRIPTION
- Fix Hide Available filter not working for TV shows on discover page by
  checking Available instead of FullyAvailable in TvSearchEngineV2 (#5356)
- Fix operator precedence bug in AvailabilityRuleHelper that incorrectly
  marked shows as fully available due to wrong boolean logic in unaired
  episode detection (#5356)
- Fix TV show availability display on discover cards to include partly
  available shows (#5356)
- Fix discovery page scroll arrows greyed out when Movie or TV filter
  selected by increasing initial load amount to exceed numVisible at all
  responsive breakpoints (#5292)
- Remove stale News section from About page since the news source has no
  content (#5349)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV availability detection to better identify unaired episodes and adjust overall availability status.

* **Improvements**
  * Discovery now recognises partial availability when showing item status.
  * Carousel loads larger batches (more items per fetch) for smoother browsing.

* **Other Changes**
  * News section removed from the About page; related news fetching has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->