### PR TITLE
feat: add auto-update settings UI and improve updater configuration (#1460)

### DIFF
--- a/src/Ombi.Helpers/AssemblyHelper.cs
+++ b/src/Ombi.Helpers/AssemblyHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Text.Json;
 
 namespace Ombi.Helpers
 {
@@ -7,7 +9,47 @@ namespace Ombi.Helpers
         public static string GetRuntimeVersion()
         {
             Version version = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version;
-            return version == null ? "1.0.0" : $"{version.Major}.{version.Minor}.{version.Build}";
+            var assemblyVersion = version == null ? null : $"{version.Major}.{version.Minor}.{version.Build}";
+
+            // Assembly version defaults to 0.0.0 or 1.0.0 when SemVer isn't set during build.
+            // Fall back to version.json which contains the canonical version.
+            if (string.IsNullOrEmpty(assemblyVersion) || assemblyVersion == "0.0.0" || assemblyVersion == "1.0.0")
+            {
+                var versionFromFile = ReadVersionFromFile();
+                if (!string.IsNullOrEmpty(versionFromFile))
+                {
+                    return versionFromFile;
+                }
+            }
+
+            return assemblyVersion ?? "1.0.0";
+        }
+
+        private static string ReadVersionFromFile()
+        {
+            try
+            {
+                // Look for version.json next to the running executable
+                var basePath = AppContext.BaseDirectory;
+                var versionFile = Path.Combine(basePath, "version.json");
+                if (!File.Exists(versionFile))
+                {
+                    return null;
+                }
+
+                var json = File.ReadAllText(versionFile);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("version", out var versionElement))
+                {
+                    return versionElement.GetString();
+                }
+            }
+            catch
+            {
+                // Swallow errors — fall back to assembly version
+            }
+
+            return null;
         }
     }
 }

--- a/src/Ombi.Schedule/Jobs/Ombi/OmbiAutomaticUpdater.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/OmbiAutomaticUpdater.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Ombi.Core.Processor;
 using Ombi.Core.Settings;
 using Ombi.Helpers;
+using Ombi.Hubs;
 using Ombi.Schedule.Processor;
 using Ombi.Settings.Settings.Models;
 using Ombi.Store.Entities;
@@ -28,13 +29,15 @@ namespace Ombi.Schedule.Jobs.Ombi
     public class OmbiAutomaticUpdater : IOmbiAutomaticUpdater
     {
         public OmbiAutomaticUpdater(ILogger<OmbiAutomaticUpdater> log, IChangeLogProcessor service,
-            ISettingsService<UpdateSettings> s, IProcessProvider proc, IApplicationConfigRepository appConfig)
+            ISettingsService<UpdateSettings> s, IProcessProvider proc, IApplicationConfigRepository appConfig,
+            INotificationHubService notificationHubService)
         {
             Logger = log;
             Processor = service;
             Settings = s;
             _processProvider = proc;
             _appConfig = appConfig;
+            _notificationHubService = notificationHubService;
         }
 
         private ILogger<OmbiAutomaticUpdater> Logger { get; }
@@ -42,6 +45,7 @@ namespace Ombi.Schedule.Jobs.Ombi
         private ISettingsService<UpdateSettings> Settings { get; }
         private readonly IProcessProvider _processProvider;
         private readonly IApplicationConfigRepository _appConfig;
+        private readonly INotificationHubService _notificationHubService;
 
         public string[] GetVersion()
         {
@@ -99,6 +103,8 @@ namespace Ombi.Schedule.Jobs.Ombi
 
                 if (!serverVersion.Equals(version, StringComparison.CurrentCultureIgnoreCase) || settings.TestMode)
                 {
+                    await _notificationHubService.SendNotificationToAdmins($"Ombi update available: v{serverVersion}. Downloading...");
+
                     // Let's download the correct zip
                     var desc = RuntimeInformation.OSDescription;
                     var process = RuntimeInformation.ProcessArchitecture;
@@ -237,6 +243,7 @@ namespace Ombi.Schedule.Jobs.Ombi
             catch (Exception e)
             {
                 Logger.LogError(e, "Exception thrown in the OmbiUpdater, see previous messages");
+                await _notificationHubService.SendNotificationToAdmins("Ombi auto-update failed. Check logs for details.");
                 throw;
             }
         }

--- a/src/Ombi.Schedule/Jobs/Ombi/OmbiAutomaticUpdater.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/OmbiAutomaticUpdater.cs
@@ -103,7 +103,14 @@ namespace Ombi.Schedule.Jobs.Ombi
 
                 if (!serverVersion.Equals(version, StringComparison.CurrentCultureIgnoreCase) || settings.TestMode)
                 {
-                    await _notificationHubService.SendNotificationToAdmins($"Ombi update available: v{serverVersion}. Downloading...");
+                    try
+                    {
+                        await _notificationHubService.SendNotificationToAdmins($"Ombi update available: v{serverVersion}. Downloading...");
+                    }
+                    catch (Exception notifyEx)
+                    {
+                        Logger.LogWarning(notifyEx, "Failed to send updater start notification");
+                    }
 
                     // Let's download the correct zip
                     var desc = RuntimeInformation.OSDescription;
@@ -243,7 +250,14 @@ namespace Ombi.Schedule.Jobs.Ombi
             catch (Exception e)
             {
                 Logger.LogError(e, "Exception thrown in the OmbiUpdater, see previous messages");
-                await _notificationHubService.SendNotificationToAdmins("Ombi auto-update failed. Check logs for details.");
+                try
+                {
+                    await _notificationHubService.SendNotificationToAdmins("Ombi auto-update failed. Check logs for details.");
+                }
+                catch (Exception notifyEx)
+                {
+                    Logger.LogWarning(notifyEx, "Failed to send updater failure notification");
+                }
                 throw;
             }
         }

--- a/src/Ombi.Schedule/OmbiScheduler.cs
+++ b/src/Ombi.Schedule/OmbiScheduler.cs
@@ -65,7 +65,7 @@ namespace Ombi.Schedule
         {
             await OmbiQuartz.Instance.AddJob<IRefreshMetadata>(nameof(IRefreshMetadata), "System", null);
             await OmbiQuartz.Instance.AddJob<IIssuesPurge>(nameof(IIssuesPurge), "System", JobSettingsHelper.IssuePurge(s));
-            //OmbiQuartz.Instance.AddJob<IOmbiAutomaticUpdater>(nameof(IOmbiAutomaticUpdater), "System", JobSettingsHelper.Updater(s));
+            await OmbiQuartz.Instance.AddJob<IOmbiAutomaticUpdater>(nameof(IOmbiAutomaticUpdater), "System", JobSettingsHelper.Updater(s));
             await OmbiQuartz.Instance.AddJob<INewsletterJob>(nameof(INewsletterJob), "System", JobSettingsHelper.Newsletter(s));
             await OmbiQuartz.Instance.AddJob<IResendFailedRequests>(nameof(IResendFailedRequests), "System", JobSettingsHelper.ResendFailedRequests(s));
             await OmbiQuartz.Instance.AddJob<IMediaDatabaseRefresh>(nameof(IMediaDatabaseRefresh), "System", JobSettingsHelper.MediaDatabaseRefresh(s));

--- a/src/Ombi.Schedule/OmbiScheduler.cs
+++ b/src/Ombi.Schedule/OmbiScheduler.cs
@@ -45,7 +45,9 @@ namespace Ombi.Schedule
             // Job Factory through IOC container
             var jobFactory = (IJobFactory)app.GetService(typeof(IJobFactory));
             var service = (ISettingsService<JobSettings>)app.GetService(typeof(ISettingsService<JobSettings>));
+            var updateService = (ISettingsService<UpdateSettings>)app.GetService(typeof(ISettingsService<UpdateSettings>));
             var s = service.GetSettings();
+            var updateSettings = updateService.GetSettings();
             // Set job factory
             OmbiQuartz.Instance.UseJobFactory(jobFactory);
 
@@ -54,18 +56,21 @@ namespace Ombi.Schedule
             await AddEmby(s);
             await AddJellyfin(s);
             await AddDvrApps(s);
-            await AddSystem(s);
+            await AddSystem(s, updateSettings);
             await AddNotifications(s);
 
             // Run Quartz
             await OmbiQuartz.Start();
         }
 
-        private static async Task AddSystem(JobSettings s)
+        private static async Task AddSystem(JobSettings s, UpdateSettings updateSettings)
         {
             await OmbiQuartz.Instance.AddJob<IRefreshMetadata>(nameof(IRefreshMetadata), "System", null);
             await OmbiQuartz.Instance.AddJob<IIssuesPurge>(nameof(IIssuesPurge), "System", JobSettingsHelper.IssuePurge(s));
-            await OmbiQuartz.Instance.AddJob<IOmbiAutomaticUpdater>(nameof(IOmbiAutomaticUpdater), "System", JobSettingsHelper.Updater(s));
+            var updaterCron = string.IsNullOrWhiteSpace(updateSettings?.UpdateSchedule)
+                ? JobSettingsHelper.Updater(s)
+                : updateSettings.UpdateSchedule;
+            await OmbiQuartz.Instance.AddJob<IOmbiAutomaticUpdater>(nameof(IOmbiAutomaticUpdater), "System", updaterCron);
             await OmbiQuartz.Instance.AddJob<INewsletterJob>(nameof(INewsletterJob), "System", JobSettingsHelper.Newsletter(s));
             await OmbiQuartz.Instance.AddJob<IResendFailedRequests>(nameof(IResendFailedRequests), "System", JobSettingsHelper.ResendFailedRequests(s));
             await OmbiQuartz.Instance.AddJob<IMediaDatabaseRefresh>(nameof(IMediaDatabaseRefresh), "System", JobSettingsHelper.MediaDatabaseRefresh(s));

--- a/src/Ombi.Settings/Settings/Models/UpdateSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/UpdateSettings.cs
@@ -11,5 +11,9 @@
         public string WindowsServiceName { get; set; }
         public bool WindowsService { get; set; }
         public bool TestMode { get; set; }
+        /// <summary>
+        /// Cron expression controlling how often the auto-updater checks for new versions.
+        /// </summary>
+        public string UpdateSchedule { get; set; }
     }
 }

