### PR TITLE
Upgrade backend from .NET 8 to .NET 10

### DIFF
--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
-    - uses: actions/setup-node@v2
+        dotnet-version: 10.0.x
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Nuget Cache
         uses: actions/cache@v4
@@ -107,12 +107,9 @@ jobs:
             format: tar.gz
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Nuget Cache
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
   build-ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -39,7 +39,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
@@ -65,7 +65,7 @@ jobs:
       tag: ${{ steps.changelog.outputs.tag }}
       version: ${{ steps.changelog.outputs.version }}
      steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v4
        - name: Conventional Changelog Action
          id: changelog
          uses: TriPSs/conventional-changelog-action@v3
@@ -106,7 +106,7 @@ jobs:
             compression: tar
             format: tar.gz
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
@@ -166,7 +166,7 @@ jobs:
     needs: [ publish, unit-test, versioning ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Download Artifacts
         id: download

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -95,7 +95,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to Ombi! This document provides guid
 ## 🚀 Getting Started
 
 ### Prerequisites
-- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - [Node.js 20+](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com/)
 - [Git](https://git-scm.com/)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.419",
+    "version": "10.0.105",
     "rollForward": "latestMinor"
   }
 }

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -47,10 +47,11 @@ if ! command -v dotnet &> /dev/null; then
     exit 1
 else
     DOTNET_VERSION=$(dotnet --version)
-    if [[ $DOTNET_VERSION == 10.* ]]; then
-        print_success "Found .NET version: $DOTNET_VERSION"
+    REQUIRED_VERSION=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' global.json | head -n1 | sed -E 's/.*"([^"]+)"/\1/')
+    if dotnet --list-sdks | awk '{print $1}' | grep -Fxq "$REQUIRED_VERSION"; then
+        print_success "Found required .NET SDK version from global.json: $REQUIRED_VERSION"
     else
-        print_error ".NET 10.0 SDK is required but $DOTNET_VERSION is installed"
+        print_error ".NET SDK $REQUIRED_VERSION is required (from global.json), but current SDK is $DOTNET_VERSION"
         print_status "Please install from: https://dotnet.microsoft.com/download/dotnet/10.0"
         exit 1
     fi

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -42,16 +42,16 @@ print_status "Checking for required tools..."
 
 # Check .NET
 if ! command -v dotnet &> /dev/null; then
-    print_error ".NET 8.0 SDK is required but not installed"
-    print_status "Please install from: https://dotnet.microsoft.com/download/dotnet/8.0"
+    print_error ".NET 10.0 SDK is required but not installed"
+    print_status "Please install from: https://dotnet.microsoft.com/download/dotnet/10.0"
     exit 1
 else
     DOTNET_VERSION=$(dotnet --version)
-    if [[ $DOTNET_VERSION == 8.* ]]; then
+    if [[ $DOTNET_VERSION == 10.* ]]; then
         print_success "Found .NET version: $DOTNET_VERSION"
     else
-        print_error ".NET 8.0 SDK is required but $DOTNET_VERSION is installed"
-        print_status "Please install from: https://dotnet.microsoft.com/download/dotnet/8.0"
+        print_error ".NET 10.0 SDK is required but $DOTNET_VERSION is installed"
+        print_status "Please install from: https://dotnet.microsoft.com/download/dotnet/10.0"
         exit 1
     fi
 fi

--- a/src/Ombi.Api.External/Ombi.Api.External.csproj
+++ b/src/Ombi.Api.External/Ombi.Api.External.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Api/Ombi.Api.csproj
+++ b/src/Ombi.Api/Ombi.Api.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
 

--- a/src/Ombi.Api/Ombi.Api.csproj
+++ b/src/Ombi.Api/Ombi.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
+++ b/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
     <PackageReference Include="Nunit" Version="3.13.3" />

--- a/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
+++ b/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
     <PackageReference Include="Nunit" Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"></packagereference>
+    <packagereference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"></packagereference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
+++ b/src/Ombi.Core.Tests/Ombi.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   <Configurations>Debug;Release;NonUiBuild</Configurations>

--- a/src/Ombi.Core/Ombi.Core.csproj
+++ b/src/Ombi.Core/Ombi.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Core/Ombi.Core.csproj
+++ b/src/Ombi.Core/Ombi.Core.csproj
@@ -13,10 +13,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="MusicBrainzAPI" Version="2.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Ombi.DependencyInjection/Ombi.DependencyInjection.csproj
+++ b/src/Ombi.DependencyInjection/Ombi.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.DependencyInjection/Ombi.DependencyInjection.csproj
+++ b/src/Ombi.DependencyInjection/Ombi.DependencyInjection.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.HealthChecks/Ombi.HealthChecks.csproj
+++ b/src/Ombi.HealthChecks/Ombi.HealthChecks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="6.0.4" />
+    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="9.0.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Ombi.HealthChecks/Ombi.HealthChecks.csproj
+++ b/src/Ombi.HealthChecks/Ombi.HealthChecks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;NonUiBuild</Configurations>
   </PropertyGroup>
 

