### PR TITLE
fix(plex): migrate legacy numeric provider ids during watchlist import

### DIFF
--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -577,6 +577,25 @@ namespace Ombi.Schedule.Tests
             _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, AdminUuid, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
+        [Test]
+        public async Task BannedByLegacyNumericId_IsSkipped()
+        {
+            // PlexUserImporter stores the numeric plex.tv id in BannedPlexUserIds when an admin
+            // bans a user. The watchlist importer sees UUIDs from the community API, so the ban
+            // check has to accept either id shape or numeric bans silently let the user through.
+            const string numericId = "555444";
+            _mocker.Setup<ISettingsService<UserManagementSettings>, Task<UserManagementSettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new UserManagementSettings { BannedPlexUserIds = new List<string> { numericId } });
+            UseDefaultPlexSettings();
+            SetupFriends(("banned-uuid", "bannedbyname"));
+            SetupLegacyUsers((numericId, "bannedbyname"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "banned-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
+        }
+
         private static void SetupAdminRole(Mock<OmbiUserManager> mgr, string adminUserId)
         {
             mgr.Setup(x => x.IsInRoleAsync(It.Is<OmbiUser>(u => u.Id == adminUserId), OmbiRoles.Admin))

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -293,12 +293,17 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
-        public async Task ExistingFriendWithLegacyNumericProviderId_IsMigratedAndImported()
+        public async Task ExistingFriendWithLegacyNumericProviderId_IsAdoptedWithoutRewritingProviderUserId()
         {
+            // Regression for https://github.com/Ombi-app/Ombi/issues/5399.
             // User was previously imported via the legacy /api/users path, which stores the
-            // numeric plex.tv account id in ProviderUserId. The community API now returns a
-            // UUID for the same user — the import must adopt that record, not skip it as a
-            // collision (https://github.com/Ombi-app/Ombi/issues/5399).
+            // numeric plex.tv account id in ProviderUserId. The community API returns a UUID
+            // for the same user. The import must:
+            //   * adopt the existing row by username (no duplicate, no skip),
+            //   * leave ProviderUserId untouched so /Token/plextoken (which matches on the
+            //     numeric id) keeps working,
+            //   * sync the watchlist against the community UUID,
+            //   * not mark the user as NotAFriend in the post-run sweep.
             const string legacyNumericId = "12345678";
             const string communityUuid = "friend-uuid";
             var users = new List<OmbiUser>
@@ -315,36 +320,17 @@ namespace Ombi.Schedule.Tests
 
             await _subject.Execute(_context.Object);
 
-            // The existing user should be updated to carry the community UUID, not duplicated.
             _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
-            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.Is<OmbiUser>(u => u.Id == "legacy-id" && u.ProviderUserId == communityUuid)), Times.Once);
+            // Crucially: do not rewrite ProviderUserId on the legacy row — that would break
+            // /api/v1/Token/plextoken which still resolves users by numeric plex.tv id.
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.Is<OmbiUser>(u => u.Id == "legacy-id")), Times.Never);
+            Assert.That(users.Single(u => u.Id == "legacy-id").ProviderUserId, Is.EqualTo(legacyNumericId));
 
