### PR TITLE
Run E2E tests against MySQL, PostgreSQL, and SQLite

### DIFF
--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -9,18 +9,185 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-jobs:
-  automation-tests:
+# Required secrets:
+#   CYPRESS_RECORD_KEY          - Shared Cypress record key
+#   CYPRESS_PROJECT_ID_MYSQL    - Cypress Cloud project ID for MySQL runs
+#   CYPRESS_PROJECT_ID_POSTGRES - Cypress Cloud project ID for PostgreSQL runs
+#   CYPRESS_PROJECT_ID_SQLITE   - Cypress Cloud project ID for SQLite runs
 
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # MySQL (full suite) and PostgreSQL (smoke) — need Docker services
+  # ──────────────────────────────────────────────────────────────
+  db-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - db: mysql
+            db_type: MySQL
+            connection_string: "Server=127.0.0.1;Port=3306;Database=ombi;User=ombi;Password=ombi;"
+            cypress_project_id_secret: CYPRESS_PROJECT_ID_MYSQL
+            cypress_spec: ""
+            test_scope: full
+          - db: postgres
+            db_type: Postgres
+            connection_string: "Host=127.0.0.1;Port=5432;Database=ombi;Username=ombi;Password=ombi;"
+            cypress_project_id_secret: CYPRESS_PROJECT_ID_POSTGRES
+            cypress_spec: "cypress/features/01-wizard/wizard.feature,cypress/features/login/login.feature,cypress/tests/login/login.spec.ts"
+            test_scope: smoke
+
+    services:
+      mysql:
+        image: mysql:8
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: ombi
+          MYSQL_USER: ombi
+          MYSQL_PASSWORD: ombi
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: ombi
+          POSTGRES_USER: ombi
+          POSTGRES_PASSWORD: ombi
+        options: >-
+          --health-cmd="pg_isready -U ombi"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    name: "E2E Tests (${{ matrix.db }} - ${{ matrix.test_scope }})"
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
-    - uses: actions/setup-node@v2
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          '**/node_modules'
+          '/home/runner/.cache/Cypress'
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+    - name: Install Frontend Deps
+      run: yarn --cwd ./src/Ombi/ClientApp install
+
+    - name: Install Test Dependencies
+      run: yarn --cwd ./tests install
+
+    - name: Start Frontend
+      run: |
+        nohup yarn --cwd ./src/Ombi/ClientApp start &
+
+    - name: Restore .NET Dependencies
+      run: dotnet restore ./src/Ombi/Ombi.csproj
+
+    - name: Build .NET Project
+      run: dotnet build ./src/Ombi/Ombi.csproj --no-restore
+
+    - name: Write database.json
+      run: |
+        cat > ./src/Ombi/database.json <<EOF
+        {
+          "OmbiDatabase": {
+            "Type": "${{ matrix.db_type }}",
+            "ConnectionString": "${{ matrix.connection_string }}"
+          },
+          "SettingsDatabase": {
+            "Type": "${{ matrix.db_type }}",
+            "ConnectionString": "${{ matrix.connection_string }}"
+          },
+          "ExternalDatabase": {
+            "Type": "${{ matrix.db_type }}",
+            "ConnectionString": "${{ matrix.connection_string }}"
+          }
+        }
+        EOF
+
+    - name: Start Backend
+      run: |
+        nohup dotnet run --project ./src/Ombi -- --host http://*:3577 &
+
+    - name: Run Wiremock
+      run: nohup docker run --rm -p 32400:8080 --name wiremock wiremock/wiremock:2.35.0 &
+
+    - name: Sleep for server to start
+      run: sleep 20
+
+    - name: Cypress Tests (full suite)
+      if: matrix.cypress_spec == ''
+      uses: cypress-io/github-action@v4
+      with:
+        record: true
+        browser: chrome
+        headless: true
+        working-directory: tests
+        wait-on: http://localhost:3577/
+        wait-on-timeout: 600
+      env:
+        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        CYPRESS_PROJECT_ID: ${{ secrets[matrix.cypress_project_id_secret] }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cypress Tests (smoke)
+      if: matrix.cypress_spec != ''
+      uses: cypress-io/github-action@v4
+      with:
+        record: true
+        browser: chrome
+        headless: true
+        working-directory: tests
+        spec: ${{ matrix.cypress_spec }}
+        wait-on: http://localhost:3577/
+        wait-on-timeout: 600
+      env:
+        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        CYPRESS_PROJECT_ID: ${{ secrets[matrix.cypress_project_id_secret] }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Stop Services
+      if: always()
+      run: |
+        pkill -f "dotnet.*Ombi" || true
+        docker container kill wiremock || true
+
+  # ──────────────────────────────────────────────────────────────
+  # SQLite (smoke) — no Docker services needed
+  # ──────────────────────────────────────────────────────────────
+  sqlite-tests:
+    runs-on: ubuntu-latest
+
+    name: "E2E Tests (sqlite - smoke)"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
 
@@ -57,18 +224,19 @@ jobs:
     - name: Sleep for server to start
       run: sleep 20
 
-    - name: Cypress Tests
+    - name: Cypress Tests (smoke)
       uses: cypress-io/github-action@v4
       with:
         record: true
         browser: chrome
         headless: true
         working-directory: tests
+        spec: "cypress/features/01-wizard/wizard.feature,cypress/features/login/login.feature,cypress/tests/login/login.spec.ts"
         wait-on: http://localhost:3577/
-        # 10 minutes
         wait-on-timeout: 600
       env:
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID_SQLITE }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Stop Services

--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -9,11 +9,13 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-# Required secrets:
-#   CYPRESS_RECORD_KEY          - Shared Cypress record key
+# Required secrets (each Cypress Cloud project has its own ID and record key):
 #   CYPRESS_PROJECT_ID_MYSQL    - Cypress Cloud project ID for MySQL runs
+#   CYPRESS_RECORD_KEY_MYSQL    - Cypress Cloud record key for MySQL runs
 #   CYPRESS_PROJECT_ID_POSTGRES - Cypress Cloud project ID for PostgreSQL runs
+#   CYPRESS_RECORD_KEY_POSTGRES - Cypress Cloud record key for PostgreSQL runs
 #   CYPRESS_PROJECT_ID_SQLITE   - Cypress Cloud project ID for SQLite runs
+#   CYPRESS_RECORD_KEY_SQLITE   - Cypress Cloud record key for SQLite runs
 
 jobs:
   # ──────────────────────────────────────────────────────────────
@@ -30,12 +32,14 @@ jobs:
             db_type: MySQL
             connection_string: "Server=127.0.0.1;Port=3306;Database=ombi;User=ombi;Password=ombi;"
             cypress_project_id_secret: CYPRESS_PROJECT_ID_MYSQL
+            cypress_record_key_secret: CYPRESS_RECORD_KEY_MYSQL
             cypress_spec: ""
             test_scope: full
           - db: postgres
             db_type: Postgres
             connection_string: "Host=127.0.0.1;Port=5432;Database=ombi;Username=ombi;Password=ombi;"
             cypress_project_id_secret: CYPRESS_PROJECT_ID_POSTGRES
+            cypress_record_key_secret: CYPRESS_RECORD_KEY_POSTGRES
             cypress_spec: "cypress/features/01-wizard/wizard.feature,cypress/features/login/login.feature,cypress/tests/login/login.spec.ts"
             test_scope: smoke
 
@@ -145,7 +149,7 @@ jobs:
         wait-on: http://localhost:3577/
         wait-on-timeout: 600
       env:
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        CYPRESS_RECORD_KEY: ${{ secrets[matrix.cypress_record_key_secret] }}
         CYPRESS_PROJECT_ID: ${{ secrets[matrix.cypress_project_id_secret] }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -161,7 +165,7 @@ jobs:
         wait-on: http://localhost:3577/
         wait-on-timeout: 600
       env:
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        CYPRESS_RECORD_KEY: ${{ secrets[matrix.cypress_record_key_secret] }}
         CYPRESS_PROJECT_ID: ${{ secrets[matrix.cypress_project_id_secret] }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -235,7 +239,7 @@ jobs:
         wait-on: http://localhost:3577/
         wait-on-timeout: 600
       env:
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY_SQLITE }}
         CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID_SQLITE }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -32,8 +32,8 @@ export default defineConfig({
     apiBaseUrl: 'http://localhost:3577/api/v1'
   },
   
-  // Project configuration
-  projectId: 'o5451s',
+  // Project configuration - can be overridden via CYPRESS_PROJECT_ID env var for multi-db CI
+  projectId: process.env.CYPRESS_PROJECT_ID || 'o5451s',
   
   e2e: {
     // Setup node events

--- a/tests/package.json
+++ b/tests/package.json
@@ -24,6 +24,7 @@
     "cypress:run": "cypress run",
     "types": "tsc --noEmit",
     "e2e": "cypress run",
+    "smoke": "cypress run --spec 'cypress/features/01-wizard/wizard.feature,cypress/features/login/login.feature,cypress/tests/login/login.spec.ts'",
     "regression": "cypress run --config-file cypress/config/regression.json",
     "demo:open": "cypress open --config-file cypress/config/demo.json"
   },


### PR DESCRIPTION
MySQL runs the full test suite as the primary database. PostgreSQL and SQLite run wizard + login specs as smoke tests. Each database variant records to a separate Cypress Cloud project via secrets.

Adds Docker services for MySQL 8 and PostgreSQL 15 with health checks, writes database.json per matrix entry, and bumps GHA action versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Split automated test workflow into separate jobs to run full and smoke suites across different databases.
  * Added a dedicated smoke test script to run a concise set of end-to-end checks.
  * Made test runner project ID configurable via environment to allow per-environment recording.

* **Chores**
  * Improved CI reliability with upgraded tooling and targeted caching for faster runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->