--- a/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
+++ b/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
+++ b/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Moq.AutoMock" Version="2.0.0" />
   </ItemGroup>

--- a/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
+++ b/src/Ombi.Helpers.Tests/Ombi.Helpers.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/src/Ombi.Helpers/LinqHelpers.cs
+++ b/src/Ombi.Helpers/LinqHelpers.cs
@@ -13,30 +13,5 @@ namespace Ombi.Helpers
             return new HashSet<T>(source, comparer);
         }
 
-        public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
-        {
-            return source.Shuffle(new Random());
-        }
-
-        public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source, Random rng)
-        {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (rng == null) throw new ArgumentNullException(nameof(rng));
-
-            return source.ShuffleIterator(rng);
-        }
-
-        private static IEnumerable<T> ShuffleIterator<T>(
-            this IEnumerable<T> source, Random rng)
-        {
-            var buffer = source.ToList();
-            for (int i = 0; i < buffer.Count; i++)
-            {
-                int j = rng.Next(i, buffer.Count);
-                yield return buffer[j];
-
-                buffer[j] = buffer[i];
-            }
-        }
     }
 }

--- a/src/Ombi.Helpers/Ombi.Helpers.csproj
+++ b/src/Ombi.Helpers/Ombi.Helpers.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="EasyCrypto" Version="4.6.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Quartz" Version="3.6.2" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />

--- a/src/Ombi.Helpers/Ombi.Helpers.csproj
+++ b/src/Ombi.Helpers/Ombi.Helpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Hubs/Ombi.Hubs.csproj
+++ b/src/Ombi.Hubs/Ombi.Hubs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;NonUiBuild</Configurations>
   </PropertyGroup>

--- a/src/Ombi.I18n/Ombi.I18n.csproj
+++ b/src/Ombi.I18n/Ombi.I18n.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Mapping/Ombi.Mapping.csproj
+++ b/src/Ombi.Mapping/Ombi.Mapping.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Notifications.Templates/Ombi.Notifications.Templates.csproj
+++ b/src/Ombi.Notifications.Templates/Ombi.Notifications.Templates.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
+++ b/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;NonUiBuild</Configurations>
   </PropertyGroup>
 

--- a/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
+++ b/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Nunit" Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"></packagereference>
     <PackageReference Include="Moq" Version="4.18.2" />
 	  <PackageReference Include="Moq.AutoMock" Version="3.4.0" />

--- a/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
+++ b/src/Ombi.Notifications.Tests/Ombi.Notifications.Tests.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="Nunit" Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"></packagereference>
+    <packagereference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"></packagereference>
     <PackageReference Include="Moq" Version="4.18.2" />
 	  <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
   </ItemGroup>

--- a/src/Ombi.Notifications/Ombi.Notifications.csproj
+++ b/src/Ombi.Notifications/Ombi.Notifications.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
+++ b/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
+++ b/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
@@ -9,12 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
     <PackageReference Include="MockQueryable.Moq" Version="6.0.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Moq.AutoMock" Version="3.4.0" />
     <PackageReference Include="Nunit" Version="3.13.3" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />

--- a/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
+++ b/src/Ombi.Schedule.Tests/Ombi.Schedule.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Nunit" Version="3.13.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Schedule/Ombi.Schedule.csproj
+++ b/src/Ombi.Schedule/Ombi.Schedule.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
+++ b/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
+++ b/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
   </ItemGroup>
 

--- a/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
+++ b/src/Ombi.Settings.Tests/Ombi.Settings.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
   </ItemGroup>

--- a/src/Ombi.Settings/Ombi.Settings.csproj
+++ b/src/Ombi.Settings/Ombi.Settings.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Quartz" Version="3.6.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi.Settings/Ombi.Settings.csproj
+++ b/src/Ombi.Settings/Ombi.Settings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Store/Ombi.Store.csproj
+++ b/src/Ombi.Store/Ombi.Store.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Store/Ombi.Store.csproj
+++ b/src/Ombi.Store/Ombi.Store.csproj
@@ -12,15 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <!--<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.9" />-->

--- a/src/Ombi.Test.Common/Ombi.Test.Common.csproj
+++ b/src/Ombi.Test.Common/Ombi.Test.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;NonUiBuild</Configurations>
   </PropertyGroup>