-            // And the watchlist should actually sync for them, against the community UUID.
+            // Watchlist syncs against the community UUID, not the stored numeric id.
             _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, communityUuid, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
             _statusStore.Verify(x => x.SetAsync("legacy-id", WatchlistSyncStatus.Successful, It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [Test]
-        public async Task ExistingFriendUsernameCollisionWithDifferentUuid_IsSkipped()
-        {
-            // If a username collides with an existing user that already has a proper
-            // community UUID stored, we must NOT hijack that user — we skip the new one.
-            var users = new List<OmbiUser>
-            {
-                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
-                new OmbiUser { Id = "other-id", UserName = "duplicate", NormalizedUserName = "DUPLICATE", UserType = UserType.PlexUser, ProviderUserId = "real-uuid-for-other" },
-            };
-            var userMgr = MockHelper.MockUserManager(users);
-            SetupAdminRole(userMgr, AdminOmbiId);
-            _mocker.Use(userMgr);
-            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
-            UseDefaultPlexSettings();
-            SetupFriends(("different-uuid", "duplicate"));
-
-            await _subject.Execute(_context.Object);
-
-            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.IsAny<OmbiUser>()), Times.Never);
-            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "different-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            // And the post-run sweep must not mislabel a user we just synced.
+            _statusStore.Verify(x => x.SetAsync("legacy-id", WatchlistSyncStatus.NotAFriend, It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -259,6 +259,7 @@ namespace Ombi.Schedule.Tests
         {
             UseDefaultPlexSettings();
             SetupFriends(("friend-uuid", "friend"));
+            SetupLegacyUsers(("12345", "friend"));
 
             await _subject.Execute(_context.Object);
 
@@ -270,6 +271,7 @@ namespace Ombi.Schedule.Tests
         {
             UseDefaultPlexSettings();
             SetupFriends(("friend-uuid", "some-friend"));
+            SetupLegacyUsers(("54321", "some-friend"));
             _mocker.Setup<IPlexApi, Task<PlexCommunityWatchlistResponse>>(x => x.GetWatchlistForUser(AdminToken, "friend-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new PlexCommunityWatchlistResponse
                 {
@@ -283,18 +285,22 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
-        public async Task NewFriendNotInLegacyUsersList_IsCreatedWithCommunityUuidFallback()
+        public async Task CommunityOnlyFriendNotInLegacyUsersList_IsSkipped()
         {
             // /api/users only contains friends with server-share access. A community-only
-            // friend won't be in there, so we have no numeric id to use; fall back to the
-            // community UUID rather than skip the user.
+            // friend isn't there, so we have no numeric plex.tv id and no way to make their
+            // row participate in PlexUserImporter cleanup, /Token/plextoken auth, etc.
+            // Auto-creating them would lead to PlexUserImporter.CleanupPlexUsers deleting
+            // them on its next run. Skip them entirely; ask the operator to share the server
+            // with the friend if they want their watchlist synced.
             UseDefaultPlexSettings();
             SetupFriends(("brand-new", "newbie"));
             // Default _plexApi.GetUsers mock returns null — friend not in legacy list.
 
             await _subject.Execute(_context.Object);
 
-            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.Is<OmbiUser>(u => u.UserName == "newbie" && u.ProviderUserId == "brand-new" && u.UserType == UserType.PlexUser)), Times.Once);
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "brand-new", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]
@@ -338,6 +344,36 @@ namespace Ombi.Schedule.Tests
             await _subject.Execute(_context.Object);
 
             _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.Is<OmbiUser>(u => u.UserName == "owner-account" && u.ProviderUserId == "11223344" && u.UserType == UserType.PlexUser)), Times.Once);
+        }
+
+        [Test]
+        public async Task ExistingFriendWhoRenamedPlexAccount_IsAdoptedNotDuplicated()
+        {
+            // A Plex user previously imported with ProviderUserId = "12345" and UserName
+            // = "oldname" later changes their plex.tv username to "newname". The community
+            // API now reports them with the new username, and /api/users still maps newname
+            // -> "12345". Without resolving the numeric id up-front and matching on either
+            // the UUID or the numeric id, we'd miss the existing row (no UUID match, no
+            // username match) and create a second row pointing at the same "12345".
+            const string numericId = "12345";
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "renamed-id", UserName = "oldname", NormalizedUserName = "OLDNAME", UserType = UserType.PlexUser, ProviderUserId = numericId },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends(("renamed-uuid", "newname"));
+            SetupLegacyUsers((numericId, "newname"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "renamed-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _statusStore.Verify(x => x.SetAsync("renamed-id", WatchlistSyncStatus.Successful, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -334,6 +334,88 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
+        public async Task ExistingFriendUsernameCollisionWithDifferentUuid_IsSkipped()
+        {
+            // A row already bound to a non-numeric (community-style) ProviderUserId that
+            // doesn't match the incoming community id is a real collision (e.g. a Plex
+            // username was reused after the original account was deleted). We must not
+            // hijack the existing row, and we must not sync against the new uuid.
+            // The sweep should also leave the row alone: the username does appear in the
+            // target list (a different Plex account happens to have it), so flipping the
+            // existing row to NotAFriend would be incorrect — it's a different question
+            // from "is this exact account still a friend".
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "other-id", UserName = "duplicate", NormalizedUserName = "DUPLICATE", UserType = UserType.PlexUser, ProviderUserId = "real-uuid-for-other" },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends(("different-uuid", "duplicate"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "different-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            _statusStore.Verify(x => x.SetAsync("other-id", WatchlistSyncStatus.NotAFriend, It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task BannedFriendWithExistingOmbiRow_IsNotMarkedNotAFriend()
+        {
+            // EnsureOmbiUser returns null for banned ids, so the row never lands in
+            // matchedUserIds. The sweep must still recognise the user as a current friend
+            // via the target list and leave the row alone — banned ≠ unfriended.
+            const string bannedUuid = "banned-uuid";
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "banned-id", UserName = "bannedfriend", NormalizedUserName = "BANNEDFRIEND", UserType = UserType.PlexUser, ProviderUserId = bannedUuid },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _mocker.Setup<ISettingsService<UserManagementSettings>, Task<UserManagementSettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new UserManagementSettings { BannedPlexUserIds = new List<string> { bannedUuid } });
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends((bannedUuid, "bannedfriend"));
+
+            await _subject.Execute(_context.Object);
+
+            _statusStore.Verify(x => x.SetAsync("banned-id", WatchlistSyncStatus.NotAFriend, It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task CancelledRun_DoesNotSweepNotAFriend()
+        {
+            // If the run is cancelled mid-loop, matchedUserIds may be incomplete. The sweep
+            // must not run, otherwise valid friends that weren't yet processed get mislabelled.
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "friend-id", UserName = "friend", NormalizedUserName = "FRIEND", UserType = UserType.PlexUser, ProviderUserId = "friend-uuid" },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends(("friend-uuid", "friend"));
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            _context.Setup(x => x.CancellationToken).Returns(cts.Token);
+
+            await _subject.Execute(_context.Object);
+
+            _statusStore.Verify(x => x.SetAsync(It.IsAny<string>(), WatchlistSyncStatus.NotAFriend, It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
         public async Task PreExistingPlexUser_NotInAllFriendsV2_IsMarkedNotAFriend()
         {
             // Seed an additional Plex user that no target will match (their ProviderUserId

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Ombi.Api.External.MediaServers.Plex;
 using Ombi.Api.External.MediaServers.Plex.Models;
 using Ombi.Api.External.MediaServers.Plex.Models.Community;
+using Ombi.Api.External.MediaServers.Plex.Models.Friends;
 using Ombi.Core.Authentication;
 using Ombi.Core.Engine;
 using Ombi.Core.Engine.Interfaces;
@@ -282,14 +283,61 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
-        public async Task NewFriendWithoutOmbiUser_IsCreated()
+        public async Task NewFriendNotInLegacyUsersList_IsCreatedWithCommunityUuidFallback()
         {
+            // /api/users only contains friends with server-share access. A community-only
+            // friend won't be in there, so we have no numeric id to use; fall back to the
+            // community UUID rather than skip the user.
             UseDefaultPlexSettings();
             SetupFriends(("brand-new", "newbie"));
+            // Default _plexApi.GetUsers mock returns null — friend not in legacy list.
 
             await _subject.Execute(_context.Object);
 
             _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.Is<OmbiUser>(u => u.UserName == "newbie" && u.ProviderUserId == "brand-new" && u.UserType == UserType.PlexUser)), Times.Once);
+        }
+
+        [Test]
+        public async Task NewFriendInLegacyUsersList_IsCreatedWithNumericPlexId()
+        {
+            // The community API returns a UUID for friends, but the rest of Ombi
+            // (PlexUserImporter, GetOmbiUserFromPlexToken, the wizard) keys on the numeric
+            // plex.tv id. When /api/users gives us the numeric id for this username we use
+            // it, so the new row stays consistent with everything else.
+            UseDefaultPlexSettings();
+            SetupFriends(("community-uuid", "newbie"));
+            SetupLegacyUsers(("99887766", "newbie"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.Is<OmbiUser>(u => u.UserName == "newbie" && u.ProviderUserId == "99887766" && u.UserType == UserType.PlexUser)), Times.Once);
+            // The watchlist call still uses the community UUID — that's the API's id space.
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "community-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task AdminWithoutPriorOmbiRow_IsCreatedWithNumericPlexId()
+        {
+            // GetAccount returns both the UUID and the numeric id for the admin. The new
+            // admin row should be created with the numeric id so /Token/plextoken works
+            // for them on first login.
+            var users = new List<OmbiUser>
+            {
+                // Some other admin sourced the OAuth token, but the plex.tv account being
+                // resolved doesn't yet have an Ombi row by username.
+                new OmbiUser { Id = AdminOmbiId, UserName = "tokenholder", NormalizedUserName = "TOKENHOLDER", UserType = UserType.PlexUser, ProviderUserId = "tokenholder-uuid", MediaServerToken = AdminToken },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _mocker.Setup<IPlexApi, Task<PlexAccount>>(x => x.GetAccount(AdminToken))
+                .ReturnsAsync(new PlexAccount { user = new User { uuid = "owner-uuid", id = "11223344", username = "owner-account", title = "Owner Account" } });
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.Is<OmbiUser>(u => u.UserName == "owner-account" && u.ProviderUserId == "11223344" && u.UserType == UserType.PlexUser)), Times.Once);
         }
 
         [Test]
@@ -340,10 +388,8 @@ namespace Ombi.Schedule.Tests
             // doesn't match the incoming community id is a real collision (e.g. a Plex
             // username was reused after the original account was deleted). We must not
             // hijack the existing row, and we must not sync against the new uuid.
-            // The sweep should also leave the row alone: the username does appear in the
-            // target list (a different Plex account happens to have it), so flipping the
-            // existing row to NotAFriend would be incorrect — it's a different question
-            // from "is this exact account still a friend".
+            // The sweep should ALSO flip the existing row to NotAFriend — it's a stale
+            // ghost: the original Plex account it was bound to is no longer a friend.
             var users = new List<OmbiUser>
             {
                 new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
@@ -360,7 +406,7 @@ namespace Ombi.Schedule.Tests
 
             _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.IsAny<OmbiUser>()), Times.Never);
             _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "different-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-            _statusStore.Verify(x => x.SetAsync("other-id", WatchlistSyncStatus.NotAFriend, It.IsAny<CancellationToken>()), Times.Never);
+            _statusStore.Verify(x => x.SetAsync("other-id", WatchlistSyncStatus.NotAFriend, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -468,6 +514,15 @@ namespace Ombi.Schedule.Tests
                 .ReturnsAsync(true);
             mgr.Setup(x => x.IsInRoleAsync(It.Is<OmbiUser>(u => u.Id != adminUserId), OmbiRoles.Admin))
                 .ReturnsAsync(false);
+        }
+
+        private void SetupLegacyUsers(params (string id, string username)[] users)
+        {
+            _mocker.Setup<IPlexApi, Task<PlexUsers>>(x => x.GetUsers(AdminToken))
+                .ReturnsAsync(new PlexUsers
+                {
+                    User = users.Select(u => new UserFriends { Id = u.id, Username = u.username }).ToArray()
+                });
         }
 
         private void SetupFriends(params (string id, string username)[] friends)

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -377,6 +377,39 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
+        public async Task ExistingFriendWithCommunityUuidProviderId_IsAdoptedViaUsernameFallback()
+        {
+            // Regression for the 4.59 -> 4.60 upgrade path. Ombi 4.59's watchlist importer
+            // auto-created friends with the community UUID in ProviderUserId. After this PR
+            // we never store UUIDs again, but those rows are still in users' databases.
+            // The username fallback must adopt them (the stored UUID equals the target's id,
+            // so the collision check passes), so the existing row keeps being used and we
+            // don't produce a duplicate via the create path.
+            const string communityUuid = "old-friend-uuid";
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "uuid-row-id", UserName = "uuidfriend", NormalizedUserName = "UUIDFRIEND", UserType = UserType.PlexUser, ProviderUserId = communityUuid },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends((communityUuid, "uuidfriend"));
+            SetupLegacyUsers(("44556677", "uuidfriend"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.Is<OmbiUser>(u => u.Id == "uuid-row-id")), Times.Never);
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, communityUuid, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _statusStore.Verify(x => x.SetAsync("uuid-row-id", WatchlistSyncStatus.Successful, It.IsAny<CancellationToken>()), Times.Once);
+            // The 4.59-era UUID stays put — we don't rewrite it.
+            Assert.That(users.Single(u => u.Id == "uuid-row-id").ProviderUserId, Is.EqualTo(communityUuid));
+        }
+
+        [Test]
         public async Task ExistingFriendWithLegacyNumericProviderId_IsAdoptedWithoutRewritingProviderUserId()
         {
             // Regression for https://github.com/Ombi-app/Ombi/issues/5399.

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -293,6 +293,61 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
+        public async Task ExistingFriendWithLegacyNumericProviderId_IsMigratedAndImported()
+        {
+            // User was previously imported via the legacy /api/users path, which stores the
+            // numeric plex.tv account id in ProviderUserId. The community API now returns a
+            // UUID for the same user — the import must adopt that record, not skip it as a
+            // collision (https://github.com/Ombi-app/Ombi/issues/5399).
+            const string legacyNumericId = "12345678";
+            const string communityUuid = "friend-uuid";
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "legacy-id", UserName = "legacyfriend", NormalizedUserName = "LEGACYFRIEND", UserType = UserType.PlexUser, ProviderUserId = legacyNumericId },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends((communityUuid, "legacyfriend"));
+
+            await _subject.Execute(_context.Object);
+
+            // The existing user should be updated to carry the community UUID, not duplicated.
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.Is<OmbiUser>(u => u.Id == "legacy-id" && u.ProviderUserId == communityUuid)), Times.Once);
+
+            // And the watchlist should actually sync for them, against the community UUID.
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, communityUuid, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _statusStore.Verify(x => x.SetAsync("legacy-id", WatchlistSyncStatus.Successful, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ExistingFriendUsernameCollisionWithDifferentUuid_IsSkipped()
+        {
+            // If a username collides with an existing user that already has a proper
+            // community UUID stored, we must NOT hijack that user — we skip the new one.
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "other-id", UserName = "duplicate", NormalizedUserName = "DUPLICATE", UserType = UserType.PlexUser, ProviderUserId = "real-uuid-for-other" },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends(("different-uuid", "duplicate"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "different-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
         public async Task PreExistingPlexUser_NotInAllFriendsV2_IsMarkedNotAFriend()
         {
             // Seed an additional Plex user that no target will match (their ProviderUserId

--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -410,6 +410,35 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
+        public async Task StaleGhostWithDifferentNumericId_IsNotAdopted()
+        {
+            // Plex username was reused after the original account was deleted. The existing
+            // Ombi row is bound to the OLD numeric id; /api/users now maps that same username
+            // to a DIFFERENT numeric id for the new account. Adopting the stale row would
+            // corrupt its identity. Skip the target, don't sync its watchlist, and let the
+            // post-run sweep flag the ghost as NotAFriend.
+            const string oldNumericId = "11111";
+            const string newNumericId = "22222";
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = AdminOmbiId, UserName = "owner", NormalizedUserName = "OWNER", UserType = UserType.PlexUser, ProviderUserId = AdminUuid, MediaServerToken = AdminToken },
+                new OmbiUser { Id = "ghost-id", UserName = "recycled", NormalizedUserName = "RECYCLED", UserType = UserType.PlexUser, ProviderUserId = oldNumericId },
+            };
+            var userMgr = MockHelper.MockUserManager(users);
+            SetupAdminRole(userMgr, AdminOmbiId);
+            _mocker.Use(userMgr);
+            _subject = _mocker.CreateInstance<PlexWatchlistImport>();
+            UseDefaultPlexSettings();
+            SetupFriends(("new-uuid", "recycled"));
+            SetupLegacyUsers((newNumericId, "recycled"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.UpdateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<IPlexApi>(x => x.GetWatchlistForUser(AdminToken, "new-uuid", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
         public async Task ExistingFriendWithLegacyNumericProviderId_IsAdoptedWithoutRewritingProviderUserId()
         {
             // Regression for https://github.com/Ombi-app/Ombi/issues/5399.

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -94,7 +94,7 @@ namespace Ombi.Schedule.Jobs.Plex
             _logger.LogInformation($"Watchlist import using server '{selectedServer.Name}' (machine {selectedServer.MachineIdentifier})");
             await NotifyClient("Starting Watchlist Import");
 
-            var (targets, friendIds, friendsFetched, adminResolved) = await BuildTargetList(adminToken, ct);
+            var (targets, friendsFetched, adminResolved) = await BuildTargetList(adminToken, ct);
             if (targets.Count == 0)
             {
                 _logger.LogInformation("No watchlist targets found (admin + friends)");
@@ -103,6 +103,7 @@ namespace Ombi.Schedule.Jobs.Plex
             }
 
             var userManagement = await _userManagementSettings.GetSettingsAsync();
+            var matchedUserIds = new HashSet<string>();
 
             foreach (var target in targets)
             {
@@ -116,6 +117,8 @@ namespace Ombi.Schedule.Jobs.Plex
                     {
                         continue;
                     }
+
+                    matchedUserIds.Add(user.Id);
 
                     var succeeded = await ImportWatchlistForUser(adminToken, target, user, settings.MonitorAll, ct);
                     await _statusStore.SetAsync(user.Id, succeeded ? WatchlistSyncStatus.Successful : WatchlistSyncStatus.Failed, ct);
@@ -131,16 +134,18 @@ namespace Ombi.Schedule.Jobs.Plex
                 }
             }
 
-            // For existing Plex users that weren't in allFriendsV2, mark them explicitly as NotAFriend.
-            // Only run this sweep when both the admin account and the friends list were resolved
-            // cleanly — otherwise a transient failure could mislabel everyone (including the admin).
+            // For existing Plex users that didn't match a target this run, mark them as NotAFriend.
+            // We compare against Ombi user ids (not ProviderUserId) because pre-existing users
+            // imported via the legacy /api/users path store the numeric plex.tv id while the
+            // community API returns UUIDs — the two won't match even for the same user.
+            // Only run the sweep when both admin and friends resolved cleanly, otherwise a
+            // transient failure could mislabel everyone.
             if (friendsFetched && adminResolved)
             {
                 var existingPlexUsers = await _ombiUserManager.Users.Where(x => x.UserType == UserType.PlexUser).ToListAsync(ct);
                 foreach (var existing in existingPlexUsers)
                 {
-                    if (string.IsNullOrEmpty(existing.ProviderUserId)) continue;
-                    if (friendIds.Contains(existing.ProviderUserId)) continue;
+                    if (matchedUserIds.Contains(existing.Id)) continue;
                     await _statusStore.SetAsync(existing.Id, WatchlistSyncStatus.NotAFriend, ct);
                 }
             }
@@ -165,10 +170,9 @@ namespace Ombi.Schedule.Jobs.Plex
             return null;
         }
 
-        private async Task<(List<PlexCommunityUser> targets, HashSet<string> friendIds, bool friendsFetched, bool adminResolved)> BuildTargetList(string adminToken, CancellationToken ct)
+        private async Task<(List<PlexCommunityUser> targets, bool friendsFetched, bool adminResolved)> BuildTargetList(string adminToken, CancellationToken ct)
         {
             var targets = new List<PlexCommunityUser>();
-            var friendIds = new HashSet<string>();
             var friendsFetched = false;
             var adminResolved = false;
 
@@ -184,7 +188,6 @@ namespace Ombi.Schedule.Jobs.Plex
                         displayName = account.user.title,
                     };
                     targets.Add(adminUser);
-                    friendIds.Add(adminUser.id);
                     adminResolved = true;
                 }
                 else
@@ -212,7 +215,6 @@ namespace Ombi.Schedule.Jobs.Plex
                 {
                     if (friend?.user == null || string.IsNullOrWhiteSpace(friend.user.id)) continue;
                     targets.Add(friend.user);
-                    friendIds.Add(friend.user.id);
                 }
                 // Only claim we fetched the friends list if the API returned no errors. A populated
                 // errors collection means the data we got is unreliable, so downstream code must not
@@ -224,7 +226,7 @@ namespace Ombi.Schedule.Jobs.Plex
                 _logger.LogError(ex, "Failed to fetch Plex friends");
             }
 
-            return (targets, friendIds, friendsFetched, adminResolved);
+            return (targets, friendsFetched, adminResolved);
         }
 
         private async Task<OmbiUser> EnsureOmbiUser(PlexCommunityUser plexUser, UserManagementSettings userManagement, CancellationToken ct)
@@ -238,27 +240,16 @@ namespace Ombi.Schedule.Jobs.Plex
             var existing = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.ProviderUserId == plexUser.id, ct);
             if (existing == null && !string.IsNullOrWhiteSpace(plexUser.username))
             {
+                // Fall back to a username match. We deliberately don't overwrite a populated
+                // ProviderUserId here — pre-existing users imported via the legacy /api/users
+                // path store the numeric plex.tv account id, while the community API we use for
+                // watchlist returns the account UUID. They're the same person, but other auth
+                // paths (notably /api/v1/Token/plextoken via OmbiUserManager.GetOmbiUserFromPlexToken)
+                // still match on the numeric id, so we leave it intact and use the in-memory
+                // matchedUserIds set to drive the NotAFriend sweep.
+                // Plex usernames are globally unique within UserType.PlexUser, so a username
+                // hit here is the same account.
                 existing = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
-                if (existing != null)
-                {
-                    if (string.IsNullOrWhiteSpace(existing.ProviderUserId) || IsLegacyPlexAccountId(existing.ProviderUserId))
-                    {
-                        // Pre-existing users imported by the legacy Plex User Importer have the
-                        // numeric plex.tv account id in ProviderUserId, but the community API we
-                        // use for watchlist returns the account UUID. Upgrade the stored id so
-                        // future runs match on the first lookup.
-                        existing.ProviderUserId = plexUser.id;
-                        await _ombiUserManager.UpdateAsync(existing);
-                    }
-                    else if (existing.ProviderUserId != plexUser.id)
-                    {
-                        // Username collision with a different Plex account — don't reassign and
-                        // skip importing for this target to avoid hijacking the existing user.
-                        _logger.LogWarning("Plex user '{Username}' ({NewId}) collides with existing Ombi user bound to {ExistingId}; skipping",
-                            plexUser.username, plexUser.id, existing.ProviderUserId);
-                        return null;
-                    }
-                }
             }
 
             if (existing != null)
@@ -307,19 +298,6 @@ namespace Ombi.Schedule.Jobs.Plex
                 }
             }
             return newUser;
-        }
-
-        // Legacy /api/users returns a numeric plex.tv account id; the community GraphQL API
-        // returns a UUID. We use this to recognise records created by the old importer so we
-        // can transparently upgrade them to the community id.
-        private static bool IsLegacyPlexAccountId(string providerUserId)
-        {
-            if (string.IsNullOrWhiteSpace(providerUserId)) return false;
-            for (var i = 0; i < providerUserId.Length; i++)
-            {
-                if (!char.IsDigit(providerUserId[i])) return false;
-            }
-            return true;
         }
 
         private const int MaxWatchlistPages = 200;

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Ombi.Api.External.MediaServers.Plex;
 using Ombi.Api.External.MediaServers.Plex.Models;
 using Ombi.Api.External.MediaServers.Plex.Models.Community;
+using Ombi.Api.External.MediaServers.Plex.Models.Friends;
 using Ombi.Api.External.ExternalApis.TheMovieDb;
 using Ombi.Api.External.ExternalApis.TheMovieDb.Models;
 using Ombi.Core.Authentication;
@@ -94,7 +95,7 @@ namespace Ombi.Schedule.Jobs.Plex
             _logger.LogInformation($"Watchlist import using server '{selectedServer.Name}' (machine {selectedServer.MachineIdentifier})");
             await NotifyClient("Starting Watchlist Import");
 
-            var (targets, friendsFetched, adminResolved) = await BuildTargetList(adminToken, ct);
+            var (targets, legacyIdsByUsername, friendsFetched, adminResolved) = await BuildTargetList(adminToken, ct);
             if (targets.Count == 0)
             {
                 _logger.LogInformation("No watchlist targets found (admin + friends)");
@@ -112,7 +113,7 @@ namespace Ombi.Schedule.Jobs.Plex
                 OmbiUser user = null;
                 try
                 {
-                    user = await EnsureOmbiUser(target, userManagement, ct);
+                    user = await EnsureOmbiUser(target, userManagement, legacyIdsByUsername, ct);
                     if (user == null)
                     {
                         continue;
@@ -135,20 +136,23 @@ namespace Ombi.Schedule.Jobs.Plex
             }
 
             // For existing Plex users that didn't match a target this run, mark them as NotAFriend.
-            // The sweep skips a row if any of these are true:
+            // The sweep skips a row when:
             //   * we successfully matched it to a target (matchedUserIds), OR
-            //   * its UserName matches a target's username, OR
-            //   * its ProviderUserId matches a target's community id.
-            // The latter two cover edge cases where matchedUserIds is incomplete:
-            // banned users (EnsureOmbiUser returns null), transient EnsureOmbiUser failures,
-            // and legacy-numeric ProviderUserId rows. Only run the sweep when both admin and
-            // friends resolved cleanly AND the run wasn't cancelled — otherwise matched data
-            // may be incomplete and we'd mislabel valid friends.
+            //   * its ProviderUserId matches a target's community id, OR
+            //   * its UserName matches a target's username AND the stored ProviderUserId is
+            //     either blank, legacy-numeric, or matches one of those username-targets' ids.
+            // The username-AND-id-aware skip is important: a stale row whose username has been
+            // reused by a different Plex account is still a stale row and should be flipped.
+            // The legacy/blank/match exemption preserves the #5399 fix for legacy-imported
+            // friends and protects banned/transient-failure rows where EnsureOmbiUser didn't
+            // successfully match. Only run the sweep when both admin and friends resolved
+            // cleanly AND the run wasn't cancelled — otherwise matched data may be incomplete.
             if (!ct.IsCancellationRequested && friendsFetched && adminResolved)
             {
-                var targetUsernames = new HashSet<string>(
-                    targets.Where(t => !string.IsNullOrWhiteSpace(t.username)).Select(t => t.username),
-                    StringComparer.OrdinalIgnoreCase);
+                var targetsByUsername = targets
+                    .Where(t => !string.IsNullOrWhiteSpace(t.username))
+                    .GroupBy(t => t.username, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
                 var targetIds = new HashSet<string>(
                     targets.Where(t => !string.IsNullOrWhiteSpace(t.id)).Select(t => t.id),
                     StringComparer.Ordinal);
@@ -157,8 +161,18 @@ namespace Ombi.Schedule.Jobs.Plex
                 foreach (var existing in existingPlexUsers)
                 {
                     if (matchedUserIds.Contains(existing.Id)) continue;
-                    if (!string.IsNullOrWhiteSpace(existing.UserName) && targetUsernames.Contains(existing.UserName)) continue;
                     if (!string.IsNullOrWhiteSpace(existing.ProviderUserId) && targetIds.Contains(existing.ProviderUserId)) continue;
+                    if (!string.IsNullOrWhiteSpace(existing.UserName)
+                        && targetsByUsername.TryGetValue(existing.UserName, out var usernameTargets))
+                    {
+                        var stored = existing.ProviderUserId;
+                        if (string.IsNullOrWhiteSpace(stored)
+                            || IsLegacyNumericPlexId(stored)
+                            || usernameTargets.Any(t => string.Equals(stored, t.id, StringComparison.Ordinal)))
+                        {
+                            continue;
+                        }
+                    }
                     await _statusStore.SetAsync(existing.Id, WatchlistSyncStatus.NotAFriend, ct);
                 }
             }
@@ -183,9 +197,14 @@ namespace Ombi.Schedule.Jobs.Plex
             return null;
         }
 
-        private async Task<(List<PlexCommunityUser> targets, bool friendsFetched, bool adminResolved)> BuildTargetList(string adminToken, CancellationToken ct)
+        private async Task<(List<PlexCommunityUser> targets, Dictionary<string, string> legacyIdsByUsername, bool friendsFetched, bool adminResolved)> BuildTargetList(string adminToken, CancellationToken ct)
         {
             var targets = new List<PlexCommunityUser>();
+            // Maps Plex username -> numeric plex.tv account id. The community API only returns
+            // UUIDs, but the rest of Ombi (PlexUserImporter, GetOmbiUserFromPlexToken, the wizard)
+            // keys on the numeric id, so we resolve it here so newly-created friend rows are
+            // consistent with everything else.
+            var legacyIdsByUsername = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var friendsFetched = false;
             var adminResolved = false;
 
@@ -201,6 +220,10 @@ namespace Ombi.Schedule.Jobs.Plex
                         displayName = account.user.title,
                     };
                     targets.Add(adminUser);
+                    if (!string.IsNullOrWhiteSpace(adminUser.username) && !string.IsNullOrWhiteSpace(account.user.id))
+                    {
+                        legacyIdsByUsername[adminUser.username] = account.user.id;
+                    }
                     adminResolved = true;
                 }
                 else
@@ -222,27 +245,53 @@ namespace Ombi.Schedule.Jobs.Plex
                     _logger.LogWarning("Plex community API returned errors fetching friends: {Errors}",
                         string.Join("; ", friendsResponse.errors.Select(e => e.message)));
                 }
-                var friends = friendsResponse?.data?.allFriendsV2 ?? new List<PlexCommunityFriend>();
+                var friends = friendsResponse?.data?.allFriendsV2;
+                if (friends == null)
+                {
+                    _logger.LogWarning("Plex community API returned no friends payload; the NotAFriend sweep will be skipped");
+                    friends = new List<PlexCommunityFriend>();
+                }
                 _logger.LogInformation("Found {Count} Plex friends", friends.Count);
                 foreach (var friend in friends)
                 {
                     if (friend?.user == null || string.IsNullOrWhiteSpace(friend.user.id)) continue;
                     targets.Add(friend.user);
                 }
-                // Only claim we fetched the friends list if the API returned no errors. A populated
-                // errors collection means the data we got is unreliable, so downstream code must not
-                // treat missing entries as "no longer a friend".
-                friendsFetched = !hasErrors;
+                // Only claim we fetched the friends list if the API returned no errors AND we
+                // actually got a payload. A populated errors collection or a null payload means
+                // the data is unreliable, so downstream code must not treat missing entries as
+                // "no longer a friend".
+                friendsFetched = !hasErrors && friendsResponse?.data?.allFriendsV2 != null;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to fetch Plex friends");
             }
 
-            return (targets, friendsFetched, adminResolved);
+            // Pull the legacy /api/users list to map friend usernames -> numeric plex.tv ids.
+            // Friends without server-share access aren't in this list; for those we fall back
+            // to the community UUID when creating their Ombi row.
+            try
+            {
+                var legacyUsers = await _plexApi.GetUsers(adminToken);
+                if (legacyUsers?.User != null)
+                {
+                    foreach (var u in legacyUsers.User)
+                    {
+                        if (string.IsNullOrWhiteSpace(u?.Username) || string.IsNullOrWhiteSpace(u.Id)) continue;
+                        legacyIdsByUsername[u.Username] = u.Id;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch legacy Plex user list; new friends will fall back to community UUIDs for ProviderUserId");
+            }
+
+            return (targets, legacyIdsByUsername, friendsFetched, adminResolved);
         }
 
-        private async Task<OmbiUser> EnsureOmbiUser(PlexCommunityUser plexUser, UserManagementSettings userManagement, CancellationToken ct)
+        private async Task<OmbiUser> EnsureOmbiUser(PlexCommunityUser plexUser, UserManagementSettings userManagement, IReadOnlyDictionary<string, string> legacyIdsByUsername, CancellationToken ct)
         {
             if (userManagement.BannedPlexUserIds != null && userManagement.BannedPlexUserIds.Contains(plexUser.id))
             {
@@ -296,11 +345,25 @@ namespace Ombi.Schedule.Jobs.Plex
                 return null;
             }
 
+            // Prefer the numeric plex.tv account id so the new row is consistent with rows
+            // created by PlexUserImporter / IdentityController, and so /Token/plextoken
+            // (OmbiUserManager.GetOmbiUserFromPlexToken) can authenticate this user. Fall
+            // back to the community UUID only when we couldn't resolve a numeric id (e.g.
+            // a friend without server-share access who isn't in /api/users).
+            var providerUserId = plexUser.id;
+            if (legacyIdsByUsername != null
+                && !string.IsNullOrWhiteSpace(plexUser.username)
+                && legacyIdsByUsername.TryGetValue(plexUser.username, out var legacyId)
+                && !string.IsNullOrWhiteSpace(legacyId))
+            {
+                providerUserId = legacyId;
+            }
+
             var newUser = new OmbiUser
             {
                 UserType = UserType.PlexUser,
                 UserName = plexUser.username,
-                ProviderUserId = plexUser.id,
+                ProviderUserId = providerUserId,
                 Email = string.Empty,
                 Alias = plexUser.displayName ?? string.Empty,
                 MovieRequestLimit = userManagement.MovieRequestLimit,

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -269,8 +269,9 @@ namespace Ombi.Schedule.Jobs.Plex
             }
 
             // Pull the legacy /api/users list to map friend usernames -> numeric plex.tv ids.
-            // Friends without server-share access aren't in this list; for those we fall back
-            // to the community UUID when creating their Ombi row.
+            // Friends without server-share access aren't in this list; EnsureOmbiUser skips
+            // creating rows for them because we have no numeric id to key on and
+            // PlexUserImporter.CleanupPlexUsers would prune them anyway.
             try
             {
                 var legacyUsers = await _plexApi.GetUsers(adminToken);
@@ -285,7 +286,7 @@ namespace Ombi.Schedule.Jobs.Plex
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to fetch legacy Plex user list; new friends will fall back to community UUIDs for ProviderUserId");
+                _logger.LogWarning(ex, "Failed to fetch legacy Plex user list; new friends will be skipped this run (need /api/users to resolve their numeric plex.tv id)");
             }
 
             return (targets, legacyIdsByUsername, friendsFetched, adminResolved);

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -370,7 +370,7 @@ namespace Ombi.Schedule.Jobs.Plex
                 x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
             if (usernameMatch == null) return null;
 
-            if (!IsUsernameAdoptionSafe(usernameMatch.ProviderUserId, plexUser.id))
+            if (!IsUsernameAdoptionSafe(usernameMatch.ProviderUserId, plexUser.id, resolvedNumericId))
             {
                 _logger.LogWarning(
                     "Plex user '{Username}' ({PlexUserId}) collides with existing Ombi user bound to {ProviderUserId}; skipping",
@@ -383,12 +383,23 @@ namespace Ombi.Schedule.Jobs.Plex
         // A username match is only safe to adopt when we can convince ourselves it's the same
         // Plex account: the stored ProviderUserId is blank (pre-link row), a legacy numeric
         // plex.tv id (the #5399 migration case), or already equals the incoming community id.
-        // Anything else (a different community UUID) is treated as a hijack/ghost row —
-        // Plex usernames can be reused after an account is deleted, so we refuse to adopt.
-        private static bool IsUsernameAdoptionSafe(string storedProviderId, string communityId)
+        // If /api/users gave us a fresh numeric id for this username AND the stored numeric id
+        // doesn't match it, we're looking at a stale ghost row from a different plex.tv
+        // account (username reuse after deletion) — refuse to adopt.
+        // Plex usernames can be reused after an account is deleted, so we refuse to adopt
+        // anything that doesn't fit one of those shapes.
+        private static bool IsUsernameAdoptionSafe(string storedProviderId, string communityId, string resolvedNumericId)
         {
             if (string.IsNullOrWhiteSpace(storedProviderId)) return true;
-            if (IsLegacyNumericPlexId(storedProviderId)) return true;
+            if (IsLegacyNumericPlexId(storedProviderId))
+            {
+                if (!string.IsNullOrWhiteSpace(resolvedNumericId)
+                    && !string.Equals(storedProviderId, resolvedNumericId, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                return true;
+            }
             return string.Equals(storedProviderId, communityId, StringComparison.Ordinal);
         }
 
@@ -405,10 +416,14 @@ namespace Ombi.Schedule.Jobs.Plex
             // server-share access) are intentionally skipped: they can't authenticate via
             // /Token/plextoken, and PlexUserImporter.CleanupPlexUsers would delete them on its
             // next run anyway. To sync their watchlist, share your server with them.
+            //
+            // Logged at Warning because if an admin ever slipped through here (an existing
+            // admin row is a hard prerequisite for this job to run at all, so in practice the
+            // adoption path will always catch them) it's a misconfiguration worth surfacing.
             if (string.IsNullOrWhiteSpace(resolvedNumericId))
             {
-                _logger.LogInformation(
-                    "Skipping Plex community friend '{Username}' ({PlexUserId}): not in the server's /api/users list. Share the Plex server with them to enable watchlist sync.",
+                _logger.LogWarning(
+                    "Skipping Plex friend '{Username}' ({PlexUserId}): not in the server's /api/users list, so Ombi has no numeric plex.tv id to key on. Share the Plex server with them to enable watchlist sync.",
                     plexUser.username, plexUser.id);
                 return null;
             }

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -135,17 +135,30 @@ namespace Ombi.Schedule.Jobs.Plex
             }
 
             // For existing Plex users that didn't match a target this run, mark them as NotAFriend.
-            // We compare against Ombi user ids (not ProviderUserId) because pre-existing users
-            // imported via the legacy /api/users path store the numeric plex.tv id while the
-            // community API returns UUIDs — the two won't match even for the same user.
-            // Only run the sweep when both admin and friends resolved cleanly, otherwise a
-            // transient failure could mislabel everyone.
-            if (friendsFetched && adminResolved)
+            // The sweep skips a row if any of these are true:
+            //   * we successfully matched it to a target (matchedUserIds), OR
+            //   * its UserName matches a target's username, OR
+            //   * its ProviderUserId matches a target's community id.
+            // The latter two cover edge cases where matchedUserIds is incomplete:
+            // banned users (EnsureOmbiUser returns null), transient EnsureOmbiUser failures,
+            // and legacy-numeric ProviderUserId rows. Only run the sweep when both admin and
+            // friends resolved cleanly AND the run wasn't cancelled — otherwise matched data
+            // may be incomplete and we'd mislabel valid friends.
+            if (!ct.IsCancellationRequested && friendsFetched && adminResolved)
             {
+                var targetUsernames = new HashSet<string>(
+                    targets.Where(t => !string.IsNullOrWhiteSpace(t.username)).Select(t => t.username),
+                    StringComparer.OrdinalIgnoreCase);
+                var targetIds = new HashSet<string>(
+                    targets.Where(t => !string.IsNullOrWhiteSpace(t.id)).Select(t => t.id),
+                    StringComparer.Ordinal);
+
                 var existingPlexUsers = await _ombiUserManager.Users.Where(x => x.UserType == UserType.PlexUser).ToListAsync(ct);
                 foreach (var existing in existingPlexUsers)
                 {
                     if (matchedUserIds.Contains(existing.Id)) continue;
+                    if (!string.IsNullOrWhiteSpace(existing.UserName) && targetUsernames.Contains(existing.UserName)) continue;
+                    if (!string.IsNullOrWhiteSpace(existing.ProviderUserId) && targetIds.Contains(existing.ProviderUserId)) continue;
                     await _statusStore.SetAsync(existing.Id, WatchlistSyncStatus.NotAFriend, ct);
                 }
             }
@@ -240,16 +253,36 @@ namespace Ombi.Schedule.Jobs.Plex
             var existing = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.ProviderUserId == plexUser.id, ct);
             if (existing == null && !string.IsNullOrWhiteSpace(plexUser.username))
             {
-                // Fall back to a username match. We deliberately don't overwrite a populated
-                // ProviderUserId here — pre-existing users imported via the legacy /api/users
-                // path store the numeric plex.tv account id, while the community API we use for
-                // watchlist returns the account UUID. They're the same person, but other auth
-                // paths (notably /api/v1/Token/plextoken via OmbiUserManager.GetOmbiUserFromPlexToken)
-                // still match on the numeric id, so we leave it intact and use the in-memory
-                // matchedUserIds set to drive the NotAFriend sweep.
-                // Plex usernames are globally unique within UserType.PlexUser, so a username
-                // hit here is the same account.
-                existing = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
+                // Fall back to a username match. Pre-existing users imported via the legacy
+                // /api/users path store the numeric plex.tv account id, while the community API
+                // returns the account UUID — same user, different identifier. We adopt that row
+                // without rewriting ProviderUserId so /api/v1/Token/plextoken
+                // (OmbiUserManager.GetOmbiUserFromPlexToken matches on the numeric id) keeps
+                // working; the in-memory matchedUserIds set drives the NotAFriend sweep instead.
+                //
+                // If the existing row already has a non-numeric ProviderUserId that doesn't
+                // match the community id, treat it as a real collision and skip — Plex usernames
+                // can be reused after an account is deleted, and we don't want to hijack the
+                // existing row.
+                var usernameMatch = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
+                if (usernameMatch != null)
+                {
+                    var stored = usernameMatch.ProviderUserId;
+                    var conflict =
+                        !string.IsNullOrWhiteSpace(stored)
+                        && !string.Equals(stored, plexUser.id, StringComparison.Ordinal)
+                        && !IsLegacyNumericPlexId(stored);
+
+                    if (conflict)
+                    {
+                        _logger.LogWarning(
+                            "Plex user '{Username}' ({PlexUserId}) collides with existing Ombi user bound to {ProviderUserId}; skipping",
+                            plexUser.username, plexUser.id, stored);
+                        return null;
+                    }
+
+                    existing = usernameMatch;
+                }
             }
 
             if (existing != null)
@@ -298,6 +331,19 @@ namespace Ombi.Schedule.Jobs.Plex
                 }
             }
             return newUser;
+        }
+
+        // The legacy /api/users path stores a numeric plex.tv account id. The community API
+        // returns a UUID-shaped string. We use this to recognise legacy-imported rows that
+        // are safe to adopt during a username fallback without tripping the hijack guard.
+        private static bool IsLegacyNumericPlexId(string providerUserId)
+        {
+            if (string.IsNullOrWhiteSpace(providerUserId)) return false;
+            for (var i = 0; i < providerUserId.Length; i++)
+            {
+                if (!char.IsDigit(providerUserId[i])) return false;
+            }
+            return true;
         }
 
         private const int MaxWatchlistPages = 200;

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -299,7 +299,26 @@ namespace Ombi.Schedule.Jobs.Plex
                 return null;
             }
 
-            var existing = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.ProviderUserId == plexUser.id, ct);
+            // Resolve the numeric plex.tv id for this username up-front (if /api/users gave
+            // us one) so we can match an existing row by either the community UUID or the
+            // numeric id. Without the numeric leg, a friend who renamed their plex.tv
+            // account would slip past both lookups and produce a duplicate Ombi row pointing
+            // at the same numeric id.
+            string resolvedNumericId = null;
+            if (legacyIdsByUsername != null
+                && !string.IsNullOrWhiteSpace(plexUser.username)
+                && legacyIdsByUsername.TryGetValue(plexUser.username, out var legacyId)
+                && !string.IsNullOrWhiteSpace(legacyId))
+            {
+                resolvedNumericId = legacyId;
+            }
+
+            var existing = resolvedNumericId != null
+                ? await _ombiUserManager.Users.FirstOrDefaultAsync(x =>
+                    x.UserType == UserType.PlexUser
+                    && (x.ProviderUserId == plexUser.id || x.ProviderUserId == resolvedNumericId), ct)
+                : await _ombiUserManager.Users.FirstOrDefaultAsync(x =>
+                    x.UserType == UserType.PlexUser && x.ProviderUserId == plexUser.id, ct);
             if (existing == null && !string.IsNullOrWhiteSpace(plexUser.username))
             {
                 // Fall back to a username match. Pre-existing users imported via the legacy
@@ -345,25 +364,28 @@ namespace Ombi.Schedule.Jobs.Plex
                 return null;
             }
 
-            // Prefer the numeric plex.tv account id so the new row is consistent with rows
-            // created by PlexUserImporter / IdentityController, and so /Token/plextoken
-            // (OmbiUserManager.GetOmbiUserFromPlexToken) can authenticate this user. Fall
-            // back to the community UUID only when we couldn't resolve a numeric id (e.g.
-            // a friend without server-share access who isn't in /api/users).
-            var providerUserId = plexUser.id;
-            if (legacyIdsByUsername != null
-                && !string.IsNullOrWhiteSpace(plexUser.username)
-                && legacyIdsByUsername.TryGetValue(plexUser.username, out var legacyId)
-                && !string.IsNullOrWhiteSpace(legacyId))
+            // Only auto-create rows for friends Ombi can treat as first-class PlexUsers — ones
+            // with a numeric plex.tv account id from /api/users. That's the same identifier
+            // PlexUserImporter, GetOmbiUserFromPlexToken and IdentityController already key on,
+            // so the new row participates in cleanup, login, and reconciliation cleanly.
+            //
+            // Community-only friends (no server-share access, so not in /api/users) are
+            // intentionally skipped: we have no numeric id for them, they can't authenticate
+            // via /Token/plextoken, and PlexUserImporter.CleanupPlexUsers would delete them
+            // on its next run anyway. To sync their watchlist, share your server with them.
+            if (string.IsNullOrWhiteSpace(resolvedNumericId))
             {
-                providerUserId = legacyId;
+                _logger.LogInformation(
+                    "Skipping Plex community friend '{Username}' ({PlexUserId}): not in the server's /api/users list. Share the Plex server with them to enable watchlist sync.",
+                    plexUser.username, plexUser.id);
+                return null;
             }
 
             var newUser = new OmbiUser
             {
                 UserType = UserType.PlexUser,
                 UserName = plexUser.username,
-                ProviderUserId = providerUserId,
+                ProviderUserId = resolvedNumericId,
                 Email = string.Empty,
                 Alias = plexUser.displayName ?? string.Empty,
                 MovieRequestLimit = userManagement.MovieRequestLimit,

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -241,8 +241,12 @@ namespace Ombi.Schedule.Jobs.Plex
                 existing = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
                 if (existing != null)
                 {
-                    if (string.IsNullOrWhiteSpace(existing.ProviderUserId))
+                    if (string.IsNullOrWhiteSpace(existing.ProviderUserId) || IsLegacyPlexAccountId(existing.ProviderUserId))
                     {
+                        // Pre-existing users imported by the legacy Plex User Importer have the
+                        // numeric plex.tv account id in ProviderUserId, but the community API we
+                        // use for watchlist returns the account UUID. Upgrade the stored id so
+                        // future runs match on the first lookup.
                         existing.ProviderUserId = plexUser.id;
                         await _ombiUserManager.UpdateAsync(existing);
                     }
@@ -303,6 +307,19 @@ namespace Ombi.Schedule.Jobs.Plex
                 }
             }
             return newUser;
+        }
+
+        // Legacy /api/users returns a numeric plex.tv account id; the community GraphQL API
+        // returns a UUID. We use this to recognise records created by the old importer so we
+        // can transparently upgrade them to the community id.
+        private static bool IsLegacyPlexAccountId(string providerUserId)
+        {
+            if (string.IsNullOrWhiteSpace(providerUserId)) return false;
+            for (var i = 0; i < providerUserId.Length; i++)
+            {
+                if (!char.IsDigit(providerUserId[i])) return false;
+            }
+            return true;
         }
 
         private const int MaxWatchlistPages = 200;

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -205,37 +205,47 @@ namespace Ombi.Schedule.Jobs.Plex
             // keys on the numeric id, so we resolve it here so newly-created friend rows are
             // consistent with everything else.
             var legacyIdsByUsername = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var friendsFetched = false;
-            var adminResolved = false;
 
+            var adminResolved = await TryAddAdminTarget(adminToken, targets, legacyIdsByUsername);
+            var friendsFetched = await TryAddFriendTargets(adminToken, targets, ct);
+            await TryPopulateLegacyIds(adminToken, legacyIdsByUsername);
+
+            return (targets, legacyIdsByUsername, friendsFetched, adminResolved);
+        }
+
+        private async Task<bool> TryAddAdminTarget(string adminToken, List<PlexCommunityUser> targets, IDictionary<string, string> legacyIdsByUsername)
+        {
             try
             {
                 var account = await _plexApi.GetAccount(adminToken);
-                if (account?.user != null && !string.IsNullOrWhiteSpace(account.user.uuid))
-                {
-                    var adminUser = new PlexCommunityUser
-                    {
-                        id = account.user.uuid,
-                        username = account.user.username ?? account.user.title,
-                        displayName = account.user.title,
-                    };
-                    targets.Add(adminUser);
-                    if (!string.IsNullOrWhiteSpace(adminUser.username) && !string.IsNullOrWhiteSpace(account.user.id))
-                    {
-                        legacyIdsByUsername[adminUser.username] = account.user.id;
-                    }
-                    adminResolved = true;
-                }
-                else
+                if (account?.user == null || string.IsNullOrWhiteSpace(account.user.uuid))
                 {
                     _logger.LogWarning("Unable to resolve admin Plex account; admin watchlist will be skipped");
+                    return false;
                 }
+
+                var adminUser = new PlexCommunityUser
+                {
+                    id = account.user.uuid,
+                    username = account.user.username ?? account.user.title,
+                    displayName = account.user.title,
+                };
+                targets.Add(adminUser);
+                if (!string.IsNullOrWhiteSpace(adminUser.username) && !string.IsNullOrWhiteSpace(account.user.id))
+                {
+                    legacyIdsByUsername[adminUser.username] = account.user.id;
+                }
+                return true;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to fetch admin Plex account");
+                return false;
             }
+        }
 
+        private async Task<bool> TryAddFriendTargets(string adminToken, List<PlexCommunityUser> targets, CancellationToken ct)
+        {
             try
             {
                 var friendsResponse = await _plexApi.GetAllFriends(adminToken, ct);
@@ -245,29 +255,33 @@ namespace Ombi.Schedule.Jobs.Plex
                     _logger.LogWarning("Plex community API returned errors fetching friends: {Errors}",
                         string.Join("; ", friendsResponse.errors.Select(e => e.message)));
                 }
-                var friends = friendsResponse?.data?.allFriendsV2;
-                if (friends == null)
+                var rawFriends = friendsResponse?.data?.allFriendsV2;
+                if (rawFriends == null)
                 {
                     _logger.LogWarning("Plex community API returned no friends payload; the NotAFriend sweep will be skipped");
-                    friends = new List<PlexCommunityFriend>();
                 }
+                var friends = rawFriends ?? new List<PlexCommunityFriend>();
                 _logger.LogInformation("Found {Count} Plex friends", friends.Count);
                 foreach (var friend in friends)
                 {
                     if (friend?.user == null || string.IsNullOrWhiteSpace(friend.user.id)) continue;
                     targets.Add(friend.user);
                 }
-                // Only claim we fetched the friends list if the API returned no errors AND we
-                // actually got a payload. A populated errors collection or a null payload means
-                // the data is unreliable, so downstream code must not treat missing entries as
-                // "no longer a friend".
-                friendsFetched = !hasErrors && friendsResponse?.data?.allFriendsV2 != null;
+                // Only claim we fetched the friends list when no errors AND a payload was
+                // returned. A populated errors collection or a null payload means the data is
+                // unreliable, so downstream code must not treat missing entries as "no longer
+                // a friend".
+                return !hasErrors && rawFriends != null;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to fetch Plex friends");
+                return false;
             }
+        }
 
+        private async Task TryPopulateLegacyIds(string adminToken, IDictionary<string, string> legacyIdsByUsername)
+        {
             // Pull the legacy /api/users list to map friend usernames -> numeric plex.tv ids.
             // Friends without server-share access aren't in this list; EnsureOmbiUser skips
             // creating rows for them because we have no numeric id to key on and
@@ -275,94 +289,111 @@ namespace Ombi.Schedule.Jobs.Plex
             try
             {
                 var legacyUsers = await _plexApi.GetUsers(adminToken);
-                if (legacyUsers?.User != null)
+                if (legacyUsers?.User == null) return;
+                foreach (var u in legacyUsers.User)
                 {
-                    foreach (var u in legacyUsers.User)
-                    {
-                        if (string.IsNullOrWhiteSpace(u?.Username) || string.IsNullOrWhiteSpace(u.Id)) continue;
-                        legacyIdsByUsername[u.Username] = u.Id;
-                    }
+                    if (string.IsNullOrWhiteSpace(u?.Username) || string.IsNullOrWhiteSpace(u.Id)) continue;
+                    legacyIdsByUsername[u.Username] = u.Id;
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to fetch legacy Plex user list; new friends will be skipped this run (need /api/users to resolve their numeric plex.tv id)");
             }
-
-            return (targets, legacyIdsByUsername, friendsFetched, adminResolved);
         }
 
         private async Task<OmbiUser> EnsureOmbiUser(PlexCommunityUser plexUser, UserManagementSettings userManagement, IReadOnlyDictionary<string, string> legacyIdsByUsername, CancellationToken ct)
         {
-            if (userManagement.BannedPlexUserIds != null && userManagement.BannedPlexUserIds.Contains(plexUser.id))
+            var resolvedNumericId = ResolveNumericId(plexUser, legacyIdsByUsername);
+
+            if (IsBanned(plexUser, resolvedNumericId, userManagement))
             {
                 _logger.LogInformation($"Skipping banned Plex user '{plexUser.username}'");
                 return null;
             }
 
-            // Resolve the numeric plex.tv id for this username up-front (if /api/users gave
-            // us one) and use it as the primary lookup. New rows only ever get the numeric
-            // id (community-only friends are skipped below), so there's no reason to query
-            // by the community UUID here.
-            //
-            // Rows created by Ombi 4.59 with the community UUID in ProviderUserId still
-            // exist in users' databases. Those are picked up by the username fallback: the
-            // stored UUID will equal plexUser.id for the non-renamed common case, so the
-            // adoption path accepts it. If a user renamed their plex.tv account AND has a
-            // 4.59-era UUID row, the fallback won't find them and a duplicate row will be
-            // created — acknowledged edge case, not worth a migration to fix.
-            string resolvedNumericId = null;
-            if (legacyIdsByUsername != null
-                && !string.IsNullOrWhiteSpace(plexUser.username)
-                && legacyIdsByUsername.TryGetValue(plexUser.username, out var legacyId)
-                && !string.IsNullOrWhiteSpace(legacyId))
+            var existing = await ResolveExistingUser(plexUser, resolvedNumericId, ct);
+            if (existing != null) return existing;
+
+            return await CreateOmbiUserIfEligible(plexUser, resolvedNumericId, userManagement);
+        }
+
+        private static string ResolveNumericId(PlexCommunityUser plexUser, IReadOnlyDictionary<string, string> legacyIdsByUsername)
+        {
+            // If /api/users knows this username we key on its numeric plex.tv id. That's the
+            // identifier PlexUserImporter, GetOmbiUserFromPlexToken and the wizard already use,
+            // so the rest of Ombi can deal with the row uniformly.
+            if (legacyIdsByUsername == null
+                || string.IsNullOrWhiteSpace(plexUser.username)
+                || !legacyIdsByUsername.TryGetValue(plexUser.username, out var legacyId)
+                || string.IsNullOrWhiteSpace(legacyId))
             {
-                resolvedNumericId = legacyId;
+                return null;
             }
+            return legacyId;
+        }
 
-            var existing = resolvedNumericId != null
-                ? await _ombiUserManager.Users.FirstOrDefaultAsync(x =>
-                    x.UserType == UserType.PlexUser && x.ProviderUserId == resolvedNumericId, ct)
-                : null;
-            if (existing == null && !string.IsNullOrWhiteSpace(plexUser.username))
+        private static bool IsBanned(PlexCommunityUser plexUser, string resolvedNumericId, UserManagementSettings userManagement)
+        {
+            if (userManagement.BannedPlexUserIds == null) return false;
+            // BannedPlexUserIds may hold either shape depending on where the ban came from:
+            // the legacy PlexUserImporter stores numeric ids, anything touched since the
+            // community-API migration stores UUIDs. Accept either.
+            if (userManagement.BannedPlexUserIds.Contains(plexUser.id)) return true;
+            if (!string.IsNullOrWhiteSpace(resolvedNumericId)
+                && userManagement.BannedPlexUserIds.Contains(resolvedNumericId)) return true;
+            return false;
+        }
+
+        private async Task<OmbiUser> ResolveExistingUser(PlexCommunityUser plexUser, string resolvedNumericId, CancellationToken ct)
+        {
+            // Primary lookup: numeric plex.tv id (the canonical identifier). New rows only
+            // ever get the numeric id, and existing legacy rows have it too.
+            OmbiUser existing = null;
+            if (resolvedNumericId != null)
             {
-                // Fall back to a username match. Pre-existing users imported via the legacy
-                // /api/users path store the numeric plex.tv account id, while the community API
-                // returns the account UUID — same user, different identifier. We adopt that row
-                // without rewriting ProviderUserId so /api/v1/Token/plextoken
-                // (OmbiUserManager.GetOmbiUserFromPlexToken matches on the numeric id) keeps
-                // working; the in-memory matchedUserIds set drives the NotAFriend sweep instead.
-                //
-                // If the existing row already has a non-numeric ProviderUserId that doesn't
-                // match the community id, treat it as a real collision and skip — Plex usernames
-                // can be reused after an account is deleted, and we don't want to hijack the
-                // existing row.
-                var usernameMatch = await _ombiUserManager.Users.FirstOrDefaultAsync(x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
-                if (usernameMatch != null)
-                {
-                    var stored = usernameMatch.ProviderUserId;
-                    var conflict =
-                        !string.IsNullOrWhiteSpace(stored)
-                        && !string.Equals(stored, plexUser.id, StringComparison.Ordinal)
-                        && !IsLegacyNumericPlexId(stored);
-
-                    if (conflict)
-                    {
-                        _logger.LogWarning(
-                            "Plex user '{Username}' ({PlexUserId}) collides with existing Ombi user bound to {ProviderUserId}; skipping",
-                            plexUser.username, plexUser.id, stored);
-                        return null;
-                    }
-
-                    existing = usernameMatch;
-                }
+                existing = await _ombiUserManager.Users.FirstOrDefaultAsync(
+                    x => x.UserType == UserType.PlexUser && x.ProviderUserId == resolvedNumericId, ct);
             }
-
-            if (existing != null)
+            if (existing != null || string.IsNullOrWhiteSpace(plexUser.username))
             {
                 return existing;
             }
 
+            // Username fallback: picks up rows whose ProviderUserId is stale / UUID-shaped
+            // (e.g. created by Ombi 4.59 with the community UUID). We don't rewrite
+            // ProviderUserId on adoption so /api/v1/Token/plextoken
+            // (OmbiUserManager.GetOmbiUserFromPlexToken keys on the numeric id) keeps
+            // working for legacy rows that hold it; the in-memory matchedUserIds set
+            // drives the NotAFriend sweep instead.
+            var usernameMatch = await _ombiUserManager.Users.FirstOrDefaultAsync(
+                x => x.UserType == UserType.PlexUser && x.UserName == plexUser.username, ct);
+            if (usernameMatch == null) return null;
+
+            if (!IsUsernameAdoptionSafe(usernameMatch.ProviderUserId, plexUser.id))
+            {
+                _logger.LogWarning(
+                    "Plex user '{Username}' ({PlexUserId}) collides with existing Ombi user bound to {ProviderUserId}; skipping",
+                    plexUser.username, plexUser.id, usernameMatch.ProviderUserId);
+                return null;
+            }
+            return usernameMatch;
+        }
+
+        // A username match is only safe to adopt when we can convince ourselves it's the same
+        // Plex account: the stored ProviderUserId is blank (pre-link row), a legacy numeric
+        // plex.tv id (the #5399 migration case), or already equals the incoming community id.
+        // Anything else (a different community UUID) is treated as a hijack/ghost row —
+        // Plex usernames can be reused after an account is deleted, so we refuse to adopt.
+        private static bool IsUsernameAdoptionSafe(string storedProviderId, string communityId)
+        {
+            if (string.IsNullOrWhiteSpace(storedProviderId)) return true;
+            if (IsLegacyNumericPlexId(storedProviderId)) return true;
+            return string.Equals(storedProviderId, communityId, StringComparison.Ordinal);
+        }
+
+        private async Task<OmbiUser> CreateOmbiUserIfEligible(PlexCommunityUser plexUser, string resolvedNumericId, UserManagementSettings userManagement)
+        {
             if (string.IsNullOrWhiteSpace(plexUser.username))
             {
                 _logger.LogInformation($"Cannot create Ombi user for Plex id {plexUser.id} without a username");
@@ -370,14 +401,10 @@ namespace Ombi.Schedule.Jobs.Plex
             }
 
             // Only auto-create rows for friends Ombi can treat as first-class PlexUsers — ones
-            // with a numeric plex.tv account id from /api/users. That's the same identifier
-            // PlexUserImporter, GetOmbiUserFromPlexToken and IdentityController already key on,
-            // so the new row participates in cleanup, login, and reconciliation cleanly.
-            //
-            // Community-only friends (no server-share access, so not in /api/users) are
-            // intentionally skipped: we have no numeric id for them, they can't authenticate
-            // via /Token/plextoken, and PlexUserImporter.CleanupPlexUsers would delete them
-            // on its next run anyway. To sync their watchlist, share your server with them.
+            // with a numeric plex.tv account id from /api/users. Community-only friends (no
+            // server-share access) are intentionally skipped: they can't authenticate via
+            // /Token/plextoken, and PlexUserImporter.CleanupPlexUsers would delete them on its
+            // next run anyway. To sync their watchlist, share your server with them.
             if (string.IsNullOrWhiteSpace(resolvedNumericId))
             {
                 _logger.LogInformation(

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -341,7 +341,11 @@ namespace Ombi.Schedule.Jobs.Plex
             if (string.IsNullOrWhiteSpace(providerUserId)) return false;
             for (var i = 0; i < providerUserId.Length; i++)
             {
-                if (!char.IsDigit(providerUserId[i])) return false;
+                // Restrict to ASCII digits — char.IsDigit accepts all Unicode digit
+                // categories (Arabic-Indic, fullwidth, etc.), which would let a contrived
+                // ProviderUserId bypass the collision guard during the username fallback.
+                var c = providerUserId[i];
+                if (c < '0' || c > '9') return false;
             }
             return true;
         }

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -300,10 +300,16 @@ namespace Ombi.Schedule.Jobs.Plex
             }
 
             // Resolve the numeric plex.tv id for this username up-front (if /api/users gave
-            // us one) so we can match an existing row by either the community UUID or the
-            // numeric id. Without the numeric leg, a friend who renamed their plex.tv
-            // account would slip past both lookups and produce a duplicate Ombi row pointing
-            // at the same numeric id.
+            // us one) and use it as the primary lookup. New rows only ever get the numeric
+            // id (community-only friends are skipped below), so there's no reason to query
+            // by the community UUID here.
+            //
+            // Rows created by Ombi 4.59 with the community UUID in ProviderUserId still
+            // exist in users' databases. Those are picked up by the username fallback: the
+            // stored UUID will equal plexUser.id for the non-renamed common case, so the
+            // adoption path accepts it. If a user renamed their plex.tv account AND has a
+            // 4.59-era UUID row, the fallback won't find them and a duplicate row will be
+            // created — acknowledged edge case, not worth a migration to fix.
             string resolvedNumericId = null;
             if (legacyIdsByUsername != null
                 && !string.IsNullOrWhiteSpace(plexUser.username)
@@ -315,10 +321,8 @@ namespace Ombi.Schedule.Jobs.Plex
 
             var existing = resolvedNumericId != null
                 ? await _ombiUserManager.Users.FirstOrDefaultAsync(x =>
-                    x.UserType == UserType.PlexUser
-                    && (x.ProviderUserId == plexUser.id || x.ProviderUserId == resolvedNumericId), ct)
-                : await _ombiUserManager.Users.FirstOrDefaultAsync(x =>
-                    x.UserType == UserType.PlexUser && x.ProviderUserId == plexUser.id, ct);
+                    x.UserType == UserType.PlexUser && x.ProviderUserId == resolvedNumericId, ct)
+                : null;
             if (existing == null && !string.IsNullOrWhiteSpace(plexUser.username))
             {
                 // Fall back to a username match. Pre-existing users imported via the legacy


### PR DESCRIPTION
Pre-existing Plex users imported via the legacy /api/users path store the
numeric plex.tv account id in ProviderUserId, whereas the community
GraphQL API used by the new watchlist importer returns the account UUID.
The username-based fallback treated that mismatch as a hijack attempt
and skipped the user, so users that existed in Ombi before signing in
would never sync. Detect the legacy numeric format and upgrade the
stored id to the community UUID so the next run matches on the first
lookup.

Fixes #5399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plex watchlist import now handles legacy numeric Plex IDs alongside community UUIDs: creates/adopts users with numeric IDs when available, uses community UUIDs for syncing, avoids rewriting provider IDs, skips community-only friends, honours bans, and prevents cancelled imports from marking users "NotAFriend".

* **Tests**
  * Added regression tests covering legacy numeric ID adoption, admin creation, renamed-user adoption, username-collision handling, banned-user behaviour and cancelled runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->