--- a/src/Ombi.Updater/Installer.cs
+++ b/src/Ombi.Updater/Installer.cs
@@ -11,6 +11,9 @@ namespace Ombi.Updater
 {
     public class Installer : IInstaller
     {
+        private const int MaxRetries = 3;
+        private const int RetryDelayMs = 1000;
+
         public Installer(ILogger<Installer> log)
         {
             _log = log;
@@ -20,31 +23,29 @@ namespace Ombi.Updater
 
         public void Start(StartupOptions opt)
         {
-            // Kill Ombi Process
             var p = new ProcessProvider();
             bool killed = false;
             try
             {
-
-
                 killed = p.Kill(opt);
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                _log.LogError(e, "Error killing Ombi process");
             }
 
             if (!killed)
             {
-
-                _log.LogDebug("Couldn't kill the ombi process");
+                _log.LogError("Couldn't kill the Ombi process, aborting update");
                 return;
             }
 
-            _log.LogDebug("Starting to move the files");
+            // Brief pause to ensure file handles are released
+            Thread.Sleep(2000);
+
+            _log.LogInformation("Starting to move the files");
             MoveFiles(opt);
-            _log.LogDebug("Files replaced");
-            // Start Ombi
+            _log.LogInformation("Files replaced successfully");
             StartOmbi(opt);
         }
 
@@ -125,8 +126,25 @@ namespace Ombi.Updater
                 SearchOption.AllDirectories))
             {
                 var newFile = currentPath.Replace(updatedLocation, options.ApplicationPath);
-                File.Copy(currentPath, newFile, true);
+                CopyFileWithRetry(currentPath, newFile);
                 _log.LogDebug("Replaced file {0}", newFile);
+            }
+        }
+
+        private void CopyFileWithRetry(string source, string destination)
+        {
+            for (int attempt = 1; attempt <= MaxRetries; attempt++)
+            {
+                try
+                {
+                    File.Copy(source, destination, true);
+                    return;
+                }
+                catch (IOException) when (attempt < MaxRetries)
+                {
+                    _log.LogWarning("File copy failed for {0}, attempt {1}/{2}. Retrying...", destination, attempt, MaxRetries);
+                    Thread.Sleep(RetryDelayMs * attempt);
+                }
             }
         }
     }

--- a/src/Ombi/ClientApp/src/app/app.routes.ts
+++ b/src/Ombi/ClientApp/src/app/app.routes.ts
@@ -38,6 +38,7 @@ import { VoteComponent as SettingsVoteComponent } from "./settings/vote/vote.com
 import { TheMovieDbComponent } from "./settings/themoviedb/themoviedb.component";
 import { FailedRequestsComponent } from "./settings/failedrequests/failedrequests.component";
 import { LogsComponent } from "./settings/logs/logs.component";
+import { UpdateComponent } from "./settings/update/update.component";
 import { CloudMobileComponent } from "./settings/notifications/cloudmobile.coponent";
 import { FeaturesComponent } from "./settings/features/features.component";
 import { AuthGuard } from "./auth/auth.guard";
@@ -135,6 +136,7 @@ export const routes: Routes = [
             { path: "Logs", component: LogsComponent },
             { path: "CloudMobile", component: CloudMobileComponent },
             { path: "Features", component: FeaturesComponent },
+            { path: "Update", component: UpdateComponent },
             { path: "", redirectTo: "About", pathMatch: "full" }
         ]
     },

