### PR TITLE
fix: restore TV details hero Request button behavior

### DIFF
--- a/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.ts
+++ b/src/Ombi/ClientApp/src/app/media-details/components/tv/tv-details.component.ts
@@ -134,6 +134,13 @@ export class TvDetailsComponent implements OnInit {
         }
     }
 
+    public request() {
+        const grid = document.getElementById("requests-grid");
+        if (grid) {
+            grid.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+    }
+
     public async issue() {
         const dialogRef = this.dialog.open(NewIssueComponent, {
             width: '500px',


### PR DESCRIPTION
The redesigned hero added (click)="request()" but the request() method had been removed earlier when the request UX moved into the grid below, so clicking the button silently did nothing. Wire it to scroll to the new request grid section instead.

Fixes #5395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added smooth scrolling to the requests section in the TV details view for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->