--- a/src/Ombi.Tests/Ombi.Tests.csproj
+++ b/src/Ombi.Tests/Ombi.Tests.csproj
@@ -14,8 +14,8 @@
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<packagereference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"></packagereference>
+		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+		<packagereference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"></packagereference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Ombi.Tests/Ombi.Tests.csproj
+++ b/src/Ombi.Tests/Ombi.Tests.csproj
@@ -7,12 +7,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
 		<PackageReference Include="Moq" Version="4.18.2" />
 		<PackageReference Include="Moq.AutoMock" Version="3.4.0" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<packagereference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"></packagereference>
 	</ItemGroup>

--- a/src/Ombi.Tests/Ombi.Tests.csproj
+++ b/src/Ombi.Tests/Ombi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;NonUiBuild</Configurations>
 	</PropertyGroup>

--- a/src/Ombi.Updater/Ombi.Updater.csproj
+++ b/src/Ombi.Updater/Ombi.Updater.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win10-x64;win10-x86;osx-x64;ubuntu-x64;debian.8-x64;centos.7-x64;linux-x64;linux-arm;linux-arm64;</RuntimeIdentifiers>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>
     <Version></Version>

--- a/src/Ombi.Updater/Ombi.Updater.csproj
+++ b/src/Ombi.Updater/Ombi.Updater.csproj
@@ -13,14 +13,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/Ombi/Extensions/DatabaseExtensions.cs
+++ b/src/Ombi/Extensions/DatabaseExtensions.cs
@@ -113,7 +113,7 @@ namespace Ombi.Extensions
             if (builder != null)
             {
                 builder.AddSqlite(
-                    sqliteConnectionString: config.ConnectionString,
+                    connectionString: config.ConnectionString,
                     name: dbName,
                     failureStatus: HealthStatus.Unhealthy,
                     tags: new string[] { "db" });
@@ -138,7 +138,7 @@ namespace Ombi.Extensions
             if (builder != null)
             {
                 builder.AddNpgSql(
-                    npgsqlConnectionString: config.ConnectionString,
+                    connectionString: config.ConnectionString,
                     name: dbName,
                     failureStatus: HealthStatus.Unhealthy,
                     tags: new string[] { "db" }

--- a/src/Ombi/Ombi.csproj
+++ b/src/Ombi/Ombi.csproj
@@ -60,22 +60,22 @@
 
  
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="6.0.2" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
-    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="9.0.0" />
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
     <PackageReference Include="ncrontab" Version="3.3.1" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -83,8 +83,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.4.0" />
     <PackageReference Include="System.Security.Cryptography.Csp" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ombi/Ombi.csproj
+++ b/src/Ombi/Ombi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <!-- <PublishTrimmed>true</PublishTrimmed>    

--- a/src/dockerfile
+++ b/src/dockerfile
@@ -7,7 +7,7 @@ COPY Ombi/ClientApp Ombi/ClientApp
 RUN yarn --cwd Ombi/ClientApp run build
 
 # Stage 2: Build and publish .NET backend
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 ARG VERSION=1.0.0
 WORKDIR /source
 
@@ -33,7 +33,7 @@ COPY . .
 RUN dotnet publish Ombi/Ombi.csproj -c Release --no-restore -o /app/publish
 
 # Stage 3: Final runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
 WORKDIR /opt/ombi
 EXPOSE 5000
 


### PR DESCRIPTION
## Summary

- Update `TargetFramework` from `net8.0` to `net10.0` across all 23 projects
- Update `global.json` SDK version from `8.0.419` to `10.0.105`
- Update Dockerfile base images from `dotnet/sdk:8.0-jammy` / `dotnet/aspnet:8.0-jammy` to `10.0-noble`
- Update CI workflow to use .NET `10.0.x` SDK and `actions/setup-dotnet@v4`
- Remove legacy .NET 5.0.x SDK setup from CI publish job
- Remove custom `LinqHelpers.Shuffle<T>()` extension methods that conflict with the built-in `Enumerable.Shuffle<T>()` added in .NET 10

## Test plan

- [x] Solution builds successfully with 0 errors
- [x] All 564 unit tests pass (6 skipped — pre-existing)
- [ ] Verify Docker image builds correctly with new base images
- [ ] Verify CI pipeline runs end-to-end on GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Retargeted projects and updated dependencies to .NET 10.0 across the codebase
  * Updated developer setup docs and scripts to require .NET 10.0
  * CI workflows and Docker images updated to use .NET 10.0 and newer action/tool versions
* **Breaking Changes**
  * Removed public Shuffle extension methods from utility helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->