### PR TITLE
fix: reset sqlite_sequence after cache table deletes to prevent Int32 overflow

### DIFF
--- a/src/Ombi.Schedule/Jobs/Radarr/RadarrSync.cs
+++ b/src/Ombi.Schedule/Jobs/Radarr/RadarrSync.cs
@@ -43,6 +43,8 @@ namespace Ombi.Schedule.Jobs.Radarr
                 // Let's remove the old cached data
                 using var tran = await _ctx.Database.BeginTransactionAsync();
                 await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM RadarrCache");
+                // Reset auto-increment to prevent Int32 overflow (see #5224)
+                await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM sqlite_sequence WHERE name = 'RadarrCache'");
                 await tran.CommitAsync();
 
                 var radarrSettings = _radarrSettings.GetSettingsAsync();

--- a/src/Ombi.Schedule/Jobs/Sonarr/SonarrSync.cs
+++ b/src/Ombi.Schedule/Jobs/Sonarr/SonarrSync.cs
@@ -69,6 +69,8 @@ namespace Ombi.Schedule.Jobs.Sonarr
                     {
                         using var tran = await _ctx.Database.BeginTransactionAsync();
                         await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM SonarrCache");
+                        // Reset auto-increment to prevent Int32 overflow (see #5224)
+                        await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM sqlite_sequence WHERE name = 'SonarrCache'");
                         await tran.CommitAsync();
                     });
 
@@ -97,6 +99,8 @@ namespace Ombi.Schedule.Jobs.Sonarr
                     {
                         using var tran = await _ctx.Database.BeginTransactionAsync();
                         await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM SonarrEpisodeCache");
+                        // Reset auto-increment to prevent Int32 overflow (see #5224)
+                        await _ctx.Database.ExecuteSqlRawAsync("DELETE FROM sqlite_sequence WHERE name = 'SonarrEpisodeCache'");
                         await tran.CommitAsync();
                     });
 


### PR DESCRIPTION
## Summary

Fixes #5224

The Sonarr and Radarr sync jobs use a delete-all-then-reinsert pattern for their cache tables (`SonarrCache`, `SonarrEpisodeCache`, `RadarrCache`). SQLite does not reset the auto-increment counter (`sqlite_sequence`) when rows are deleted via `DELETE FROM`, so repeated sync cycles cause the rowid to grow unboundedly until it overflows `Int32` (`2,147,483,647`).

This causes the sync to crash with:
```
System.OverflowException: Arithmetic operation resulted in an overflow.
  at Microsoft.Data.Sqlite.SqliteDataReader.GetInt32(Int32 ordinal)
```

## Root Cause

Each sync cycle:
1. Deletes all rows from the cache table
2. Re-inserts all rows

But `DELETE FROM` does **not** reset `sqlite_sequence`, so IDs keep incrementing across cycles. With ~10k episodes syncing every 15 minutes, the counter reaches Int32 max after roughly 3-4 years of uptime.

## Fix

After each `DELETE` operation, reset the `sqlite_sequence` entry for the affected table:

- **SonarrCache** (bulk delete): `DELETE FROM sqlite_sequence WHERE name = 'SonarrCache'`
- **SonarrEpisodeCache** (per-series delete): `UPDATE sqlite_sequence SET seq = (SELECT COALESCE(MAX(Id), 0) FROM SonarrEpisodeCache) WHERE name = 'SonarrEpisodeCache'` — uses `MAX(Id)` since this is a partial delete, not a full wipe
- **RadarrCache** (bulk delete): `DELETE FROM sqlite_sequence WHERE name = 'RadarrCache'`

## Testing

Reproduced and verified on an Ombi instance installed since August 2022:
- `SonarrEpisodeCache` sqlite_sequence had reached exactly `2,147,483,647`
- `RadarrCache` was at `1,082,130,259` (on track to overflow)
- After applying the fix and resetting the sequences, the Sonarr sync resumed successfully