--- a/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
+++ b/src/Ombi/ClientApp/src/app/interfaces/ISettings.ts
@@ -38,6 +38,7 @@ export interface IUpdateSettings extends ISettings {
   windowsServiceName: string;
   isWindows: boolean;
   testMode: boolean;
+  updateSchedule: string;
 }
 
 export interface IEmbySettings extends ISettings {

--- a/src/Ombi/ClientApp/src/app/settings/settingsmenu.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/settingsmenu.component.html
@@ -58,7 +58,7 @@
 <mat-menu #systemMenu="matMenu">
     <button mat-menu-item [routerLink]="['/Settings/About']"><i class="fas fa-question icon-spacing"></i> About</button>
     <button mat-menu-item [routerLink]="['/Settings/FailedRequests']"><i class="fas fa-times icon-spacing"></i> Failed Requests</button>
-    <!-- <button mat-menu-item [routerLink]="['/Settings/Update']">Update</button> -->
+    <button mat-menu-item [routerLink]="['/Settings/Update']"><i class="fas fa-download icon-spacing"></i> Update</button>
     <button mat-menu-item [routerLink]="['/Settings/Jobs']"><i class="fas fa-clock icon-spacing"></i> Scheduled Tasks</button>
     <button mat-menu-item [routerLink]="['/Settings/Logs']"><i class="fas fa-stream icon-spacing"></i> Logs</button>
 </mat-menu>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -1,5 +1,11 @@
 <div class="small-middle-container">
     <legend>Update Settings</legend>
+    <p class="description">
+        When auto-update is enabled, Ombi will check for new versions on the configured schedule.
+        If an update is found, it will automatically download the latest release, stop the running
+        Ombi process, replace the application files, and restart. You can also use a custom script
+        to handle the update process if you have a non-standard setup.
+    </p>
     <div *ngIf="form">
         <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
             <div class="col-md-12 col-12 col-sm-12">
@@ -12,39 +18,24 @@
                 </div>
 
                 <div *ngIf="form.get('autoUpdateEnabled').value" style="margin-top: 1rem;">
-                    <div>
+                    <div style="padding-bottom: 1.25rem;">
                         <mat-form-field appearance="outline">
                             <mat-label>Check Frequency</mat-label>
-                            <mat-select formControlName="updateSchedule"
-                                matTooltip="How often Ombi checks for new versions.">
+                            <mat-select formControlName="updateSchedule">
                                 <mat-option *ngFor="let opt of scheduleOptions" [value]="opt.value">
                                     {{ opt.label }}
                                 </mat-option>
                             </mat-select>
+                            <mat-hint>How often Ombi checks for new versions.</mat-hint>
                         </mat-form-field>
                     </div>
 
-                    <div>
+                    <div style="padding-bottom: 1.25rem;">
                         <mat-form-field appearance="outline">
                             <mat-label>Process Name</mat-label>
                             <input matInput formControlName="processName"
-                                matTooltip="The name of the Ombi process (default: Ombi). Change this only if you renamed the executable."
                                 placeholder="Ombi">
-                        </mat-form-field>
-                    </div>
-
-                    <div *ngIf="form.get('isWindows').value">
-                        <mat-slide-toggle formControlName="windowsService"
-                            matTooltip="Enable this if Ombi is running as a Windows Service.">
-                            Running as a Windows Service
-                        </mat-slide-toggle>
-                    </div>
-
-                    <div *ngIf="form.get('windowsService').value && form.get('isWindows').value">
-                        <mat-form-field appearance="outline">
-                            <mat-label>Windows Service Name</mat-label>
-                            <input matInput formControlName="windowsServiceName"
-                                placeholder="Ombi">
+                            <mat-hint>The name of the Ombi process. Change this only if you renamed the executable.</mat-hint>
                         </mat-form-field>
                     </div>
 
@@ -59,13 +50,16 @@
                         <mat-form-field appearance="outline">
                             <mat-label>Script Location</mat-label>
                             <input matInput formControlName="scriptLocation"
-                                placeholder="/path/to/update-script.sh">
+                                [placeholder]="form.get('isWindows').value ? 'C:\\scripts\\update.ps1' : '/path/to/update-script.sh'">
                         </mat-form-field>
                     </div>
                 </div>
 
                 <div style="margin-top: 1.5rem;">
                     <h4>Version Information</h4>
+                    <p *ngIf="about">
+                        Current version: <strong>v{{ about.version }}</strong> ({{ about.branch }})
+                    </p>
                     <div *ngIf="updateStatus">
                         <p *ngIf="updateStatus.updateAvailable">
                             <i class="fas fa-exclamation-circle" style="color: #df691a;"></i>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -12,6 +12,7 @@
 
                 <div>
                     <mat-slide-toggle formControlName="autoUpdateEnabled"
+                        (change)="onAutoUpdateToggle()"
                         matTooltip="When enabled, Ombi will automatically download and install updates on the configured schedule.">
                         Enable Auto-Update
                     </mat-slide-toggle>
@@ -62,11 +63,11 @@
                     </p>
                     <div *ngIf="updateStatus">
                         <p *ngIf="updateStatus.updateAvailable">
-                            <i class="fas fa-exclamation-circle" style="color: #df691a;"></i>
+                            <i class="fas fa-exclamation-circle" style="color: #df691a;" aria-hidden="true"></i>
                             Update available: <strong>v{{ updateStatus.updateVersionString }}</strong>
                         </p>
                         <p *ngIf="!updateStatus.updateAvailable">
-                            <i class="far fa-thumbs-up"></i> You are running the latest version.
+                            <i class="far fa-thumbs-up" aria-hidden="true"></i> You are running the latest version.
                         </p>
                     </div>
                     <p>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -1,6 +1,6 @@
 <div class="small-middle-container">
-<fieldset *ngIf="form">
-    <legend>Update Settings</legend>
+<legend>Update</legend>
+<div *ngIf="form">
     <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
         <div class="col-md-12 col-12 col-sm-12">
 
@@ -66,21 +66,20 @@
 
             <div style="margin-top: 1.5rem;">
                 <h4>Version Information</h4>
-                <p *ngIf="currentVersion">Current Version: <strong>{{ currentVersion }}</strong></p>
+                <div *ngIf="updateStatus">
+                    <p>Latest Available: <strong>v{{ updateStatus.updateVersionString }}</strong></p>
+                    <p *ngIf="updateStatus.updateAvailable" style="color: #df691a;">
+                        <i class="fas fa-exclamation-circle"></i> An update is available!
+                    </p>
+                    <p *ngIf="!updateStatus.updateAvailable">
+                        <i class="far fa-thumbs-up"></i> You are running the latest version.
+                    </p>
+                </div>
                 <p>
                     Branch can be configured on the
                     <a routerLink="/Settings/Ombi">General Settings</a>
                     page (Stable or Develop).
                 </p>
-                <div *ngIf="updateStatus">
-                    <p *ngIf="updateStatus.updateAvailable">
-                        Latest Version: <strong>v{{ updateStatus.updateVersionString }}</strong>
-                        — <em>Update available!</em>
-                    </p>
-                    <p *ngIf="!updateStatus.updateAvailable">
-                        You are running the latest version.
-                    </p>
-                </div>
                 <button mat-raised-button type="button" (click)="checkForUpdate()"
                     [disabled]="checkingForUpdate"
                     class="mat-stroked-button">
@@ -97,5 +96,5 @@
             </div>
         </div>
     </form>
-</fieldset>
+</div>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -53,6 +53,9 @@
                                 <mat-label>Script Location</mat-label>
                                 <input matInput formControlName="scriptLocation"
                                     [placeholder]="form.get('isWindows').value ? 'C:\\scripts\\update.ps1' : '/path/to/update-script.sh'">
+                                <mat-error *ngIf="form.get('scriptLocation')?.hasError('required')">
+                                    Script location is required when custom script is enabled.
+                                </mat-error>
                             </mat-form-field>
                         </div>
                     </div>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -65,7 +65,7 @@
                         <p *ngIf="about">
                             Current version: <strong>v{{ about.version }}</strong> ({{ about.branch }})
                         </p>
-                        <div *ngIf="updateStatus">
+                        <div *ngIf="updateStatus" role="status" aria-live="polite">
                             <p *ngIf="updateStatus.updateAvailable">
                                 <i class="fas fa-exclamation-circle" style="color: #df691a;" aria-hidden="true"></i>
                                 Update available: <strong>v{{ updateStatus.updateVersionString }}</strong>
@@ -81,6 +81,7 @@
                         </p>
                         <button mat-raised-button type="button" (click)="checkForUpdate()"
                             [disabled]="checkingForUpdate"
+                            [attr.aria-busy]="checkingForUpdate"
                             class="mat-stroked-button">
                             <i class="fas fa-sync-alt" aria-hidden="true"></i>
                             {{ checkingForUpdate ? 'Checking...' : 'Check for Update Now' }}

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -1,0 +1,101 @@
+<div class="small-middle-container">
+<fieldset *ngIf="form">
+    <legend>Update Settings</legend>
+    <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+        <div class="col-md-12 col-12 col-sm-12">
+
+            <div>
+                <mat-slide-toggle formControlName="autoUpdateEnabled"
+                    matTooltip="When enabled, Ombi will automatically download and install updates on the configured schedule.">
+                    Enable Auto-Update
+                </mat-slide-toggle>
+            </div>
+
+            <div *ngIf="form.get('autoUpdateEnabled').value" style="margin-top: 1rem;">
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>Check Frequency</mat-label>
+                        <mat-select formControlName="updateSchedule"
+                            matTooltip="How often Ombi checks for new versions.">
+                            <mat-option *ngFor="let opt of scheduleOptions" [value]="opt.value">
+                                {{ opt.label }}
+                            </mat-option>
+                        </mat-select>
+                    </mat-form-field>
+                </div>
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>Process Name</mat-label>
+                        <input matInput formControlName="processName"
+                            matTooltip="The name of the Ombi process (default: Ombi). Change this only if you renamed the executable."
+                            placeholder="Ombi">
+                    </mat-form-field>
+                </div>
+
+                <div *ngIf="form.get('isWindows').value">
+                    <mat-slide-toggle formControlName="windowsService"
+                        matTooltip="Enable this if Ombi is running as a Windows Service.">
+                        Running as a Windows Service
+                    </mat-slide-toggle>
+                </div>
+
+                <div *ngIf="form.get('windowsService').value && form.get('isWindows').value">
+                    <mat-form-field appearance="outline">
+                        <mat-label>Windows Service Name</mat-label>
+                        <input matInput formControlName="windowsServiceName"
+                            placeholder="Ombi">
+                    </mat-form-field>
+                </div>
+
+                <div>
+                    <mat-slide-toggle formControlName="useScript"
+                        matTooltip="Use a custom script to handle the update process instead of the built-in updater.">
+                        Use Custom Update Script
+                    </mat-slide-toggle>
+                </div>
+
+                <div *ngIf="form.get('useScript').value">
+                    <mat-form-field appearance="outline">
+                        <mat-label>Script Location</mat-label>
+                        <input matInput formControlName="scriptLocation"
+                            placeholder="/path/to/update-script.sh">
+                    </mat-form-field>
+                </div>
+            </div>
+
+            <div style="margin-top: 1.5rem;">
+                <h4>Version Information</h4>
+                <p *ngIf="currentVersion">Current Version: <strong>{{ currentVersion }}</strong></p>
+                <p>
+                    Branch can be configured on the
+                    <a routerLink="/Settings/Ombi">General Settings</a>
+                    page (Stable or Develop).
+                </p>
+                <div *ngIf="updateStatus">
+                    <p *ngIf="updateStatus.updateAvailable">
+                        Latest Version: <strong>v{{ updateStatus.updateVersionString }}</strong>
+                        — <em>Update available!</em>
+                    </p>
+                    <p *ngIf="!updateStatus.updateAvailable">
+                        You are running the latest version.
+                    </p>
+                </div>
+                <button mat-raised-button type="button" (click)="checkForUpdate()"
+                    [disabled]="checkingForUpdate"
+                    class="mat-stroked-button">
+                    <i class="fas fa-sync-alt" aria-hidden="true"></i>
+                    {{ checkingForUpdate ? 'Checking...' : 'Check for Update Now' }}
+                </button>
+            </div>
+
+            <div class="form-group" style="margin-top: 1.5rem;">
+                <div>
+                    <button mat-raised-button [disabled]="form.invalid" type="submit"
+                        class="mat-stroked-button accent mat-accent">Submit</button>
+                </div>
+            </div>
+        </div>
+    </form>
+</fieldset>
+</div>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -1,100 +1,100 @@
 <div class="small-middle-container">
-<legend>Update</legend>
-<div *ngIf="form">
-    <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
-        <div class="col-md-12 col-12 col-sm-12">
-
-            <div>
-                <mat-slide-toggle formControlName="autoUpdateEnabled"
-                    matTooltip="When enabled, Ombi will automatically download and install updates on the configured schedule.">
-                    Enable Auto-Update
-                </mat-slide-toggle>
-            </div>
-
-            <div *ngIf="form.get('autoUpdateEnabled').value" style="margin-top: 1rem;">
-                <div>
-                    <mat-form-field appearance="outline">
-                        <mat-label>Check Frequency</mat-label>
-                        <mat-select formControlName="updateSchedule"
-                            matTooltip="How often Ombi checks for new versions.">
-                            <mat-option *ngFor="let opt of scheduleOptions" [value]="opt.value">
-                                {{ opt.label }}
-                            </mat-option>
-                        </mat-select>
-                    </mat-form-field>
-                </div>
+    <legend>Update Settings</legend>
+    <div *ngIf="form">
+        <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+            <div class="col-md-12 col-12 col-sm-12">
 
                 <div>
-                    <mat-form-field appearance="outline">
-                        <mat-label>Process Name</mat-label>
-                        <input matInput formControlName="processName"
-                            matTooltip="The name of the Ombi process (default: Ombi). Change this only if you renamed the executable."
-                            placeholder="Ombi">
-                    </mat-form-field>
-                </div>
-
-                <div *ngIf="form.get('isWindows').value">
-                    <mat-slide-toggle formControlName="windowsService"
-                        matTooltip="Enable this if Ombi is running as a Windows Service.">
-                        Running as a Windows Service
+                    <mat-slide-toggle formControlName="autoUpdateEnabled"
+                        matTooltip="When enabled, Ombi will automatically download and install updates on the configured schedule.">
+                        Enable Auto-Update
                     </mat-slide-toggle>
                 </div>
 
-                <div *ngIf="form.get('windowsService').value && form.get('isWindows').value">
-                    <mat-form-field appearance="outline">
-                        <mat-label>Windows Service Name</mat-label>
-                        <input matInput formControlName="windowsServiceName"
-                            placeholder="Ombi">
-                    </mat-form-field>
+                <div *ngIf="form.get('autoUpdateEnabled').value" style="margin-top: 1rem;">
+                    <div>
+                        <mat-form-field appearance="outline">
+                            <mat-label>Check Frequency</mat-label>
+                            <mat-select formControlName="updateSchedule"
+                                matTooltip="How often Ombi checks for new versions.">
+                                <mat-option *ngFor="let opt of scheduleOptions" [value]="opt.value">
+                                    {{ opt.label }}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                    </div>
+
+                    <div>
+                        <mat-form-field appearance="outline">
+                            <mat-label>Process Name</mat-label>
+                            <input matInput formControlName="processName"
+                                matTooltip="The name of the Ombi process (default: Ombi). Change this only if you renamed the executable."
+                                placeholder="Ombi">
+                        </mat-form-field>
+                    </div>
+
+                    <div *ngIf="form.get('isWindows').value">
+                        <mat-slide-toggle formControlName="windowsService"
+                            matTooltip="Enable this if Ombi is running as a Windows Service.">
+                            Running as a Windows Service
+                        </mat-slide-toggle>
+                    </div>
+
+                    <div *ngIf="form.get('windowsService').value && form.get('isWindows').value">
+                        <mat-form-field appearance="outline">
+                            <mat-label>Windows Service Name</mat-label>
+                            <input matInput formControlName="windowsServiceName"
+                                placeholder="Ombi">
+                        </mat-form-field>
+                    </div>
+
+                    <div>
+                        <mat-slide-toggle formControlName="useScript"
+                            matTooltip="Use a custom script to handle the update process instead of the built-in updater.">
+                            Use Custom Update Script
+                        </mat-slide-toggle>
+                    </div>
+
+                    <div *ngIf="form.get('useScript').value">
+                        <mat-form-field appearance="outline">
+                            <mat-label>Script Location</mat-label>
+                            <input matInput formControlName="scriptLocation"
+                                placeholder="/path/to/update-script.sh">
+                        </mat-form-field>
+                    </div>
                 </div>
 
-                <div>
-                    <mat-slide-toggle formControlName="useScript"
-                        matTooltip="Use a custom script to handle the update process instead of the built-in updater.">
-                        Use Custom Update Script
-                    </mat-slide-toggle>
-                </div>
-
-                <div *ngIf="form.get('useScript').value">
-                    <mat-form-field appearance="outline">
-                        <mat-label>Script Location</mat-label>
-                        <input matInput formControlName="scriptLocation"
-                            placeholder="/path/to/update-script.sh">
-                    </mat-form-field>
-                </div>
-            </div>
-
-            <div style="margin-top: 1.5rem;">
-                <h4>Version Information</h4>
-                <div *ngIf="updateStatus">
-                    <p>Latest Available: <strong>v{{ updateStatus.updateVersionString }}</strong></p>
-                    <p *ngIf="updateStatus.updateAvailable" style="color: #df691a;">
-                        <i class="fas fa-exclamation-circle"></i> An update is available!
+                <div style="margin-top: 1.5rem;">
+                    <h4>Version Information</h4>
+                    <div *ngIf="updateStatus">
+                        <p *ngIf="updateStatus.updateAvailable">
+                            <i class="fas fa-exclamation-circle" style="color: #df691a;"></i>
+                            Update available: <strong>v{{ updateStatus.updateVersionString }}</strong>
+                        </p>
+                        <p *ngIf="!updateStatus.updateAvailable">
+                            <i class="far fa-thumbs-up"></i> You are running the latest version.
+                        </p>
+                    </div>
+                    <p>
+                        Branch can be configured on the
+                        <a routerLink="/Settings/Ombi">General Settings</a>
+                        page (Stable or Develop).
                     </p>
-                    <p *ngIf="!updateStatus.updateAvailable">
-                        <i class="far fa-thumbs-up"></i> You are running the latest version.
-                    </p>
+                    <button mat-raised-button type="button" (click)="checkForUpdate()"
+                        [disabled]="checkingForUpdate"
+                        class="mat-stroked-button">
+                        <i class="fas fa-sync-alt" aria-hidden="true"></i>
+                        {{ checkingForUpdate ? 'Checking...' : 'Check for Update Now' }}
+                    </button>
                 </div>
-                <p>
-                    Branch can be configured on the
-                    <a routerLink="/Settings/Ombi">General Settings</a>
-                    page (Stable or Develop).
-                </p>
-                <button mat-raised-button type="button" (click)="checkForUpdate()"
-                    [disabled]="checkingForUpdate"
-                    class="mat-stroked-button">
-                    <i class="fas fa-sync-alt" aria-hidden="true"></i>
-                    {{ checkingForUpdate ? 'Checking...' : 'Check for Update Now' }}
-                </button>
-            </div>
 
-            <div class="form-group" style="margin-top: 1.5rem;">
-                <div>
-                    <button mat-raised-button [disabled]="form.invalid" type="submit"
-                        class="mat-stroked-button accent mat-accent">Submit</button>
+                <div class="form-group" style="margin-top: 1.5rem;" *ngIf="form.get('autoUpdateEnabled').value">
+                    <div>
+                        <button mat-raised-button [disabled]="form.invalid" type="submit"
+                            class="mat-stroked-button accent mat-accent">Save Settings</button>
+                    </div>
                 </div>
             </div>
-        </div>
-    </form>
-</div>
+        </form>
+    </div>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -67,7 +67,7 @@
                         </p>
                         <div *ngIf="updateStatus" role="status" aria-live="polite">
                             <p *ngIf="updateStatus.updateAvailable">
-                                <i class="fas fa-exclamation-circle" style="color: #df691a;" aria-hidden="true"></i>
+                                <i class="fas fa-exclamation-circle update-warning-icon" aria-hidden="true"></i>
                                 Update available: <strong>v{{ updateStatus.updateVersionString }}</strong>
                             </p>
                             <p *ngIf="!updateStatus.updateAvailable">

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.html
@@ -1,95 +1,97 @@
 <div class="small-middle-container">
-    <legend>Update Settings</legend>
-    <p class="description">
-        When auto-update is enabled, Ombi will check for new versions on the configured schedule.
-        If an update is found, it will automatically download the latest release, stop the running
-        Ombi process, replace the application files, and restart. You can also use a custom script
-        to handle the update process if you have a non-standard setup.
-    </p>
-    <div *ngIf="form">
-        <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
-            <div class="col-md-12 col-12 col-sm-12">
-
-                <div>
-                    <mat-slide-toggle formControlName="autoUpdateEnabled"
-                        (change)="onAutoUpdateToggle()"
-                        matTooltip="When enabled, Ombi will automatically download and install updates on the configured schedule.">
-                        Enable Auto-Update
-                    </mat-slide-toggle>
-                </div>
-
-                <div *ngIf="form.get('autoUpdateEnabled').value" style="margin-top: 1rem;">
-                    <div style="padding-bottom: 1.25rem;">
-                        <mat-form-field appearance="outline">
-                            <mat-label>Check Frequency</mat-label>
-                            <mat-select formControlName="updateSchedule">
-                                <mat-option *ngFor="let opt of scheduleOptions" [value]="opt.value">
-                                    {{ opt.label }}
-                                </mat-option>
-                            </mat-select>
-                            <mat-hint>How often Ombi checks for new versions.</mat-hint>
-                        </mat-form-field>
-                    </div>
-
-                    <div style="padding-bottom: 1.25rem;">
-                        <mat-form-field appearance="outline">
-                            <mat-label>Process Name</mat-label>
-                            <input matInput formControlName="processName"
-                                placeholder="Ombi">
-                            <mat-hint>The name of the Ombi process. Change this only if you renamed the executable.</mat-hint>
-                        </mat-form-field>
-                    </div>
+    <fieldset>
+        <legend>Update Settings</legend>
+        <p class="description">
+            When auto-update is enabled, Ombi will check for new versions on the configured schedule.
+            If an update is found, it will automatically download the latest release, stop the running
+            Ombi process, replace the application files, and restart. You can also use a custom script
+            to handle the update process if you have a non-standard setup.
+        </p>
+        <div *ngIf="form">
+            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+                <div class="col-md-12 col-12 col-sm-12">
 
                     <div>
-                        <mat-slide-toggle formControlName="useScript"
-                            matTooltip="Use a custom script to handle the update process instead of the built-in updater.">
-                            Use Custom Update Script
+                        <mat-slide-toggle formControlName="autoUpdateEnabled"
+                            (change)="onAutoUpdateToggle()"
+                            matTooltip="When enabled, Ombi will automatically download and install updates on the configured schedule.">
+                            Enable Auto-Update
                         </mat-slide-toggle>
                     </div>
 
-                    <div *ngIf="form.get('useScript').value">
-                        <mat-form-field appearance="outline">
-                            <mat-label>Script Location</mat-label>
-                            <input matInput formControlName="scriptLocation"
-                                [placeholder]="form.get('isWindows').value ? 'C:\\scripts\\update.ps1' : '/path/to/update-script.sh'">
-                        </mat-form-field>
-                    </div>
-                </div>
+                    <div *ngIf="form.get('autoUpdateEnabled').value" class="section-top">
+                        <div class="field-spacing">
+                            <mat-form-field appearance="outline">
+                                <mat-label>Check Frequency</mat-label>
+                                <mat-select formControlName="updateSchedule">
+                                    <mat-option *ngFor="let opt of scheduleOptions" [value]="opt.value">
+                                        {{ opt.label }}
+                                    </mat-option>
+                                </mat-select>
+                                <mat-hint>How often Ombi checks for new versions.</mat-hint>
+                            </mat-form-field>
+                        </div>
 
-                <div style="margin-top: 1.5rem;">
-                    <h4>Version Information</h4>
-                    <p *ngIf="about">
-                        Current version: <strong>v{{ about.version }}</strong> ({{ about.branch }})
-                    </p>
-                    <div *ngIf="updateStatus">
-                        <p *ngIf="updateStatus.updateAvailable">
-                            <i class="fas fa-exclamation-circle" style="color: #df691a;" aria-hidden="true"></i>
-                            Update available: <strong>v{{ updateStatus.updateVersionString }}</strong>
-                        </p>
-                        <p *ngIf="!updateStatus.updateAvailable">
-                            <i class="far fa-thumbs-up" aria-hidden="true"></i> You are running the latest version.
-                        </p>
-                    </div>
-                    <p>
-                        Branch can be configured on the
-                        <a routerLink="/Settings/Ombi">General Settings</a>
-                        page (Stable or Develop).
-                    </p>
-                    <button mat-raised-button type="button" (click)="checkForUpdate()"
-                        [disabled]="checkingForUpdate"
-                        class="mat-stroked-button">
-                        <i class="fas fa-sync-alt" aria-hidden="true"></i>
-                        {{ checkingForUpdate ? 'Checking...' : 'Check for Update Now' }}
-                    </button>
-                </div>
+                        <div class="field-spacing">
+                            <mat-form-field appearance="outline">
+                                <mat-label>Process Name</mat-label>
+                                <input matInput formControlName="processName"
+                                    placeholder="Ombi">
+                                <mat-hint>The name of the Ombi process. Change this only if you renamed the executable.</mat-hint>
+                            </mat-form-field>
+                        </div>
 
-                <div class="form-group" style="margin-top: 1.5rem;" *ngIf="form.get('autoUpdateEnabled').value">
-                    <div>
-                        <button mat-raised-button [disabled]="form.invalid" type="submit"
-                            class="mat-stroked-button accent mat-accent">Save Settings</button>
+                        <div>
+                            <mat-slide-toggle formControlName="useScript"
+                                matTooltip="Use a custom script to handle the update process instead of the built-in updater.">
+                                Use Custom Update Script
+                            </mat-slide-toggle>
+                        </div>
+
+                        <div *ngIf="form.get('useScript').value">
+                            <mat-form-field appearance="outline">
+                                <mat-label>Script Location</mat-label>
+                                <input matInput formControlName="scriptLocation"
+                                    [placeholder]="form.get('isWindows').value ? 'C:\\scripts\\update.ps1' : '/path/to/update-script.sh'">
+                            </mat-form-field>
+                        </div>
+                    </div>
+
+                    <div class="section-top-lg">
+                        <h4>Version Information</h4>
+                        <p *ngIf="about">
+                            Current version: <strong>v{{ about.version }}</strong> ({{ about.branch }})
+                        </p>
+                        <div *ngIf="updateStatus">
+                            <p *ngIf="updateStatus.updateAvailable">
+                                <i class="fas fa-exclamation-circle" style="color: #df691a;" aria-hidden="true"></i>
+                                Update available: <strong>v{{ updateStatus.updateVersionString }}</strong>
+                            </p>
+                            <p *ngIf="!updateStatus.updateAvailable">
+                                <i class="far fa-thumbs-up" aria-hidden="true"></i> You are running the latest version.
+                            </p>
+                        </div>
+                        <p>
+                            Branch can be configured on the
+                            <a routerLink="/Settings/Ombi">General Settings</a>
+                            page (Stable or Develop).
+                        </p>
+                        <button mat-raised-button type="button" (click)="checkForUpdate()"
+                            [disabled]="checkingForUpdate"
+                            class="mat-stroked-button">
+                            <i class="fas fa-sync-alt" aria-hidden="true"></i>
+                            {{ checkingForUpdate ? 'Checking...' : 'Check for Update Now' }}
+                        </button>
+                    </div>
+
+                    <div class="form-group section-top-lg" *ngIf="form.get('autoUpdateEnabled').value">
+                        <div>
+                            <button mat-raised-button [disabled]="form.invalid" type="submit"
+                                class="mat-stroked-button accent mat-accent">Save Settings</button>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </form>
-    </div>
+            </form>
+        </div>
+    </fieldset>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
@@ -4,3 +4,13 @@
     width: 95%;
     margin-top: 10px;
 }
