### PR TITLE
fix: issue deletion failing due to foreign key constraint on IssueComments

### DIFF
--- a/src/Ombi.Tests/IssuesControllerTests.cs
+++ b/src/Ombi.Tests/IssuesControllerTests.cs
@@ -130,6 +130,7 @@ namespace Ombi.Tests
 
             _issues.Setup(x => x.GetAll()).Returns(new List<Issues> { issue }.AsQueryable().BuildMock());
             _issues.Setup(x => x.Delete(issue)).Returns(Task.CompletedTask);
+            _comments.Setup(x => x.GetAll()).Returns(new List<IssueComments>().AsQueryable().BuildMock());
             _notification.Setup(x => x.Notify(It.IsAny<NotificationOptions>())).Returns(Task.CompletedTask);
 
             var result = await _subject.DeleteIssue(11);
@@ -141,6 +142,41 @@ namespace Ombi.Tests
                 n.RequestType == RequestType.TvShow &&
                 n.Substitutes[NotificationSubstitues.Title] == "Issue to delete"
             )), Times.Once);
+            _issues.Verify(x => x.Delete(issue), Times.Once);
+        }
+
+        [Test]
+        public async Task DeleteIssue_DeletesAssociatedComments_BeforeDeletingIssue()
+        {
+            var comment1 = new IssueComments { Id = 1, IssuesId = 11, Comment = "First comment", UserId = "reporter-id" };
+            var comment2 = new IssueComments { Id = 2, IssuesId = 11, Comment = "Second comment", UserId = "admin-id" };
+            var unrelatedComment = new IssueComments { Id = 3, IssuesId = 99, Comment = "Other issue", UserId = "admin-id" };
+
+            var issue = new Issues
+            {
+                Id = 11,
+                Title = "Issue with comments",
+                Subject = "Subject",
+                Description = "Description",
+                RequestType = RequestType.Movie,
+                Status = IssueStatus.Pending,
+                UserReportedId = "reporter-id",
+                IssueCategory = new IssueCategory { Id = 1, Value = "Playback" },
+                Comments = new List<IssueComments> { comment1, comment2 }
+            };
+
+            _issues.Setup(x => x.GetAll()).Returns(new List<Issues> { issue }.AsQueryable().BuildMock());
+            _issues.Setup(x => x.Delete(issue)).Returns(Task.CompletedTask);
+            _comments.Setup(x => x.GetAll()).Returns(new List<IssueComments> { comment1, comment2, unrelatedComment }.AsQueryable().BuildMock());
+            _comments.Setup(x => x.Delete(It.IsAny<IssueComments>())).Returns(Task.CompletedTask);
+            _notification.Setup(x => x.Notify(It.IsAny<NotificationOptions>())).Returns(Task.CompletedTask);
+
+            var result = await _subject.DeleteIssue(11);
+
+            Assert.That(result, Is.True);
+            _comments.Verify(x => x.Delete(comment1), Times.Once);
+            _comments.Verify(x => x.Delete(comment2), Times.Once);
+            _comments.Verify(x => x.Delete(unrelatedComment), Times.Never);
             _issues.Verify(x => x.Delete(issue), Times.Once);
         }
 

--- a/src/Ombi.Tests/IssuesControllerTests.cs
+++ b/src/Ombi.Tests/IssuesControllerTests.cs
@@ -131,6 +131,7 @@ namespace Ombi.Tests
             _issues.Setup(x => x.GetAll()).Returns(new List<Issues> { issue }.AsQueryable().BuildMock());
             _issues.Setup(x => x.Delete(issue)).Returns(Task.CompletedTask);
             _comments.Setup(x => x.GetAll()).Returns(new List<IssueComments>().AsQueryable().BuildMock());
+            _comments.Setup(x => x.DeleteRange(It.IsAny<IEnumerable<IssueComments>>())).Returns(Task.CompletedTask);
             _notification.Setup(x => x.Notify(It.IsAny<NotificationOptions>())).Returns(Task.CompletedTask);
 
             var result = await _subject.DeleteIssue(11);
@@ -165,19 +166,24 @@ namespace Ombi.Tests
                 Comments = new List<IssueComments> { comment1, comment2 }
             };
 
+            var callOrder = new List<string>();
+
             _issues.Setup(x => x.GetAll()).Returns(new List<Issues> { issue }.AsQueryable().BuildMock());
-            _issues.Setup(x => x.Delete(issue)).Returns(Task.CompletedTask);
+            _issues.Setup(x => x.Delete(issue)).Callback(() => callOrder.Add("DeleteIssue")).Returns(Task.CompletedTask);
             _comments.Setup(x => x.GetAll()).Returns(new List<IssueComments> { comment1, comment2, unrelatedComment }.AsQueryable().BuildMock());
-            _comments.Setup(x => x.Delete(It.IsAny<IssueComments>())).Returns(Task.CompletedTask);
+            _comments.Setup(x => x.DeleteRange(It.IsAny<IEnumerable<IssueComments>>()))
+                .Callback(() => callOrder.Add("DeleteComments"))
+                .Returns(Task.CompletedTask);
             _notification.Setup(x => x.Notify(It.IsAny<NotificationOptions>())).Returns(Task.CompletedTask);
 
             var result = await _subject.DeleteIssue(11);
 
             Assert.That(result, Is.True);
-            _comments.Verify(x => x.Delete(comment1), Times.Once);
-            _comments.Verify(x => x.Delete(comment2), Times.Once);
-            _comments.Verify(x => x.Delete(unrelatedComment), Times.Never);
+            _comments.Verify(x => x.DeleteRange(It.Is<IEnumerable<IssueComments>>(c =>
+                c.Count() == 2 && c.Contains(comment1) && c.Contains(comment2) && !c.Contains(unrelatedComment)
+            )), Times.Once);
             _issues.Verify(x => x.Delete(issue), Times.Once);
+            Assert.That(callOrder, Is.EqualTo(new List<string> { "DeleteComments", "DeleteIssue" }));
         }
 
         [Test]

--- a/src/Ombi/Controllers/V1/IssuesController.cs
+++ b/src/Ombi/Controllers/V1/IssuesController.cs
@@ -307,10 +307,7 @@ namespace Ombi.Controllers.V1
             await _notification.Notify(notificationModel);
 
             var comments = await _issueComments.GetAll().Where(x => x.IssuesId == id).ToListAsync();
-            foreach (var comment in comments)
-            {
-                await _issueComments.Delete(comment);
-            }
+            await _issueComments.DeleteRange(comments);
 
             await _issues.Delete(issue);
             return true;

--- a/src/Ombi/Controllers/V1/IssuesController.cs
+++ b/src/Ombi/Controllers/V1/IssuesController.cs
@@ -306,6 +306,12 @@ namespace Ombi.Controllers.V1
 
             await _notification.Notify(notificationModel);
 
+            var comments = await _issueComments.GetAll().Where(x => x.IssuesId == id).ToListAsync();
+            foreach (var comment in comments)
+            {
+                await _issueComments.Delete(comment);
+            }
+
             await _issues.Delete(issue);
             return true;
         }


### PR DESCRIPTION
Delete associated IssueComments before deleting the parent Issue to
prevent MySQL foreign key constraint violations (#5392).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an issue now also removes its associated comments first, preventing orphaned comments and ensuring data consistency.

* **Tests**
  * Added and updated tests to verify associated comments are deleted before the issue and that deletion order is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->