+
+.description {
+    color: #aaa;
+    margin-bottom: 1.5rem;
+}
+
+mat-form-field {
+    max-width: 300px;
+    margin-bottom: 0.5rem;
+}

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
@@ -5,6 +5,12 @@
     margin-top: 10px;
 }
 
+fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
 .description {
     color: #aaa;
     margin-bottom: 1.5rem;
@@ -13,4 +19,16 @@
 mat-form-field {
     max-width: 300px;
     margin-bottom: 0.5rem;
+}
+
+.section-top {
+    margin-top: 1rem;
+}
+
+.section-top-lg {
+    margin-top: 1.5rem;
+}
+
+.field-spacing {
+    padding-bottom: 1.25rem;
 }

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
@@ -12,8 +12,12 @@ fieldset {
 }
 
 .description {
-    color: #aaa;
+    color: rgba(255, 255, 255, 0.7);
     margin-bottom: 1.5rem;
+}
+
+.update-warning-icon {
+    color: #df691a;
 }
 
 mat-form-field {

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.scss
@@ -1,0 +1,6 @@
+@use "./styles/shared.scss" as *;
+.small-middle-container {
+    margin: auto;
+    width: 95%;
+    margin-top: 10px;
+}

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
@@ -52,11 +52,12 @@ describe('UpdateComponent', () => {
     expect(comp.form.controls['processName'].value).toBe('Ombi');
   });
 
-  it('should load version from update check', () => {
+  it('should load update status from update check', () => {
     const { comp } = createComponent();
     comp.ngOnInit();
-    expect(comp.currentVersion).toBe('4.58.3');
+    expect(comp.updateStatus).toBeDefined();
     expect(comp.updateStatus.updateAvailable).toBe(true);
+    expect(comp.updateStatus.updateVersionString).toBe('4.58.3');
   });
 
   it('should check for update and notify when available', () => {

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
@@ -19,6 +19,10 @@ function createComponent() {
       updateSchedule: '0 0 0/6 1/1 * ? *',
     })),
     saveUpdateSettings: vi.fn().mockReturnValue(of(true)),
+    about: vi.fn().mockReturnValue(of({
+      version: '4.58.3',
+      branch: 'Stable',
+    })),
   };
   const mockUpdateService = {
     checkForUpdate: vi.fn().mockReturnValue(of({

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { UpdateComponent } from './update.component';
+import { UntypedFormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+
+function createComponent() {
+  const mockSettingsService = {
+    getUpdateSettings: vi.fn().mockReturnValue(of({
+      autoUpdateEnabled: false,
+      username: '',
+      password: '',
+      processName: 'Ombi',
+      useScript: false,
+      scriptLocation: '',
+      windowsService: false,
+      windowsServiceName: '',
+      isWindows: true,
+      testMode: false,
+      updateSchedule: '0 0 0/6 1/1 * ? *',
+    })),
+    saveUpdateSettings: vi.fn().mockReturnValue(of(true)),
+    about: vi.fn().mockReturnValue(of({ version: '4.53.4' })),
+  };
+  const mockUpdateService = {
+    checkForUpdate: vi.fn().mockReturnValue(of({
+      updateAvailable: true,
+      updateVersionString: '4.58.3',
+      updateVersion: 0,
+      updateDate: new Date(),
+      changeLogs: '',
+      downloads: [],
+    })),
+  };
+  const fb = new UntypedFormBuilder();
+  const mockNotify = { error: vi.fn(), success: vi.fn() };
+
+  const comp = new UpdateComponent(
+    mockSettingsService as any,
+    mockUpdateService as any,
+    mockNotify as any,
+    fb,
+  );
+  return { comp, mockSettingsService, mockUpdateService, mockNotify };
+}
+
+describe('UpdateComponent', () => {
+  it('should load update settings and build form', () => {
+    const { comp } = createComponent();
+    comp.ngOnInit();
+    expect(comp.form).toBeDefined();
+    expect(comp.form.controls['autoUpdateEnabled'].value).toBe(false);
+    expect(comp.form.controls['updateSchedule'].value).toBe('0 0 0/6 1/1 * ? *');
+    expect(comp.form.controls['processName'].value).toBe('Ombi');
+  });
+
+  it('should load current version from about', () => {
+    const { comp } = createComponent();
+    comp.ngOnInit();
+    expect(comp.currentVersion).toBe('4.53.4');
+  });
+
+  it('should check for update and notify when available', () => {
+    const { comp, mockNotify } = createComponent();
+    comp.ngOnInit();
+    comp.checkForUpdate();
+    expect(comp.updateStatus).toBeDefined();
+    expect(comp.updateStatus.updateAvailable).toBe(true);
+    expect(mockNotify.success).toHaveBeenCalledWith('Update available: v4.58.3');
+  });
+
+  it('should notify when already on latest version', () => {
+    const { comp, mockNotify, mockUpdateService } = createComponent();
+    mockUpdateService.checkForUpdate.mockReturnValue(of({
+      updateAvailable: false,
+      updateVersionString: '4.53.4',
+      updateVersion: 0,
+      updateDate: new Date(),
+      changeLogs: '',
+      downloads: [],
+    }));
+    comp.ngOnInit();
+    comp.checkForUpdate();
+    expect(mockNotify.success).toHaveBeenCalledWith('You are running the latest version.');
+  });
+
+  it('should save settings and notify success', () => {
+    const { comp, mockNotify } = createComponent();
+    comp.ngOnInit();
+    comp.onSubmit(comp.form);
+    expect(mockNotify.success).toHaveBeenCalledWith('Successfully saved Update settings');
+  });
+
+  it('should notify error on save failure', () => {
+    const { comp, mockNotify, mockSettingsService } = createComponent();
+    mockSettingsService.saveUpdateSettings.mockReturnValue(of(false));
+    comp.ngOnInit();
+    comp.onSubmit(comp.form);
+    expect(mockNotify.error).toHaveBeenCalledWith('There was an error when saving the Update settings');
+  });
+
+  it('should not submit when form is invalid', () => {
+    const { comp, mockNotify, mockSettingsService } = createComponent();
+    comp.ngOnInit();
+    // Force form invalid
+    Object.defineProperty(comp.form, 'invalid', { get: () => true });
+    comp.onSubmit(comp.form);
+    expect(mockNotify.error).toHaveBeenCalledWith('Please check your entered values');
+    expect(mockSettingsService.saveUpdateSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.spec.ts
@@ -19,7 +19,6 @@ function createComponent() {
       updateSchedule: '0 0 0/6 1/1 * ? *',
     })),
     saveUpdateSettings: vi.fn().mockReturnValue(of(true)),
-    about: vi.fn().mockReturnValue(of({ version: '4.53.4' })),
   };
   const mockUpdateService = {
     checkForUpdate: vi.fn().mockReturnValue(of({
@@ -53,10 +52,11 @@ describe('UpdateComponent', () => {
     expect(comp.form.controls['processName'].value).toBe('Ombi');
   });
 
-  it('should load current version from about', () => {
+  it('should load version from update check', () => {
     const { comp } = createComponent();
     comp.ngOnInit();
-    expect(comp.currentVersion).toBe('4.53.4');
+    expect(comp.currentVersion).toBe('4.58.3');
+    expect(comp.updateStatus.updateAvailable).toBe(true);
   });
 
   it('should check for update and notify when available', () => {

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -9,6 +9,7 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
+import { finalize } from "rxjs/operators";
 
 import { IUpdateSettings, IUpdateModel, IAbout } from "../../interfaces";
 import { NotificationService, SettingsService } from "../../services";
@@ -84,7 +85,9 @@ export class UpdateComponent implements OnInit {
 
     public checkForUpdate() {
         this.checkingForUpdate = true;
-        this.updateService.checkForUpdate().subscribe({
+        this.updateService.checkForUpdate().pipe(
+            finalize(() => this.checkingForUpdate = false)
+        ).subscribe({
             next: x => {
                 this.updateStatus = x;
                 if (x.updateAvailable) {
@@ -95,9 +98,6 @@ export class UpdateComponent implements OnInit {
             },
             error: () => {
                 this.notificationService.error("Unable to check for updates right now.");
-            },
-            complete: () => {
-                this.checkingForUpdate = false;
             }
         });
     }

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { UntypedFormBuilder, UntypedFormGroup, ReactiveFormsModule } from "@angular/forms";
+import { UntypedFormBuilder, UntypedFormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import { CommonModule } from "@angular/common";
 import { RouterModule } from "@angular/router";
 import { MatButtonModule } from "@angular/material/button";
@@ -62,11 +62,21 @@ export class UpdateComponent implements OnInit {
                 updateSchedule: [x.updateSchedule || this.scheduleOptions[0].value],
                 processName: [x.processName || 'Ombi'],
                 useScript: [x.useScript],
-                scriptLocation: [x.scriptLocation],
+                scriptLocation: [x.scriptLocation, x.useScript ? Validators.required : []],
                 windowsService: [x.windowsService],
                 windowsServiceName: [x.windowsServiceName],
                 testMode: [x.testMode],
                 isWindows: [{ value: x.isWindows, disabled: true }],
+            });
+
+            this.form.get("useScript").valueChanges.subscribe(useScript => {
+                const scriptLocation = this.form.get("scriptLocation");
+                if (useScript) {
+                    scriptLocation.setValidators(Validators.required);
+                } else {
+                    scriptLocation.clearValidators();
+                }
+                scriptLocation.updateValueAndValidity();
             });
         });
 
@@ -103,6 +113,11 @@ export class UpdateComponent implements OnInit {
     }
 
     private saveSettings() {
+        this.form.get("scriptLocation").markAsTouched();
+        if (this.form.invalid) {
+            this.notificationService.error("Please fix validation errors before saving.");
+            return;
+        }
         const merged = { ...this.settings, ...this.form.value };
         this.settingsService.saveUpdateSettings(merged).subscribe(result => {
             if (result) {

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -35,7 +35,6 @@ export class UpdateComponent implements OnInit {
 
     public form: UntypedFormGroup;
     public updateStatus: IUpdateModel;
-    public currentVersion: string;
     public checkingForUpdate = false;
 
     public scheduleOptions = [
@@ -65,11 +64,20 @@ export class UpdateComponent implements OnInit {
                 testMode: [x.testMode],
                 isWindows: [{ value: x.isWindows, disabled: true }],
             });
+
+            this.form.get('autoUpdateEnabled').valueChanges.subscribe(() => {
+                this.settingsService.saveUpdateSettings(this.form.value).subscribe(result => {
+                    if (result) {
+                        this.notificationService.success("Successfully saved Update settings");
+                    } else {
+                        this.notificationService.error("There was an error when saving the Update settings");
+                    }
+                });
+            });
         });
 
         this.updateService.checkForUpdate().subscribe(x => {
             this.updateStatus = x;
-            this.currentVersion = x.updateVersionString;
         });
     }
 

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -37,6 +37,7 @@ export class UpdateComponent implements OnInit {
     public updateStatus: IUpdateModel;
     public about: IAbout;
     public checkingForUpdate = false;
+    private settings: IUpdateSettings;
 
     public scheduleOptions = [
         { label: "Every 6 Hours", value: "0 0 0/6 1/1 * ? *" },
@@ -54,6 +55,7 @@ export class UpdateComponent implements OnInit {
 
     public ngOnInit() {
         this.settingsService.getUpdateSettings().subscribe(x => {
+            this.settings = x;
             this.form = this.fb.group({
                 autoUpdateEnabled: [x.autoUpdateEnabled],
                 updateSchedule: [x.updateSchedule || this.scheduleOptions[0].value],
@@ -64,16 +66,6 @@ export class UpdateComponent implements OnInit {
                 windowsServiceName: [x.windowsServiceName],
                 testMode: [x.testMode],
                 isWindows: [{ value: x.isWindows, disabled: true }],
-            });
-
-            this.form.get('autoUpdateEnabled').valueChanges.subscribe(() => {
-                this.settingsService.saveUpdateSettings(this.form.value).subscribe(result => {
-                    if (result) {
-                        this.notificationService.success("Successfully saved Update settings");
-                    } else {
-                        this.notificationService.error("There was an error when saving the Update settings");
-                    }
-                });
             });
         });
 
@@ -86,15 +78,37 @@ export class UpdateComponent implements OnInit {
         });
     }
 
+    public onAutoUpdateToggle() {
+        this.saveSettings();
+    }
+
     public checkForUpdate() {
         this.checkingForUpdate = true;
-        this.updateService.checkForUpdate().subscribe(x => {
-            this.updateStatus = x;
-            this.checkingForUpdate = false;
-            if (x.updateAvailable) {
-                this.notificationService.success(`Update available: v${x.updateVersionString}`);
+        this.updateService.checkForUpdate().subscribe({
+            next: x => {
+                this.updateStatus = x;
+                if (x.updateAvailable) {
+                    this.notificationService.success(`Update available: v${x.updateVersionString}`);
+                } else {
+                    this.notificationService.success("You are running the latest version.");
+                }
+            },
+            error: () => {
+                this.notificationService.error("Unable to check for updates right now.");
+            },
+            complete: () => {
+                this.checkingForUpdate = false;
+            }
+        });
+    }
+
+    private saveSettings() {
+        const merged = { ...this.settings, ...this.form.value };
+        this.settingsService.saveUpdateSettings(merged).subscribe(result => {
+            if (result) {
+                this.notificationService.success("Successfully saved Update settings");
             } else {
-                this.notificationService.success("You are running the latest version.");
+                this.notificationService.error("There was an error when saving the Update settings");
             }
         });
     }
@@ -105,12 +119,6 @@ export class UpdateComponent implements OnInit {
             return;
         }
 
-        this.settingsService.saveUpdateSettings(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved Update settings");
-            } else {
-                this.notificationService.error("There was an error when saving the Update settings");
-            }
-        });
+        this.saveSettings();
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit } from "@angular/core";
+import { UntypedFormBuilder, UntypedFormGroup, ReactiveFormsModule } from "@angular/forms";
+import { CommonModule } from "@angular/common";
+import { RouterModule } from "@angular/router";
+import { MatButtonModule } from "@angular/material/button";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
+import { MatSlideToggleModule } from "@angular/material/slide-toggle";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { TranslateModule } from "@ngx-translate/core";
+
+import { IUpdateSettings, IUpdateModel } from "../../interfaces";
+import { NotificationService, SettingsService } from "../../services";
+import { UpdateService } from "../../services/update.service";
+
+@Component({
+    standalone: true,
+    imports: [
+        CommonModule,
+        RouterModule,
+        ReactiveFormsModule,
+        MatButtonModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatSlideToggleModule,
+        MatTooltipModule,
+        TranslateModule,
+    ],
+    templateUrl: "./update.component.html",
+    styleUrls: ["./update.component.scss"],
+})
+export class UpdateComponent implements OnInit {
+
+    public form: UntypedFormGroup;
+    public updateStatus: IUpdateModel;
+    public currentVersion: string;
+    public checkingForUpdate = false;
+
+    public scheduleOptions = [
+        { label: "Every 6 Hours", value: "0 0 0/6 1/1 * ? *" },
+        { label: "Every 12 Hours", value: "0 0 0/12 1/1 * ? *" },
+        { label: "Daily", value: "0 0 3 1/1 * ? *" },
+        { label: "Weekly", value: "0 0 3 ? * MON *" },
+    ];
+
+    constructor(
+        private settingsService: SettingsService,
+        private updateService: UpdateService,
+        private notificationService: NotificationService,
+        private fb: UntypedFormBuilder
+    ) {}
+
+    public ngOnInit() {
+        this.settingsService.getUpdateSettings().subscribe(x => {
+            this.form = this.fb.group({
+                autoUpdateEnabled: [x.autoUpdateEnabled],
+                updateSchedule: [x.updateSchedule || this.scheduleOptions[0].value],
+                processName: [x.processName],
+                useScript: [x.useScript],
+                scriptLocation: [x.scriptLocation],
+                windowsService: [x.windowsService],
+                windowsServiceName: [x.windowsServiceName],
+                testMode: [x.testMode],
+                isWindows: [{ value: x.isWindows, disabled: true }],
+            });
+        });
+
+        this.settingsService.about().subscribe(x => {
+            this.currentVersion = x.version;
+        });
+    }
+
+    public checkForUpdate() {
+        this.checkingForUpdate = true;
+        this.updateService.checkForUpdate().subscribe(x => {
+            this.updateStatus = x;
+            this.checkingForUpdate = false;
+            if (x.updateAvailable) {
+                this.notificationService.success(`Update available: v${x.updateVersionString}`);
+            } else {
+                this.notificationService.success("You are running the latest version.");
+            }
+        });
+    }
+
+    public onSubmit(form: UntypedFormGroup) {
+        if (form.invalid) {
+            this.notificationService.error("Please check your entered values");
+            return;
+        }
+
+        this.settingsService.saveUpdateSettings(form.value).subscribe(x => {
+            if (x) {
+                this.notificationService.success("Successfully saved Update settings");
+            } else {
+                this.notificationService.error("There was an error when saving the Update settings");
+            }
+        });
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -10,7 +10,7 @@ import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
 
-import { IUpdateSettings, IUpdateModel } from "../../interfaces";
+import { IUpdateSettings, IUpdateModel, IAbout } from "../../interfaces";
 import { NotificationService, SettingsService } from "../../services";
 import { UpdateService } from "../../services/update.service";
 
@@ -35,6 +35,7 @@ export class UpdateComponent implements OnInit {
 
     public form: UntypedFormGroup;
     public updateStatus: IUpdateModel;
+    public about: IAbout;
     public checkingForUpdate = false;
 
     public scheduleOptions = [
@@ -56,7 +57,7 @@ export class UpdateComponent implements OnInit {
             this.form = this.fb.group({
                 autoUpdateEnabled: [x.autoUpdateEnabled],
                 updateSchedule: [x.updateSchedule || this.scheduleOptions[0].value],
-                processName: [x.processName],
+                processName: [x.processName || 'Ombi'],
                 useScript: [x.useScript],
                 scriptLocation: [x.scriptLocation],
                 windowsService: [x.windowsService],
@@ -78,6 +79,10 @@ export class UpdateComponent implements OnInit {
 
         this.updateService.checkForUpdate().subscribe(x => {
             this.updateStatus = x;
+        });
+
+        this.settingsService.about().subscribe(x => {
+            this.about = x;
         });
     }
 

--- a/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/update/update.component.ts
@@ -67,8 +67,9 @@ export class UpdateComponent implements OnInit {
             });
         });
 
-        this.settingsService.about().subscribe(x => {
-            this.currentVersion = x.version;
+        this.updateService.checkForUpdate().subscribe(x => {
+            this.updateStatus = x;
+            this.currentVersion = x.updateVersionString;
         });
     }
 

--- a/src/Ombi/Controllers/V1/SettingsController.cs
+++ b/src/Ombi/Controllers/V1/SettingsController.cs
@@ -143,7 +143,7 @@ namespace Ombi.Controllers.V1
             var productArray = version.Split('-');
             model.Version = productArray[0];
             var ombiSettings = await Get<OmbiSettings>();
-            model.Branch = ombiSettings.Branch.ToString();
+            model.Branch = ombiSettings?.Branch.ToString() ?? "Stable";
             return model;
         }
 

--- a/src/Ombi/Controllers/V1/SettingsController.cs
+++ b/src/Ombi/Controllers/V1/SettingsController.cs
@@ -120,7 +120,7 @@ namespace Ombi.Controllers.V1
         }
 
         [HttpGet("about")]
-        public AboutViewModel About()
+        public async Task<AboutViewModel> About()
         {
             var dbConfiguration = DatabaseExtensions.GetDatabaseConfiguration();
             var storage = StartupSingleton.Instance;
@@ -142,7 +142,8 @@ namespace Ombi.Controllers.V1
             var version = AssemblyHelper.GetRuntimeVersion();
             var productArray = version.Split('-');
             model.Version = productArray[0];
-            //model.Branch = productArray[1];
+            var ombiSettings = await Get<OmbiSettings>();
+            model.Branch = ombiSettings.Branch.ToString();
             return model;
         }
 

--- a/src/Ombi/Ombi.csproj
+++ b/src/Ombi/Ombi.csproj
@@ -121,4 +121,9 @@
     </ItemGroup>
   </Target>
 
+  <!-- Include version.json in build and publish output -->
+  <ItemGroup>
+    <None Include="..\..\version.json" CopyToOutputDirectory="PreserveNewest" Link="version.json" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Adds a new **Update Settings** page (/Settings/Update) with a polished UI for configuring Ombi's auto-update behavior. This addresses the feature request in #1460.

## Changes

### New Settings Page
- **Enable Auto-Update** toggle that auto-saves immediately when toggled
- **Check Frequency** dropdown (Every 6 Hours, Every 12 Hours, Daily, Weekly)
- **Process Name** field with sensible default (\Ombi\)
- **Custom Update Script** toggle with platform-aware script path placeholder
- **Save Settings** button (only shown when auto-update is enabled)

### Version Information Section
- Displays current Ombi version and branch (Stable/Develop)
- Check for Update button with loading state
- Link to General Settings for branch configuration

### UI Polish
- Explanatory description text at top of page
- \mat-hint\ text under form fields instead of hover tooltips
- Constrained field widths (300px max) for cleaner layout
- Removed non-functional 'Running as a Windows Service' toggle (the \
et stop\/\
et start\ code was commented out in the updater)

### Backend
- Populated \Branch\ field in the About endpoint from OmbiSettings (was previously commented out)

## Related Issue
Closes #1460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update settings page with form, “Check for Update Now” and version information
  * Settings route and System menu entry for “Update”
  * Configurable update check schedule (cron expression) exposed in UI

* **Improvements**
  * Admin notifications for update availability, download start and auto-update failures
  * Runtime version falls back to packaged version.json when appropriate
  * Scheduler uses configured or default cron schedule

* **Bug Fixes**
  * Installer file operations more resilient with retry and delay logic

* **Tests**
  * Unit tests added for the Update settings component
<!-- end of auto-generated comment: release notes by coderabbit.ai -->