### PR TITLE
feat(plex-settings): redesign settings page with modern layout

### DIFF
--- a/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.html
@@ -1,121 +1,164 @@
-<h1 mat-dialog-title>Server Configuration</h1>
-<mat-dialog-content>
-    <h2>Connection</h2>
+<div class="plex-dialog">
+    <header class="plex-dialog__head">
+        <div class="plex-dialog__icon" aria-hidden="true">
+            <mat-icon>dns</mat-icon>
+        </div>
+        <div class="plex-dialog__heading">
+            <div class="plex-dialog__eyebrow">Plex server</div>
+            <h1 class="plex-dialog__title">{{ data.server.name || 'Configure server' }}</h1>
+            <p class="plex-dialog__subtitle">
+                Connection details Ombi will use to talk to this Plex server.
+            </p>
+        </div>
+        <button type="button" class="plex-dialog__close" (click)="cancel()" aria-label="Close">
+            <mat-icon>close</mat-icon>
+        </button>
+    </header>
 
+    <mat-dialog-content class="plex-dialog__body">
+        <section class="dialog-section">
+            <div class="dialog-section__head">
+                <h2 class="dialog-section__title">Connection</h2>
+                <p class="dialog-section__desc">Where this server can be reached on your network.</p>
+            </div>
 
-    <mat-form-field appearance="outline" floatLabel=auto>
-      <mat-label>Server Name</mat-label>
-      <input matInput id="serverName" placeholder="Server Name" name="name" [(ngModel)]="this.data.server.name" value="{{this.data.server.name}}" autocomplete="off">
-    </mat-form-field>
+            <div class="form-stack">
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Server name</mat-label>
+                    <input matInput id="serverName" name="name" autocomplete="off"
+                           [(ngModel)]="data.server.name">
+                </mat-form-field>
 
-    <div class="row">
-      <mat-form-field class="col-md-6 col-12" appearance="outline" floatLabel=auto>
-        <mat-label>Hostname / IP</mat-label>
-        <input matInput id="ip" placeholder="Hostname or IP" name="ip" [(ngModel)]="this.data.server.ip" value="{{this.data.server.ip}}"
-           #serverHostnameIpControl="ngModel" required autocomplete="off">
-        <mat-error *ngIf="serverHostnameIpControl.hasError('required')">Must be specified.</mat-error>
-      </mat-form-field>
+                <div class="form-row form-row--connection">
+                    <mat-form-field appearance="outline" class="form-row__host">
+                        <mat-label>Hostname / IP</mat-label>
+                        <input matInput id="ip" name="ip" autocomplete="off"
+                               [(ngModel)]="data.server.ip" #serverHostnameIpControl="ngModel" required>
+                        <mat-error *ngIf="serverHostnameIpControl.hasError('required')">Must be specified.</mat-error>
+                    </mat-form-field>
 
-      <mat-form-field class="col-md-4 col-7" appearance="outline" floatLabel=auto>
-        <mat-label>Port</mat-label>
-        <input id="port" matInput placeholder="Port" name="port" [(ngModel)]="this.data.server.port" value="{{this.data.server.port}}"
-           #serverPortControl="ngModel" required pattern="^[0-9]*$" autocomplete="off">
-        <mat-error *ngIf="serverPortControl.hasError('required')">Must be specified.</mat-error>
-        <mat-error *ngIf="serverPortControl.hasError('pattern')">Must be a number.</mat-error>
-      </mat-form-field>
+                    <mat-form-field appearance="outline" class="form-row__port">
+                        <mat-label>Port</mat-label>
+                        <input matInput id="port" name="port" autocomplete="off"
+                               [(ngModel)]="data.server.port"
+                               #serverPortControl="ngModel" required pattern="^[0-9]*$">
+                        <mat-error *ngIf="serverPortControl.hasError('required')">Required.</mat-error>
+                        <mat-error *ngIf="serverPortControl.hasError('pattern')">Must be a number.</mat-error>
+                    </mat-form-field>
 
-      <mat-slide-toggle id="ssl" class="col-md-2 col-5 mt-3" id="ssl" name="ssl" [(ngModel)]="this.data.server.ssl" [checked]="this.data.server.ssl">
-        SSL
-      </mat-slide-toggle>
-    </div>
+                    <div class="form-row__ssl">
+                        <mat-slide-toggle id="ssl" name="ssl" [(ngModel)]="data.server.ssl">SSL</mat-slide-toggle>
+                    </div>
+                </div>
+            </div>
+        </section>
 
-    <mat-form-field appearance="outline" floatLabel=auto>
-      <mat-label>Plex Authorization Token</mat-label>
-      <input id="authToken" matInput placeholder="Plex Authorization Token" name="authToken" [(ngModel)]="this.data.server.plexAuthToken" value="{{this.data.server.plexAuthToken}}"
-         #serverApiKeyControl="ngModel" required autocomplete="off">
-      <mat-error *ngIf="serverApiKeyControl.hasError('required')">Must be specified.</mat-error>
-    </mat-form-field>
+        <section class="dialog-section">
+            <div class="dialog-section__head">
+                <h2 class="dialog-section__title">Authentication</h2>
+                <p class="dialog-section__desc">Credentials Plex uses to identify this server.</p>
+            </div>
 
-    <mat-form-field appearance="outline" floatLabel=auto>
-      <mat-label>Machine Identifier</mat-label>
-      <input id="machineId" matInput placeholder="Machine Identifier" name="MachineIdentifier" [(ngModel)]="this.data.server.machineIdentifier" value="{{this.data.server.machineIdentifier}}"
-         #serverApiKeyControl="ngModel" required autocomplete="off">
-      <mat-error *ngIf="serverApiKeyControl.hasError('required')">Must be specified.</mat-error>
-    </mat-form-field>
+            <div class="form-stack">
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Plex authorization token</mat-label>
+                    <input matInput id="authToken" name="authToken" autocomplete="off"
+                           [(ngModel)]="data.server.plexAuthToken" #serverApiKeyControl="ngModel" required>
+                    <mat-error *ngIf="serverApiKeyControl.hasError('required')">Must be specified.</mat-error>
+                </mat-form-field>
 
-    <mat-form-field appearance="outline" floatLabel=auto>
-      <mat-label>Externally Facing Hostname</mat-label>
-      <input id="externalHostname" matInput placeholder="e.g. https://emby.this.data.server.com/" name="serverHostname" name="hostname"
-        [(ngModel)]="this.data.server.serverHostname" value="{{this.data.server.serverHostname}}" autocomplete="off">
-      <mat-hint>
-        This will be the external address that users will navigate to when they press the 'View On Plex' button
-<br>
-            <span *ngIf="this.data.server.serverHostname">Current URL: "{{this.data.server.serverHostname}}/web/app#!/server/{{this.data.server.machineIdentifier}}/details?key=%2flibrary%2Fmetadata%2F53334"</span>
-            <span *ngIf="!this.data.server.serverHostname">Current URL: "https://app.plex.tv/web/app#!/server/{{this.data.server.machineIdentifier}}/details?key=%2flibrary%2Fmetadata%2F53334"</span>
-     
-      </mat-hint>
-    </mat-form-field>
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Machine identifier</mat-label>
+                    <input matInput id="machineId" name="MachineIdentifier" autocomplete="off"
+                           [(ngModel)]="data.server.machineIdentifier" #machineIdControl="ngModel" required>
+                    <mat-error *ngIf="machineIdControl.hasError('required')">Must be specified.</mat-error>
+                </mat-form-field>
+            </div>
+        </section>
 
-    <mat-form-field appearance="outline" floatLabel=auto>
-      <mat-label>Episode Batch Size</mat-label>
-      <input id="batchSize" matInput placeholder="150" name="MachineIdentifier" [(ngModel)]="this.data.server.episodeBatchSize" value="{{this.data.server.episodeBatchSize}}" autocomplete="off">
-      <mat-hint>
-        150 by default, you shouldn't need to change this, this sets how many episodes we request from Plex at a single time.
-      </mat-hint>
-    </mat-form-field>
+        <section class="dialog-section">
+            <div class="dialog-section__head">
+                <h2 class="dialog-section__title">Advanced</h2>
+                <p class="dialog-section__desc">Optional settings &mdash; usually you can leave these alone.</p>
+            </div>
 
-    <h2>Libraries</h2>
-    <div>
-      <button id="loadLibs" mat-raised-button (click)="loadLibraries()"
-          class="mat-focus-indicator mat-stroked-button mat-button-base">Load Libraries
-          <i class="fas fa-film"></i>
-      </button>
-  </div>
-    <div *ngIf="this.data.server.plexSelectedLibraries && this.data.server.plexSelectedLibraries.length > 0">
-      <label>Please select the libraries for Ombi to monitor. If nothing is selected, Ombi will monitor all
-        libraries.</label>
-        <div *ngFor="let lib of this.data.server.plexSelectedLibraries; let i = index">
-          <div class="md-form-field">
-              <div class="checkbox">
-                  <mat-slide-toggle id="lib-{{i}}" [(ngModel)]="lib.enabled" [checked]="lib.enabled"
-                      for="{{lib.title}}">{{lib.title}}</mat-slide-toggle>
-              </div>
-          </div>
-      </div>
-    </div>
+            <div class="form-stack">
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Externally facing hostname</mat-label>
+                    <input matInput id="externalHostname" name="hostname" autocomplete="off"
+                           placeholder="https://plex.example.com"
+                           [(ngModel)]="data.server.serverHostname">
+                </mat-form-field>
 
-</mat-dialog-content>
+                <div class="callout callout--muted">
+                    <mat-icon>link</mat-icon>
+                    <span>
+                        Sample &ldquo;View on Plex&rdquo; link:
+                        <code class="callout__code">{{ (data.server.serverHostname || 'https://app.plex.tv') }}/web/app#!/server/{{ data.server.machineIdentifier || '...' }}/details?key=%2flibrary%2Fmetadata%2F53334</code>
+                    </span>
+                </div>
 
-<mat-dialog-actions align=end>
-  <button id="testPlexButton" style="margin: .5em 0 0 .5em;" align-middle mat-stroked-button color="accent"
-    (click)="testPlex()">
-    <span style="display: flex; align-items: baseline; white-space: pre-wrap;">
-      <i class="fas fa-vial"></i>
-      <span> Test</span>
-    </span>
-  </button>
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Episode batch size</mat-label>
+                    <input matInput id="batchSize" name="batchSize" autocomplete="off"
+                           [(ngModel)]="data.server.episodeBatchSize">
+                    <mat-hint>Defaults to 150. Controls how many episodes are pulled per Plex request.</mat-hint>
+                </mat-form-field>
+            </div>
+        </section>
 
-  <button id="deleteServer" style="margin: .5em 0 0 .5em;" align-middle mat-stroked-button color="warn"
-  (click)="delete()">
-  <span style="display: flex; align-items: baseline; white-space: pre-wrap;">
-    <i class="fas fa-trash"></i>
-    <span> Delete</span>
-  </span>
-</button>
+        <section class="dialog-section">
+            <div class="dialog-section__head dialog-section__head--inline">
+                <div>
+                    <h2 class="dialog-section__title">Libraries</h2>
+                    <p class="dialog-section__desc">Pick which libraries Ombi monitors. Leave all off to monitor every library.</p>
+                </div>
+                <button type="button" id="loadLibs" class="dialog-btn dialog-btn--ghost"
+                        (click)="loadLibraries()">
+                    <mat-icon>refresh</mat-icon>
+                    Load libraries
+                </button>
+            </div>
 
-  <button id="cancel" style="margin: .5em 0 0 0.5em;" mat-stroked-button color="basic" (click)="cancel()">
-    <span style="display: flex; align-items: baseline; white-space: pre-wrap;">
-      <i class="fas fa-times"></i>
-      <span> Cancel</span>
-    </span>
-  </button>
+            <div *ngIf="data.server.plexSelectedLibraries?.length; else noLibs" class="library-grid">
+                <label *ngFor="let lib of data.server.plexSelectedLibraries; let i = index"
+                       class="library-tile"
+                       [class.library-tile--on]="lib.enabled">
+                    <span class="library-tile__icon">
+                        <mat-icon>{{ lib.enabled ? 'check_circle' : 'folder' }}</mat-icon>
+                    </span>
+                    <span class="library-tile__name">{{ lib.title }}</span>
+                    <mat-slide-toggle id="lib-{{i}}" [(ngModel)]="lib.enabled"></mat-slide-toggle>
+                </label>
+            </div>
 
+            <ng-template #noLibs>
+                <div class="empty-state">
+                    <mat-icon>folder_open</mat-icon>
+                    <p>No libraries loaded yet. Click <strong>Load libraries</strong> after entering connection details.</p>
+                </div>
+            </ng-template>
+        </section>
+    </mat-dialog-content>
 
-  <button id="saveServer" style="margin: .5em 0 0 .5em;" mat-stroked-button color="accent"
-     (click)="save()">
-    <span style="display: flex; align-items: baseline; white-space: pre-wrap;">
-      <i style="vertical-align: text-top;" class="fas fa-check"></i>
-      <span> Save</span>
-    </span>
-  </button>
-</mat-dialog-actions>
+    <mat-dialog-actions class="plex-dialog__actions">
+        <button type="button" id="testPlexButton" class="dialog-btn dialog-btn--ghost" (click)="testPlex()">
+            <mat-icon>science</mat-icon>
+            Test connection
+        </button>
+
+        <span class="plex-dialog__actions-spacer"></span>
+
+        <button type="button" id="deleteServer" class="dialog-btn dialog-btn--danger" (click)="delete()">
+            <mat-icon>delete_outline</mat-icon>
+            Delete
+        </button>
+        <button type="button" id="cancel" class="dialog-btn dialog-btn--neutral" (click)="cancel()">
+            Cancel
+        </button>
+        <button type="button" id="saveServer" class="dialog-btn dialog-btn--primary" (click)="save()">
+            <mat-icon>check</mat-icon>
+            Save
+        </button>
+    </mat-dialog-actions>
+</div>

--- a/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.scss
@@ -1,27 +1,439 @@
-@media (max-width: 978px) {
-  ::ng-deep .mat-dialog-container {
-    overflow: unset;
+$plex-bg:           #0b1220;
+$plex-surface:      #131b29;
+$plex-surface-2:    #1a2333;
+$plex-border:       #232c3f;
+$plex-border-soft:  #1d2536;
+$plex-text:         #e6ebf5;
+$plex-text-muted:   #9aa6bd;
+$plex-text-faint:   #6e7a92;
+$plex-accent:       #62d2fa;
+$plex-accent-soft:  rgba(98, 210, 250, 0.14);
+$plex-danger:       #f87171;
+$plex-success:      #4ade80;
+
+:host {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    color: $plex-text;
+    background: $plex-surface;
+}
 
-    .mat-dialog-content{
-        max-height: unset;
+.plex-dialog {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    background: $plex-surface;
+    color: $plex-text;
+
+    &__head {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 18px;
+        padding: 28px 28px 20px;
+        background: radial-gradient(120% 140% at 0% 0%, rgba(98, 210, 250, 0.08) 0%, transparent 55%);
     }
 
-    .mat-dialog-actions{
+    &__icon {
+        width: 48px;
+        height: 48px;
+        border-radius: 12px;
+        background: $plex-accent-soft;
+        color: $plex-accent;
+        display: grid;
+        place-items: center;
+
+        mat-icon { font-size: 26px; height: 26px; width: 26px; }
+    }
+
+    &__heading { min-width: 0; }
+
+    &__eyebrow {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: $plex-text-faint;
+    }
+
+    &__title {
+        margin: 4px 0 4px;
+        font-size: 20px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        color: #fff;
+        word-break: break-word;
+    }
+
+    &__subtitle {
+        margin: 0;
+        font-size: 13px;
+        color: $plex-text-muted;
+        line-height: 1.45;
+    }
+
+    &__close {
+        appearance: none;
+        background: transparent;
+        border: 1px solid transparent;
+        color: $plex-text-faint;
+        width: 36px;
+        height: 36px;
+        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+        transition: background .15s, border-color .15s, color .15s;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.04);
+            border-color: $plex-border-soft;
+            color: $plex-text;
+        }
+
+        &:focus-visible { outline: 2px solid $plex-accent; outline-offset: 2px; }
+    }
+
+    &__body {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        min-height: 0;
+        padding: 8px 24px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+    }
+
+    &__actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        padding: 18px 28px 24px;
+        margin: 0;
+        background: transparent;
         min-height: unset;
     }
 
-    emby-server-dialog-component {
-      display: flex;
-      flex-direction: column;
-      min-height: 1px;
-    }
-  }
+    &__actions-spacer { flex: 1 1 auto; }
 }
 
-::ng-deep mat-form-field .mat-form-field {
-  &-subscript-wrapper {
-    position: static;
-  }
+.dialog-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    &__head {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 0 6px;
+
+        &--inline {
+            flex-direction: row;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 16px;
+
+            > div { min-width: 0; }
+        }
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        color: #fff;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+    }
+
+    &__desc {
+        margin: 0;
+        font-size: 12.5px;
+        color: $plex-text-muted;
+        line-height: 1.5;
+    }
+}
+
+.form-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 18px 18px 6px;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid $plex-border-soft;
+    border-radius: 12px;
+}
+
+.full-width { width: 100%; }
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 130px auto;
+    gap: 12px;
+    align-items: start;
+
+    &__ssl {
+        display: flex;
+        align-items: center;
+        height: 56px;
+        padding: 0 4px;
+    }
+}
+
+.callout {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    font-size: 12.5px;
+    line-height: 1.5;
+
+    mat-icon { flex: 0 0 auto; font-size: 18px; height: 18px; width: 18px; margin-top: 2px; }
+
+    &--muted {
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid $plex-border-soft;
+        color: $plex-text-muted;
+
+        mat-icon { color: $plex-text-faint; }
+    }
+
+    &__code {
+        display: block;
+        margin-top: 6px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 11.5px;
+        color: $plex-text;
+        background: rgba(0, 0, 0, 0.25);
+        border: 1px solid $plex-border-soft;
+        border-radius: 6px;
+        padding: 6px 8px;
+        word-break: break-all;
+    }
+}
+
+.library-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 10px;
+}
+
+.library-tile {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    background: $plex-surface-2;
+    border: 1px solid $plex-border;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: border-color .15s, background .15s;
+
+    &:hover {
+        border-color: rgba(98, 210, 250, 0.45);
+    }
+
+    &--on {
+        border-color: rgba(98, 210, 250, 0.55);
+        background: rgba(98, 210, 250, 0.06);
+
+        .library-tile__icon {
+            background: $plex-accent-soft;
+            color: $plex-accent;
+        }
+    }
+
+    &__icon {
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.04);
+        color: $plex-text-faint;
+        display: grid;
+        place-items: center;
+
+        mat-icon { font-size: 18px; height: 18px; width: 18px; }
+    }
+
+    &__name {
+        font-size: 13.5px;
+        font-weight: 500;
+        color: #fff;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.empty-state {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 18px;
+    border: 1px dashed $plex-border;
+    border-radius: 12px;
+    color: $plex-text-muted;
+    font-size: 13px;
+    line-height: 1.5;
+
+    mat-icon { color: $plex-text-faint; font-size: 28px; height: 28px; width: 28px; flex: 0 0 auto; }
+    p { margin: 0; }
+    strong { color: $plex-text; }
+}
+
+.dialog-btn {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 38px;
+    padding: 0 14px;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background .15s, border-color .15s, color .15s, transform .12s;
+
+    mat-icon { font-size: 18px; height: 18px; width: 18px; }
+
+    &:focus-visible { outline: 2px solid $plex-accent; outline-offset: 2px; }
+    &:hover:not([disabled]) { transform: translateY(-1px); }
+    &[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+    &--primary {
+        background: $plex-accent;
+        color: #07111e;
+
+        &:hover:not([disabled]) { background: lighten($plex-accent, 4%); }
+    }
+
+    &--neutral {
+        background: transparent;
+        border-color: $plex-border;
+        color: $plex-text;
+
+        &:hover:not([disabled]) { background: rgba(255, 255, 255, 0.04); border-color: lighten($plex-border, 8%); }
+    }
+
+    &--ghost {
+        background: rgba(255, 255, 255, 0.03);
+        border-color: $plex-border-soft;
+        color: $plex-text;
+
+        &:hover:not([disabled]) {
+            background: rgba(98, 210, 250, 0.08);
+            border-color: rgba(98, 210, 250, 0.45);
+            color: #fff;
+        }
+    }
+
+    &--danger {
+        background: transparent;
+        border-color: rgba(248, 113, 113, 0.35);
+        color: $plex-danger;
+
+        &:hover:not([disabled]) {
+            background: rgba(248, 113, 113, 0.08);
+            border-color: rgba(248, 113, 113, 0.6);
+        }
+    }
+}
+
+::ng-deep .plex-dialog-panel {
+    .mat-dialog-container {
+        padding: 0 !important;
+        border-radius: 16px !important;
+        background: $plex-surface !important;
+        color: $plex-text !important;
+        border: 1px solid $plex-border !important;
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55) !important;
+        overflow: hidden !important;
+        max-height: 90vh !important;
+        height: auto !important;
+        display: flex !important;
+        flex-direction: column !important;
+    }
+
+    .mat-dialog-content {
+        padding: 0 !important;
+        margin: 0 !important;
+        max-height: none !important;
+        color: $plex-text !important;
+    }
+
+    .mat-dialog-actions {
+        padding: 0 !important;
+        margin: 0 !important;
+        min-height: 0 !important;
+    }
+
+    .mat-dialog-title {
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    .mat-dialog-container > * {
+        margin: 0 !important;
+    }
+}
+
+::ng-deep .plex-dialog {
+    .mat-mdc-form-field { width: 100%; }
+
+    .mat-mdc-text-field-wrapper {
+        background: rgba(255, 255, 255, 0.03);
+        border-radius: 10px;
+    }
+
+    .mdc-notched-outline > * { border-color: $plex-border !important; }
+    .mat-mdc-form-field:hover .mdc-notched-outline > * { border-color: lighten($plex-border, 10%) !important; }
+    .mat-mdc-form-field.mat-focused .mdc-notched-outline > * { border-color: $plex-accent !important; }
+
+    .mdc-floating-label { color: $plex-text-muted !important; }
+    .mat-mdc-input-element { color: $plex-text !important; caret-color: $plex-accent; }
+    .mat-mdc-form-field-hint-wrapper,
+    .mat-mdc-form-field-hint { color: $plex-text-faint !important; }
+    .mat-mdc-form-field-error { color: $plex-danger !important; }
+
+    .mat-mdc-slide-toggle .mdc-form-field { color: $plex-text; }
+}
+
+@media (max-width: 720px) {
+    .plex-dialog {
+        margin: 0;
+        max-height: 100vh;
+        height: 100%;
+        border-radius: 0;
+    }
+
+    .form-row {
+        grid-template-columns: 1fr;
+
+        &__ssl { height: auto; }
+    }
+
+    .plex-dialog__head {
+        grid-template-columns: auto 1fr auto;
+        padding: 18px;
+    }
+
+    .plex-dialog__body { padding: 16px; }
+
+    .plex-dialog__actions {
+        padding: 12px 14px;
+
+        .dialog-btn { flex: 1 1 auto; }
+        .plex-dialog__actions-spacer { display: none; }
+    }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/plex-server-dialog/plex-server-dialog.component.ts
@@ -6,6 +6,7 @@ import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatButtonModule } from "@angular/material/button";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
+import { MatIconModule } from "@angular/material/icon";
 
 import {
   PlexService,
@@ -25,7 +26,8 @@ import { PlexServerDialogData } from "../models";
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
-    MatSlideToggleModule
+    MatSlideToggleModule,
+    MatIconModule
   ],
   selector: "plex-server-dialog-component",
   templateUrl: "plex-server-dialog.component.html",

--- a/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.html
@@ -1,48 +1,97 @@
-﻿<div class="watchlist-dialog-container">
-  <mat-card class="watchlist-dialog-card">
-    <mat-card-header>
-      <mat-card-title>Watchlist Users</mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="watchlist-info-section">
-        <mat-icon color="primary" class="info-icon">info</mat-icon>
-        <span>
-          Ombi syncs watchlists using the server owner's Plex OAuth token &mdash; the server owner must be signed into Ombi via Plex for this to work.
-          Users you share with never need to log in themselves.
-          A user shows "Not a friend" if the server owner isn't a Plex friend of theirs, or they haven't set their watchlist visibility to "Friends" in Plex.
-        </span>
-      </div>
-      <mat-progress-bar *ngIf="isReloading" mode="indeterminate"></mat-progress-bar>
-      <div class="watchlist-legend">
-        <span><mat-icon color="primary">check_circle</mat-icon> Successfully syncing the watchlist</span>
-        <span><mat-icon color="warn">cancel</mat-icon> Error returned by the Plex community API</span>
-        <span><mat-icon color="accent">person_off</mat-icon> Not a friend of the server owner, or watchlist visibility is not set to Friends</span>
-        <span><mat-icon>schedule</mat-icon> Waiting for the first sync run</span>
-      </div>
-      <table mat-table *ngIf="dataSource" [dataSource]="dataSource" matSort class="mat-elevation-z8 modern-table">
-        <ng-container matColumnDef="userName">
-          <th mat-header-cell *matHeaderCellDef> Username </th>
-          <td mat-cell *matCellDef="let element"> {{element.userName}} </td>
-        </ng-container>
-        <ng-container matColumnDef="syncStatus">
-          <th mat-header-cell *matHeaderCellDef> Watchlist Sync Result </th>
-          <td mat-cell *matCellDef="let element">
-            <mat-icon *ngIf="element.syncStatus === WatchlistSyncStatus.Successful" color="primary">check_circle</mat-icon>
-            <mat-icon *ngIf="element.syncStatus === WatchlistSyncStatus.Failed" color="warn">cancel</mat-icon>
-            <mat-icon *ngIf="element.syncStatus === WatchlistSyncStatus.NotAFriend" color="accent">person_off</mat-icon>
-            <mat-icon *ngIf="element.syncStatus === WatchlistSyncStatus.Pending">schedule</mat-icon>
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-      </table>
-    </mat-card-content>
-    <mat-card-actions align="end">
-      <button mat-flat-button color="primary" (click)="forceRecheck()" [disabled]="isReloading">
-        <mat-icon>cached</mat-icon>
-        Force recheck
-      </button>
-      <button mat-stroked-button mat-dialog-close color="accent">Close</button>
-    </mat-card-actions>
-  </mat-card>
+<div class="plex-dialog">
+    <header class="plex-dialog__head">
+        <div class="plex-dialog__icon" aria-hidden="true">
+            <mat-icon>bookmark_added</mat-icon>
+        </div>
+        <div class="plex-dialog__heading">
+            <div class="plex-dialog__eyebrow">Plex watchlist</div>
+            <h1 class="plex-dialog__title">Watchlist users</h1>
+            <p class="plex-dialog__subtitle">
+                Sync status for every user whose Plex watchlist Ombi is tracking.
+            </p>
+        </div>
+        <button type="button" class="plex-dialog__close" mat-dialog-close aria-label="Close">
+            <mat-icon>close</mat-icon>
+        </button>
+    </header>
+
+    <mat-progress-bar *ngIf="isReloading" mode="indeterminate" class="plex-dialog__progress"></mat-progress-bar>
+
+    <mat-dialog-content class="plex-dialog__body">
+        <div class="callout callout--info">
+            <mat-icon>info</mat-icon>
+            <div class="callout__text">
+                Ombi syncs watchlists using the server owner's Plex OAuth token &mdash; the server owner must be signed in via Plex.
+                Users you share with never need to log in themselves. A user shows
+                <strong>Not a friend</strong> if the server owner isn't a Plex friend, or the user's watchlist visibility isn't set to
+                <strong>Friends</strong>.
+            </div>
+        </div>
+
+        <div class="legend">
+            <span class="legend__item legend__item--success">
+                <mat-icon>check_circle</mat-icon>
+                Successfully syncing
+            </span>
+            <span class="legend__item legend__item--danger">
+                <mat-icon>cancel</mat-icon>
+                Plex API error
+            </span>
+            <span class="legend__item legend__item--warn">
+                <mat-icon>person_off</mat-icon>
+                Not a friend / wrong visibility
+            </span>
+            <span class="legend__item legend__item--muted">
+                <mat-icon>schedule</mat-icon>
+                Waiting for first sync
+            </span>
+        </div>
+
+        <div *ngIf="dataSource && dataSource.data?.length; else empty" class="users-table">
+            <div class="users-table__head">
+                <span>Username</span>
+                <span>Sync status</span>
+            </div>
+            <div class="users-table__body">
+                <div *ngFor="let row of dataSource.data" class="users-table__row">
+                    <span class="users-table__user">{{ row.userName }}</span>
+                    <span class="status-chip"
+                          [class.status-chip--success]="row.syncStatus === WatchlistSyncStatus.Successful"
+                          [class.status-chip--danger]="row.syncStatus === WatchlistSyncStatus.Failed"
+                          [class.status-chip--warn]="row.syncStatus === WatchlistSyncStatus.NotAFriend"
+                          [class.status-chip--muted]="row.syncStatus === WatchlistSyncStatus.Pending">
+                        <mat-icon *ngIf="row.syncStatus === WatchlistSyncStatus.Successful">check_circle</mat-icon>
+                        <mat-icon *ngIf="row.syncStatus === WatchlistSyncStatus.Failed">cancel</mat-icon>
+                        <mat-icon *ngIf="row.syncStatus === WatchlistSyncStatus.NotAFriend">person_off</mat-icon>
+                        <mat-icon *ngIf="row.syncStatus === WatchlistSyncStatus.Pending">schedule</mat-icon>
+                        <span class="status-chip__label">
+                            <ng-container [ngSwitch]="row.syncStatus">
+                                <ng-container *ngSwitchCase="WatchlistSyncStatus.Successful">Syncing</ng-container>
+                                <ng-container *ngSwitchCase="WatchlistSyncStatus.Failed">Failed</ng-container>
+                                <ng-container *ngSwitchCase="WatchlistSyncStatus.NotAFriend">Not a friend</ng-container>
+                                <ng-container *ngSwitchCase="WatchlistSyncStatus.Pending">Pending</ng-container>
+                            </ng-container>
+                        </span>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <ng-template #empty>
+            <div class="empty-state">
+                <mat-icon>person_search</mat-icon>
+                <p>No watchlist users yet. They'll appear here once Plex users start watching content.</p>
+            </div>
+        </ng-template>
+    </mat-dialog-content>
+
+    <mat-dialog-actions class="plex-dialog__actions">
+        <button type="button" class="dialog-btn dialog-btn--ghost"
+                (click)="forceRecheck()" [disabled]="isReloading">
+            <mat-icon>cached</mat-icon>
+            {{ isReloading ? 'Rechecking...' : 'Force recheck' }}
+        </button>
+        <span class="plex-dialog__actions-spacer"></span>
+        <button type="button" class="dialog-btn dialog-btn--neutral" mat-dialog-close>Close</button>
+    </mat-dialog-actions>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/components/watchlist/plex-watchlist.component.scss
@@ -1,105 +1,363 @@
-@use "./styles/shared.scss" as *;
-.small-middle-container {
-    margin: auto;
-    width: 95%;
-    margin-top: 10px;
-}
-.fieldset {
+$plex-bg:           #0b1220;
+$plex-surface:      #131b29;
+$plex-surface-2:    #1a2333;
+$plex-border:       #232c3f;
+$plex-border-soft:  #1d2536;
+$plex-text:         #e6ebf5;
+$plex-text-muted:   #9aa6bd;
+$plex-text-faint:   #6e7a92;
+$plex-accent:       #62d2fa;
+$plex-accent-soft:  rgba(98, 210, 250, 0.14);
+$plex-success:      #4ade80;
+$plex-warn:         #f59e0b;
+$plex-danger:       #f87171;
+
+:host {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
     width: 100%;
+    color: $plex-text;
+    background: $plex-surface;
 }
 
-.key {
-    width: 40px;
+.plex-dialog {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    background: $plex-surface;
+    color: $plex-text;
+
+    &__head {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 18px;
+        padding: 28px 28px 20px;
+        background: radial-gradient(120% 140% at 0% 0%, rgba(98, 210, 250, 0.08) 0%, transparent 55%);
+    }
+
+    &__icon {
+        width: 48px;
+        height: 48px;
+        border-radius: 12px;
+        background: $plex-accent-soft;
+        color: $plex-accent;
+        display: grid;
+        place-items: center;
+
+        mat-icon { font-size: 26px; height: 26px; width: 26px; }
+    }
+
+    &__heading { min-width: 0; }
+
+    &__eyebrow {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: $plex-text-faint;
+    }
+
+    &__title {
+        margin: 4px 0 4px;
+        font-size: 20px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        color: #fff;
+    }
+
+    &__subtitle {
+        margin: 0;
+        font-size: 13px;
+        color: $plex-text-muted;
+        line-height: 1.45;
+    }
+
+    &__close {
+        appearance: none;
+        background: transparent;
+        border: 1px solid transparent;
+        color: $plex-text-faint;
+        width: 36px;
+        height: 36px;
+        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+        transition: background .15s, border-color .15s, color .15s;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.04);
+            border-color: $plex-border-soft;
+            color: $plex-text;
+        }
+
+        &:focus-visible { outline: 2px solid $plex-accent; outline-offset: 2px; }
+    }
+
+    &__progress {
+        flex: 0 0 auto;
+        --mdc-linear-progress-active-indicator-color: #{$plex-accent};
+        --mdc-linear-progress-track-color: #{$plex-border};
+    }
+
+    &__body {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        min-height: 0;
+        padding: 8px 24px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+    }
+
+    &__actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        padding: 18px 28px 24px;
+        margin: 0;
+        background: transparent;
+        min-height: unset;
+    }
+
+    &__actions-spacer { flex: 1 1 auto; }
 }
 
-.watchlist-dialog-container {
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  margin: 0 auto;
+.callout {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px 16px;
+    border-radius: 12px;
+    font-size: 13px;
+    line-height: 1.5;
+
+    mat-icon { flex: 0 0 auto; font-size: 20px; height: 20px; width: 20px; }
+
+    &__text {
+        flex: 1;
+        strong { color: #fff; font-weight: 600; }
+    }
+
+    &--info {
+        background: rgba(98, 210, 250, 0.08);
+        border: 1px solid rgba(98, 210, 250, 0.25);
+        color: $plex-text;
+
+        mat-icon { color: $plex-accent; }
+    }
 }
 
-.watchlist-dialog-card {
-  background: #23272f;
-  color: #f1f3f6;
-  border-radius: 12px;
-  border: 1px solid #353a45;
-  box-shadow: 0 2px 12px 0 rgba(0,0,0,0.25);
-  min-width: 420px;
-  max-width: 600px;
-  width: 100%;
-  max-height: 70vh;
-  display: flex;
-  flex-direction: column;
+.legend {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 8px;
+
+    &__item {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border-radius: 10px;
+        font-size: 12.5px;
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid $plex-border-soft;
+        color: $plex-text-muted;
+
+        mat-icon { font-size: 16px; height: 16px; width: 16px; }
+
+        &--success mat-icon { color: $plex-success; }
+        &--danger  mat-icon { color: $plex-danger; }
+        &--warn    mat-icon { color: $plex-warn; }
+        &--muted   mat-icon { color: $plex-text-faint; }
+    }
 }
 
-mat-card-content {
-  flex: 1 1 auto;
-  overflow-y: auto;
-  min-height: 0;
+.users-table {
+    border: 1px solid $plex-border;
+    border-radius: 12px;
+    overflow: hidden;
+
+    &__head {
+        display: grid;
+        grid-template-columns: 1fr 180px;
+        gap: 12px;
+        padding: 12px 16px;
+        background: rgba(255, 255, 255, 0.02);
+        border-bottom: 1px solid $plex-border;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: $plex-text-faint;
+    }
+
+    &__body {
+        display: flex;
+        flex-direction: column;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: 1fr 180px;
+        gap: 12px;
+        align-items: center;
+        padding: 12px 16px;
+        border-bottom: 1px solid $plex-border-soft;
+
+        &:last-child { border-bottom: 0; }
+        &:hover { background: rgba(255, 255, 255, 0.02); }
+    }
+
+    &__user {
+        font-size: 14px;
+        font-weight: 500;
+        color: #fff;
+        overflow-wrap: anywhere;
+    }
 }
 
-mat-card-header {
-  border-bottom: 1px solid #353a45;
-  margin-bottom: 12px;
-  flex: 0 0 auto;
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.04);
+    color: $plex-text-muted;
+    width: fit-content;
+
+    mat-icon { font-size: 14px; height: 14px; width: 14px; }
+
+    &--success { color: $plex-success; background: rgba(74, 222, 128, 0.10); border-color: rgba(74, 222, 128, 0.30); }
+    &--danger  { color: $plex-danger;  background: rgba(248, 113, 113, 0.10); border-color: rgba(248, 113, 113, 0.30); }
+    &--warn    { color: $plex-warn;    background: rgba(245, 158, 11, 0.10);  border-color: rgba(245, 158, 11, 0.30); }
+    &--muted   { color: $plex-text-faint; }
 }
 
-mat-card-title {
-  color: #fff !important;
-  font-weight: 700 !important;
-  letter-spacing: 0.5px;
+::ng-deep .plex-dialog-panel {
+    .mat-dialog-container {
+        padding: 0 !important;
+        border-radius: 16px !important;
+        background: $plex-surface !important;
+        color: $plex-text !important;
+        border: 1px solid $plex-border !important;
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55) !important;
+        overflow: hidden !important;
+        max-height: 90vh !important;
+        height: auto !important;
+        display: flex !important;
+        flex-direction: column !important;
+    }
+
+    .mat-dialog-content {
+        padding: 0 !important;
+        margin: 0 !important;
+        max-height: none !important;
+        color: $plex-text !important;
+    }
+
+    .mat-dialog-actions {
+        padding: 0 !important;
+        margin: 0 !important;
+        min-height: 0 !important;
+    }
+
+    .mat-dialog-title {
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    .mat-dialog-container > * {
+        margin: 0 !important;
+    }
 }
 
-.watchlist-info-section {
-  display: flex;
-  align-items: center;
-  background: #23272f;
-  color: #e0e3ea;
-  padding: 12px 0 8px 0;
-  font-size: 15px;
-  gap: 12px;
+.empty-state {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 24px;
+    border: 1px dashed $plex-border;
+    border-radius: 12px;
+    color: $plex-text-muted;
+    font-size: 13px;
+    line-height: 1.5;
+
+    mat-icon { color: $plex-text-faint; font-size: 32px; height: 32px; width: 32px; flex: 0 0 auto; }
+    p { margin: 0; }
 }
 
-.info-icon {
-  font-size: 28px;
-  color: #ffb300;
+.dialog-btn {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 38px;
+    padding: 0 14px;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background .15s, border-color .15s, color .15s, transform .12s;
+
+    mat-icon { font-size: 18px; height: 18px; width: 18px; }
+
+    &:focus-visible { outline: 2px solid $plex-accent; outline-offset: 2px; }
+    &:hover:not([disabled]) { transform: translateY(-1px); }
+    &[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+    &--neutral {
+        background: transparent;
+        border-color: $plex-border;
+        color: $plex-text;
+
+        &:hover:not([disabled]) { background: rgba(255, 255, 255, 0.04); border-color: lighten($plex-border, 8%); }
+    }
+
+    &--ghost {
+        background: rgba(255, 255, 255, 0.03);
+        border-color: $plex-border-soft;
+        color: $plex-text;
+
+        &:hover:not([disabled]) {
+            background: rgba(98, 210, 250, 0.08);
+            border-color: rgba(98, 210, 250, 0.45);
+            color: #fff;
+        }
+    }
 }
 
-.watchlist-legend {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-bottom: 18px;
-  margin-top: 8px;
-  font-size: 14px;
-  color: #b0b6c3;
-}
+@media (max-width: 720px) {
+    .plex-dialog {
+        margin: 0;
+        max-height: 100vh;
+        height: 100%;
+        border-radius: 0;
+    }
 
-.watchlist-legend mat-icon {
-  vertical-align: middle;
-  margin-right: 6px;
-}
+    .plex-dialog__head { padding: 18px; }
+    .plex-dialog__body { padding: 16px; }
 
-.modern-table {
-  background: transparent;
-  color: #f1f3f6;
-  border-radius: 8px;
-  margin-top: 10px;
-}
+    .users-table__head,
+    .users-table__row {
+        grid-template-columns: 1fr auto;
+    }
 
-.modern-table th, .modern-table td {
-  color: #f1f3f6;
-  font-size: 15px;
-}
-
-mat-card-actions {
-  padding-top: 16px;
-  flex: 0 0 auto;
-  background: #23272f;
-}
-
-button[mat-stroked-button] {
-  font-weight: 600;
-  border-radius: 6px;
+    .plex-dialog__actions {
+        padding: 12px 14px;
+        .dialog-btn { flex: 1 1 auto; }
+        .plex-dialog__actions-spacer { display: none; }
+    }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
@@ -156,6 +156,8 @@
 
         <div class="action-grid">
             <button type="button" class="action-tile"
+                    [class.action-tile--disabled]="!s.enable"
+                    [disabled]="!s.enable"
                     (click)="runSync(PlexSyncType.Full)" id="fullSync">
                 <span class="action-tile__icon action-tile__icon--blue">
                     <mat-icon>sync</mat-icon>
@@ -167,6 +169,8 @@
             </button>
 
             <button type="button" class="action-tile"
+                    [class.action-tile--disabled]="!s.enable"
+                    [disabled]="!s.enable"
                     (click)="runSync(PlexSyncType.RecentlyAdded)" id="recentlyAddedSync">
                 <span class="action-tile__icon action-tile__icon--teal">
                     <mat-icon>update</mat-icon>
@@ -178,6 +182,8 @@
             </button>
 
             <button type="button" class="action-tile"
+                    [class.action-tile--disabled]="!s.enable"
+                    [disabled]="!s.enable"
                     (click)="runSync(PlexSyncType.ClearAndReSync)" id="clearData">
                 <span class="action-tile__icon action-tile__icon--amber">
                     <mat-icon>cleaning_services</mat-icon>
@@ -189,8 +195,8 @@
             </button>
 
             <button type="button" class="action-tile"
-                    [class.action-tile--disabled]="!s.enableWatchlistImport"
-                    [disabled]="!s.enableWatchlistImport"
+                    [class.action-tile--disabled]="!s.enable || !s.enableWatchlistImport"
+                    [disabled]="!s.enable || !s.enableWatchlistImport"
                     (click)="runSync(PlexSyncType.WatchlistImport)" id="watchlistImport">
                 <span class="action-tile__icon action-tile__icon--violet">
                     <mat-icon>playlist_add</mat-icon>

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
@@ -1,4 +1,5 @@
-<div class="plex-page" *ngIf="settings">
+@if (settings(); as s) {
+<div class="plex-page">
 
     <!-- Page header -->
     <header class="page-header">
@@ -14,15 +15,17 @@
         </div>
         <div class="page-header__status">
             <span class="status-pill"
-                  [class.status-pill--on]="settings.enable"
-                  [class.status-pill--off]="!settings.enable">
+                  [class.status-pill--on]="s.enable"
+                  [class.status-pill--off]="!s.enable">
                 <span class="status-pill__dot"></span>
-                {{ settings.enable ? 'Enabled' : 'Disabled' }}
+                {{ s.enable ? 'Enabled' : 'Disabled' }}
             </span>
-            <span class="server-count" *ngIf="settings.servers?.length">
-                <mat-icon>dns</mat-icon>
-                {{ settings.servers.length }} server{{ settings.servers.length === 1 ? '' : 's' }}
-            </span>
+            @if (s.servers?.length) {
+                <span class="server-count">
+                    <mat-icon>dns</mat-icon>
+                    {{ s.servers.length }} server{{ s.servers.length === 1 ? '' : 's' }}
+                </span>
+            }
         </div>
     </header>
 
@@ -38,7 +41,7 @@
                     Master switch for the Plex media server connection. Disabling pauses sync and watchlist import.
                 </p>
             </div>
-            <mat-slide-toggle [id]="'enable'" [(ngModel)]="settings.enable" aria-label="Enable Plex"></mat-slide-toggle>
+            <mat-slide-toggle [id]="'enable'" [(ngModel)]="s.enable" aria-label="Enable Plex"></mat-slide-toggle>
         </div>
     </section>
 
@@ -55,20 +58,23 @@
             </div>
 
             <div class="server-grid">
-                <button class="server-tile"
-                        type="button"
-                        *ngFor="let server of settings.servers"
-                        (click)="edit(server)"
-                        [id]="server.name + '-button'">
-                    <span class="server-tile__icon"><mat-icon>dns</mat-icon></span>
-                    <span class="server-tile__name">{{ server.name }}</span>
-                    <span class="server-tile__meta" *ngIf="server.ip">
-                        {{ server.ssl ? 'https' : 'http' }}://{{ server.ip }}<ng-container *ngIf="server.port">:{{ server.port }}</ng-container>
-                    </span>
-                    <span class="server-tile__edit">
-                        <mat-icon>edit</mat-icon>
-                    </span>
-                </button>
+                @for (server of s.servers; track server.id) {
+                    <button class="server-tile"
+                            type="button"
+                            (click)="edit(server)"
+                            [id]="server.name + '-button'">
+                        <span class="server-tile__icon"><mat-icon>dns</mat-icon></span>
+                        <span class="server-tile__name">{{ server.name }}</span>
+                        @if (server.ip) {
+                            <span class="server-tile__meta">
+                                {{ server.ssl ? 'https' : 'http' }}://{{ server.ip }}@if (server.port) {<span>:{{ server.port }}</span>}
+                            </span>
+                        }
+                        <span class="server-tile__edit">
+                            <mat-icon>edit</mat-icon>
+                        </span>
+                    </button>
+                }
 
                 <button class="server-tile server-tile--add"
                         type="button"
@@ -122,14 +128,17 @@
 
                 <mat-form-field appearance="outline" class="full-width">
                     <mat-label>Select a discovered server</mat-label>
-                    <mat-select [id]="'servers'" *ngIf="loadedServers">
-                        <mat-option (click)="selectServer(s)"
-                                    *ngFor="let s of loadedServers.servers.devices"
-                                    [value]="s.device">
-                            {{ s.name }}
-                        </mat-option>
-                    </mat-select>
-                    <input matInput disabled placeholder="No servers loaded" *ngIf="!loadedServers">
+                    @if (loadedServers(); as discovered) {
+                        <mat-select [id]="'servers'">
+                            @for (device of discovered.servers.devices; track device.machineIdentifier) {
+                                <mat-option (click)="selectServer(device)" [value]="device.device">
+                                    {{ device.name }}
+                                </mat-option>
+                            }
+                        </mat-select>
+                    } @else {
+                        <input matInput disabled placeholder="No servers loaded">
+                    }
                 </mat-form-field>
             </div>
         </section>
@@ -179,8 +188,8 @@
             </button>
 
             <button type="button" class="action-tile"
-                    [class.action-tile--disabled]="!settings.enableWatchlistImport"
-                    [disabled]="!settings.enableWatchlistImport"
+                    [class.action-tile--disabled]="!s.enableWatchlistImport"
+                    [disabled]="!s.enableWatchlistImport"
                     (click)="runSync(PlexSyncType.WatchlistImport)" id="watchlistImport">
                 <span class="action-tile__icon action-tile__icon--violet">
                     <mat-icon>playlist_add</mat-icon>
@@ -217,13 +226,13 @@
                     </p>
                 </div>
                 <mat-slide-toggle [id]="'enableWatchlistImport'"
-                                  [(ngModel)]="settings.enableWatchlistImport"
+                                  [(ngModel)]="s.enableWatchlistImport"
                                   aria-label="Enable watchlist requests">
                 </mat-slide-toggle>
             </div>
 
             <div class="setting-row"
-                 [class.setting-row--disabled]="!settings.enableWatchlistImport">
+                 [class.setting-row--disabled]="!s.enableWatchlistImport">
                 <div class="setting-row__media">
                     <mat-icon>tv</mat-icon>
                 </div>
@@ -234,8 +243,8 @@
                     </p>
                 </div>
                 <mat-slide-toggle [id]="'monitorAll'"
-                                  [(ngModel)]="settings.monitorAll"
-                                  [disabled]="!settings.enableWatchlistImport"
+                                  [(ngModel)]="s.monitorAll"
+                                  [disabled]="!s.enableWatchlistImport"
                                   aria-label="Request whole show">
                 </mat-slide-toggle>
             </div>
@@ -265,3 +274,4 @@
         </button>
     </div>
 </div>
+}

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
@@ -129,9 +129,10 @@
                 <mat-form-field appearance="outline" class="full-width">
                     <mat-label>Select a discovered server</mat-label>
                     @if (loadedServers(); as discovered) {
-                        <mat-select [id]="'servers'">
+                        <mat-select [id]="'servers'"
+                                    (selectionChange)="selectServer($event.value)">
                             @for (device of discovered.servers.devices; track device.machineIdentifier) {
-                                <mat-option (click)="selectServer(device)" [value]="device.device">
+                                <mat-option [value]="device">
                                     {{ device.name }}
                                 </mat-option>
                             }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.html
@@ -1,165 +1,267 @@
-﻿<div class="plex-settings-container" *ngIf="settings">
-    <mat-card class="settings-card">
-        <mat-card-header>
-            <mat-card-title>Plex Configuration</mat-card-title>
-        </mat-card-header>
+<div class="plex-page" *ngIf="settings">
 
-        <mat-card-content>
-            <!-- Watchlist Settings Section -->
-            <div class="settings-section">
-                <div class="section-header">
-                    <h2>Watchlist Settings</h2>
+    <!-- Page header -->
+    <header class="page-header">
+        <div class="page-header__icon" aria-hidden="true">
+            <mat-icon>play_circle</mat-icon>
+        </div>
+        <div class="page-header__text">
+            <div class="page-header__eyebrow">Media Server</div>
+            <h1 class="page-header__title">Plex</h1>
+            <p class="page-header__subtitle">
+                Connect Ombi to your Plex servers, sync your libraries, and import user watchlists.
+            </p>
+        </div>
+        <div class="page-header__status">
+            <span class="status-pill"
+                  [class.status-pill--on]="settings.enable"
+                  [class.status-pill--off]="!settings.enable">
+                <span class="status-pill__dot"></span>
+                {{ settings.enable ? 'Enabled' : 'Disabled' }}
+            </span>
+            <span class="server-count" *ngIf="settings.servers?.length">
+                <mat-icon>dns</mat-icon>
+                {{ settings.servers.length }} server{{ settings.servers.length === 1 ? '' : 's' }}
+            </span>
+        </div>
+    </header>
+
+    <!-- Master enable -->
+    <section class="surface surface--hero" aria-labelledby="enable-plex-label">
+        <div class="row-toggle">
+            <div class="row-toggle__media">
+                <mat-icon>power_settings_new</mat-icon>
+            </div>
+            <div class="row-toggle__text">
+                <h2 class="row-toggle__title" id="enable-plex-label">Enable Plex integration</h2>
+                <p class="row-toggle__desc">
+                    Master switch for the Plex media server connection. Disabling pauses sync and watchlist import.
+                </p>
+            </div>
+            <mat-slide-toggle [id]="'enable'" [(ngModel)]="settings.enable" aria-label="Enable Plex"></mat-slide-toggle>
+        </div>
+    </section>
+
+    <!-- Servers + Discover -->
+    <div class="grid-2">
+
+        <!-- Servers -->
+        <section class="surface" aria-labelledby="servers-heading">
+            <div class="section-head">
+                <div>
+                    <h2 class="section-head__title" id="servers-heading">Servers</h2>
+                    <p class="section-head__desc">Manage the Plex servers Ombi will read from.</p>
                 </div>
+            </div>
 
-                <div class="settings-grid">
-                    <mat-card class="setting-card">
-                        <mat-card-content>
-                            <div class="setting-header">
-                                <h3>Enable Plex</h3>
-                                <mat-slide-toggle [id]="'enable'" [(ngModel)]="settings.enable"></mat-slide-toggle>
-                            </div>
-                        </mat-card-content>
-                    </mat-card>
-
-                    <mat-card class="setting-card">
-                        <mat-card-content>
-                            <div class="setting-header">
-                                <h3>Enable User Watchlist Requests</h3>
-                                <mat-slide-toggle [id]="'enableWatchlistImport'" [(ngModel)]="settings.enableWatchlistImport"></mat-slide-toggle>
-                            </div>
-                            <p class="setting-description">
-                                When a Plex User adds something to their watchlist in Plex, it will turn up in Ombi as a Request if enabled. 
-                                This <strong>only</strong> applies to users that are logging in with their Plex Account.
-                                <br>Request limits if set are all still applied
-                            </p>
-                        </mat-card-content>
-                    </mat-card>
-
-                    <mat-card class="setting-card" [class.disabled]="!settings.enableWatchlistImport">
-                        <mat-card-content>
-                            <div class="setting-header">
-                                <h3>Request Whole Show</h3>
-                                <mat-slide-toggle [id]="'monitorAll'" [(ngModel)]="settings.monitorAll" [disabled]="!settings.enableWatchlistImport"></mat-slide-toggle>
-                            </div>
-                            <p class="setting-description">
-                                If enabled then watchlist requests for TV Shows will request the <strong>whole</strong> show. 
-                                If not enabled it will only request the latest season.
-                            </p>
-                        </mat-card-content>
-                    </mat-card>
-
-                </div>
-                <mat-card class="info-banner">
-                    <mat-icon color="primary" style="margin-right: 12px;">info</mat-icon>
-                    <span style="flex:1;">
-                        Some users may need to re-log in to use the watchlist feature.
+            <div class="server-grid">
+                <button class="server-tile"
+                        type="button"
+                        *ngFor="let server of settings.servers"
+                        (click)="edit(server)"
+                        [id]="server.name + '-button'">
+                    <span class="server-tile__icon"><mat-icon>dns</mat-icon></span>
+                    <span class="server-tile__name">{{ server.name }}</span>
+                    <span class="server-tile__meta" *ngIf="server.ip">
+                        {{ server.ssl ? 'https' : 'http' }}://{{ server.ip }}<ng-container *ngIf="server.port">:{{ server.port }}</ng-container>
                     </span>
-                    <button mat-button color="accent" (click)="openWatchlistUserLog()">
-                        View Users
-                    </button>
-                </mat-card>
+                    <span class="server-tile__edit">
+                        <mat-icon>edit</mat-icon>
+                    </span>
+                </button>
+
+                <button class="server-tile server-tile--add"
+                        type="button"
+                        (click)="newServer()"
+                        id="newServer">
+                    <span class="server-tile__icon server-tile__icon--add">
+                        <mat-icon>add</mat-icon>
+                    </span>
+                    <span class="server-tile__name">Add server</span>
+                    <span class="server-tile__meta">Configure a new Plex connection</span>
+                </button>
             </div>
+        </section>
 
-            <!-- Main Content Area -->
-            <div class="main-content">
-                <!-- Left Column - Servers and Actions -->
-                <div class="content-column">
-                    <!-- Servers Section -->
-                    <div class="settings-section">
-                        <h2>Plex Servers</h2>
-                        <div class="servers-grid">
-                            <mat-card class="server-card" *ngFor="let server of settings.servers">
-                                <mat-card-content>
-                                    <button mat-button (click)="edit(server)" [id]="server.name + '-button'">
-                                        <mat-icon>dns</mat-icon>
-                                        <span>{{server.name}}</span>
-                                    </button>
-                                </mat-card-content>
-                            </mat-card>
-
-                            <mat-card class="server-card new-server">
-                                <mat-card-content>
-                                    <button mat-button (click)="newServer()" id="newServer">
-                                        <mat-icon>add_circle</mat-icon>
-                                        <span>Add Server</span>
-                                    </button>
-                                </mat-card-content>
-                            </mat-card>
-                        </div>
-                    </div>
-
-                    <!-- Sync Actions Section -->
-                    <div class="settings-section">
-                        <h2>Sync Actions</h2>
-                        <div class="sync-actions-grid">
-                            <button mat-stroked-button (click)="runSync(PlexSyncType.Full)" id="fullSync">
-                                <mat-icon>sync</mat-icon>
-                                Full Sync
-                            </button>
-                            <button mat-stroked-button (click)="runSync(PlexSyncType.RecentlyAdded)" id="recentlyAddedSync">
-                                <mat-icon>update</mat-icon>
-                                Partial Sync
-                            </button>
-                            <button mat-stroked-button (click)="runSync(PlexSyncType.ClearAndReSync)" id="clearData">
-                                <mat-icon>cleaning_services</mat-icon>
-                                Clear & Resync
-                            </button>
-                            <button mat-stroked-button (click)="runSync(PlexSyncType.WatchlistImport)" id="watchlistImport">
-                                <mat-icon>playlist_add</mat-icon>
-                                Run Watchlist Import
-                            </button>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Right Column - Plex Credentials -->
-                <div class="content-column">
-                    <div class="settings-section">
-                        <h2>Plex Credentials</h2>
-                        <mat-card class="credentials-card">
-                            <mat-card-content>
-                                <p class="credentials-description">
-                                    These fields are optional to automatically fill in your Plex server settings.
-                                    <br>This will pass your username and password to the Plex.tv API to grab the servers associated with this user.
-                                    <br>If you have 2FA enabled on your account, you need to append the 2FA code to the end of your password.
-                                </p>
-
-                                <mat-form-field appearance="outline" class="full-width">
-                                    <mat-label>Username</mat-label>
-                                    <input matInput [id]="'username'" [(ngModel)]="username">
-                                </mat-form-field>
-
-                                <mat-form-field appearance="outline" class="full-width">
-                                    <mat-label>Password</mat-label>
-                                    <input matInput [id]="'password'" type="password" [(ngModel)]="password">
-                                </mat-form-field>
-
-                                <button mat-raised-button color="primary" id="loadServers" (click)="requestServers()" class="full-width">
-                                    <mat-icon>key</mat-icon>
-                                    Load Servers
-                                </button>
-
-                                <mat-form-field appearance="outline" class="full-width mt-3">
-                                    <mat-label>Select Server</mat-label>
-                                    <mat-select [id]="'servers'" *ngIf="loadedServers">
-                                        <mat-option (click)="selectServer(s)" *ngFor="let s of loadedServers.servers.devices" [value]="s.device">
-                                            {{s.name}}
-                                        </mat-option>
-                                    </mat-select>
-                                    <input matInput disabled placeholder="No Servers Loaded" *ngIf="!loadedServers">
-                                </mat-form-field>
-                            </mat-card-content>
-                        </mat-card>
-                    </div>
+        <!-- Plex.tv credentials / discover -->
+        <section class="surface" aria-labelledby="discover-heading">
+            <div class="section-head">
+                <div>
+                    <h2 class="section-head__title" id="discover-heading">Discover with Plex.tv</h2>
+                    <p class="section-head__desc">
+                        Optional. Sign in with your Plex.tv account to auto-fill server details.
+                    </p>
                 </div>
             </div>
-        </mat-card-content>
 
-        <mat-card-actions align="end">
-            <button mat-raised-button color="accent" (click)="save()" id="save">
-                <mat-icon>save</mat-icon>
-                Save Changes
+            <div class="callout callout--muted">
+                <mat-icon>shield</mat-icon>
+                <span>
+                    Credentials are sent to the Plex.tv API to fetch your servers.
+                    If 2FA is enabled, append your code to the password.
+                </span>
+            </div>
+
+            <div class="form-stack">
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Plex.tv username</mat-label>
+                    <input matInput [id]="'username'" [(ngModel)]="username" autocomplete="off">
+                </mat-form-field>
+
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Password</mat-label>
+                    <input matInput [id]="'password'" type="password" [(ngModel)]="password" autocomplete="off">
+                </mat-form-field>
+
+                <button mat-flat-button color="primary" id="loadServers"
+                        (click)="requestServers()"
+                        class="full-width btn-primary">
+                    <mat-icon>vpn_key</mat-icon>
+                    Load servers
+                </button>
+
+                <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Select a discovered server</mat-label>
+                    <mat-select [id]="'servers'" *ngIf="loadedServers">
+                        <mat-option (click)="selectServer(s)"
+                                    *ngFor="let s of loadedServers.servers.devices"
+                                    [value]="s.device">
+                            {{ s.name }}
+                        </mat-option>
+                    </mat-select>
+                    <input matInput disabled placeholder="No servers loaded" *ngIf="!loadedServers">
+                </mat-form-field>
+            </div>
+        </section>
+    </div>
+
+    <!-- Sync actions -->
+    <section class="surface" aria-labelledby="sync-heading">
+        <div class="section-head">
+            <div>
+                <h2 class="section-head__title" id="sync-heading">Sync actions</h2>
+                <p class="section-head__desc">Trigger background jobs on demand.</p>
+            </div>
+        </div>
+
+        <div class="action-grid">
+            <button type="button" class="action-tile"
+                    (click)="runSync(PlexSyncType.Full)" id="fullSync">
+                <span class="action-tile__icon action-tile__icon--blue">
+                    <mat-icon>sync</mat-icon>
+                </span>
+                <span class="action-tile__body">
+                    <span class="action-tile__title">Full sync</span>
+                    <span class="action-tile__desc">Re-scan every library on every server.</span>
+                </span>
             </button>
-        </mat-card-actions>
-    </mat-card>
+
+            <button type="button" class="action-tile"
+                    (click)="runSync(PlexSyncType.RecentlyAdded)" id="recentlyAddedSync">
+                <span class="action-tile__icon action-tile__icon--teal">
+                    <mat-icon>update</mat-icon>
+                </span>
+                <span class="action-tile__body">
+                    <span class="action-tile__title">Partial sync</span>
+                    <span class="action-tile__desc">Pick up only recently added items.</span>
+                </span>
+            </button>
+
+            <button type="button" class="action-tile"
+                    (click)="runSync(PlexSyncType.ClearAndReSync)" id="clearData">
+                <span class="action-tile__icon action-tile__icon--amber">
+                    <mat-icon>cleaning_services</mat-icon>
+                </span>
+                <span class="action-tile__body">
+                    <span class="action-tile__title">Clear &amp; re-sync</span>
+                    <span class="action-tile__desc">Drop cached media and rebuild from scratch.</span>
+                </span>
+            </button>
+
+            <button type="button" class="action-tile"
+                    [class.action-tile--disabled]="!settings.enableWatchlistImport"
+                    [disabled]="!settings.enableWatchlistImport"
+                    (click)="runSync(PlexSyncType.WatchlistImport)" id="watchlistImport">
+                <span class="action-tile__icon action-tile__icon--violet">
+                    <mat-icon>playlist_add</mat-icon>
+                </span>
+                <span class="action-tile__body">
+                    <span class="action-tile__title">Watchlist import</span>
+                    <span class="action-tile__desc">Pull in user watchlists from Plex now.</span>
+                </span>
+            </button>
+        </div>
+    </section>
+
+    <!-- Watchlist -->
+    <section class="surface" aria-labelledby="watchlist-heading">
+        <div class="section-head">
+            <div>
+                <h2 class="section-head__title" id="watchlist-heading">Watchlist</h2>
+                <p class="section-head__desc">
+                    Turn Plex watchlist additions into Ombi requests for users signed in with their Plex account.
+                </p>
+            </div>
+        </div>
+
+        <div class="setting-list">
+            <div class="setting-row">
+                <div class="setting-row__media">
+                    <mat-icon>bookmark_added</mat-icon>
+                </div>
+                <div class="setting-row__text">
+                    <h3 class="setting-row__title">Enable user watchlist requests</h3>
+                    <p class="setting-row__desc">
+                        When a Plex user adds something to their watchlist it will appear in Ombi as a request.
+                        Existing request limits still apply.
+                    </p>
+                </div>
+                <mat-slide-toggle [id]="'enableWatchlistImport'"
+                                  [(ngModel)]="settings.enableWatchlistImport"
+                                  aria-label="Enable watchlist requests">
+                </mat-slide-toggle>
+            </div>
+
+            <div class="setting-row"
+                 [class.setting-row--disabled]="!settings.enableWatchlistImport">
+                <div class="setting-row__media">
+                    <mat-icon>tv</mat-icon>
+                </div>
+                <div class="setting-row__text">
+                    <h3 class="setting-row__title">Request whole show</h3>
+                    <p class="setting-row__desc">
+                        If on, watchlisted TV shows are requested in full. Otherwise only the latest season is requested.
+                    </p>
+                </div>
+                <mat-slide-toggle [id]="'monitorAll'"
+                                  [(ngModel)]="settings.monitorAll"
+                                  [disabled]="!settings.enableWatchlistImport"
+                                  aria-label="Request whole show">
+                </mat-slide-toggle>
+            </div>
+        </div>
+
+        <div class="callout callout--info">
+            <mat-icon>info</mat-icon>
+            <span class="callout__text">
+                Some users may need to re-log in to use the watchlist feature.
+            </span>
+            <button mat-stroked-button (click)="openWatchlistUserLog()" class="callout__action">
+                View users
+            </button>
+        </div>
+    </section>
+
+    <!-- Sticky save bar -->
+    <div class="save-bar">
+        <div class="save-bar__hint">
+            Changes are applied after saving.
+        </div>
+        <button mat-flat-button color="primary"
+                class="btn-primary save-bar__btn"
+                (click)="save()" id="save">
+            <mat-icon>check</mat-icon>
+            Save changes
+        </button>
+    </div>
 </div>

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
@@ -1,11 +1,5 @@
 @use "./styles/shared.scss" as *;
 
-/* ----------------------------------------------------------------------------
-   Plex settings page
-   Design tokens are defined locally so the component is self-contained while
-   still feeling at home in the Ombi dark theme.
----------------------------------------------------------------------------- */
-
 $plex-bg:           #0b1220;
 $plex-surface:      #131b29;
 $plex-surface-2:    #1a2333;
@@ -16,17 +10,6 @@ $plex-text-muted:   #9aa6bd;
 $plex-text-faint:   #6e7a92;
 $plex-accent:       #62d2fa;
 $plex-accent-soft:  rgba(98, 210, 250, 0.14);
-$plex-success:      #4ade80;
-$plex-warn:         #f59e0b;
-$plex-danger:       #ef4444;
-$plex-violet:       #a78bfa;
-$plex-teal:         #2dd4bf;
-
-$radius-sm: 8px;
-$radius-md: 12px;
-$radius-lg: 16px;
-
-/* ---------------------------------- Page ---------------------------------- */
 
 .plex-page {
     max-width: 1200px;
@@ -38,15 +21,13 @@ $radius-lg: 16px;
     gap: 24px;
 }
 
-/* --------------------------------- Header --------------------------------- */
-
 .page-header {
     display: grid;
     grid-template-columns: auto 1fr auto;
     align-items: center;
     gap: 24px;
     padding: 28px 32px;
-    border-radius: $radius-lg;
+    border-radius: 16px;
     background:
         radial-gradient(120% 140% at 0% 0%, rgba(98, 210, 250, 0.10) 0%, transparent 60%),
         linear-gradient(180deg, $plex-surface-2 0%, $plex-surface 100%);
@@ -62,11 +43,7 @@ $radius-lg: 16px;
         display: grid;
         place-items: center;
 
-        mat-icon {
-            font-size: 32px;
-            height: 32px;
-            width: 32px;
-        }
+        mat-icon { font-size: 32px; height: 32px; width: 32px; }
     }
 
     &__eyebrow {
@@ -83,7 +60,7 @@ $radius-lg: 16px;
         font-weight: 700;
         letter-spacing: -0.02em;
         line-height: 1.1;
-        color: #ffffff;
+        color: #fff;
     }
 
     &__subtitle {
@@ -110,7 +87,6 @@ $radius-lg: 16px;
     border-radius: 999px;
     font-size: 12px;
     font-weight: 600;
-    letter-spacing: 0.02em;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.04);
 
@@ -123,15 +99,13 @@ $radius-lg: 16px;
     }
 
     &--on {
-        color: $plex-success;
+        color: #4ade80;
         background: rgba(74, 222, 128, 0.12);
         border-color: rgba(74, 222, 128, 0.30);
     }
 
     &--off {
         color: $plex-text-faint;
-        background: rgba(255, 255, 255, 0.04);
-        border-color: rgba(255, 255, 255, 0.08);
     }
 }
 
@@ -142,25 +116,17 @@ $radius-lg: 16px;
     font-size: 12px;
     color: $plex-text-muted;
 
-    mat-icon {
-        font-size: 14px;
-        height: 14px;
-        width: 14px;
-    }
+    mat-icon { font-size: 14px; height: 14px; width: 14px; }
 }
-
-/* --------------------------------- Surface -------------------------------- */
 
 .surface {
     background: $plex-surface;
     border: 1px solid $plex-border;
-    border-radius: $radius-lg;
+    border-radius: 16px;
     padding: 24px 28px;
     box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset;
 
-    &--hero {
-        padding: 20px 24px;
-    }
+    &--hero { padding: 20px 24px; }
 }
 
 .section-head {
@@ -174,8 +140,7 @@ $radius-lg: 16px;
         margin: 0;
         font-size: 18px;
         font-weight: 600;
-        letter-spacing: -0.01em;
-        color: #ffffff;
+        color: #fff;
     }
 
     &__desc {
@@ -186,21 +151,11 @@ $radius-lg: 16px;
     }
 }
 
-/* --------------------------------- Layout --------------------------------- */
-
 .grid-2 {
     display: grid;
     grid-template-columns: 1.15fr 1fr;
     gap: 24px;
 }
-
-@media (max-width: 1024px) {
-    .grid-2 {
-        grid-template-columns: 1fr;
-    }
-}
-
-/* --------------------------- Toggle / setting row ------------------------- */
 
 .row-toggle {
     display: grid;
@@ -222,7 +177,7 @@ $radius-lg: 16px;
         margin: 0;
         font-size: 16px;
         font-weight: 600;
-        color: #ffffff;
+        color: #fff;
     }
 
     &__desc {
@@ -230,14 +185,12 @@ $radius-lg: 16px;
         font-size: 13px;
         color: $plex-text-muted;
         line-height: 1.5;
-        max-width: 70ch;
     }
 }
 
 .setting-list {
     display: flex;
     flex-direction: column;
-    gap: 4px;
     border-top: 1px solid $plex-border-soft;
 }
 
@@ -248,15 +201,9 @@ $radius-lg: 16px;
     gap: 18px;
     padding: 18px 4px;
     border-bottom: 1px solid $plex-border-soft;
-    transition: opacity 0.15s ease;
 
-    &:last-child {
-        border-bottom: 0;
-    }
-
-    &--disabled {
-        opacity: 0.55;
-    }
+    &:last-child { border-bottom: 0; }
+    &--disabled { opacity: 0.55; }
 
     &__media {
         width: 40px;
@@ -267,18 +214,14 @@ $radius-lg: 16px;
         display: grid;
         place-items: center;
 
-        mat-icon {
-            font-size: 22px;
-            height: 22px;
-            width: 22px;
-        }
+        mat-icon { font-size: 22px; height: 22px; width: 22px; }
     }
 
     &__title {
         margin: 0;
         font-size: 15px;
         font-weight: 600;
-        color: #ffffff;
+        color: #fff;
     }
 
     &__desc {
@@ -286,53 +229,44 @@ $radius-lg: 16px;
         font-size: 13px;
         color: $plex-text-muted;
         line-height: 1.5;
-        max-width: 70ch;
     }
 }
 
-/* --------------------------------- Servers -------------------------------- */
-
-.server-grid {
+.server-grid,
+.action-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 14px;
 }
 
+.action-grid { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
 .server-tile {
-    position: relative;
     appearance: none;
     text-align: left;
     background: $plex-surface-2;
     border: 1px solid $plex-border;
-    border-radius: $radius-md;
+    border-radius: 12px;
     padding: 18px 16px 16px;
     color: $plex-text;
     cursor: pointer;
     display: grid;
     grid-template-columns: auto 1fr auto;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-        "icon name edit"
-        "icon meta meta";
+    grid-template-areas: "icon name edit" "icon meta meta";
     column-gap: 12px;
     row-gap: 4px;
-    transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+    transition: transform .12s ease, border-color .15s, background .15s, box-shadow .15s;
 
     &:hover {
-        border-color: rgba(98, 210, 250, 0.45);
+        border-color: rgba(98, 210, 250, .45);
         background: lighten($plex-surface-2, 2%);
         transform: translateY(-1px);
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+        box-shadow: 0 6px 18px rgba(0, 0, 0, .25);
 
-        .server-tile__edit {
-            opacity: 1;
-        }
+        .server-tile__edit { opacity: 1; }
     }
 
-    &:focus-visible {
-        outline: 2px solid $plex-accent;
-        outline-offset: 2px;
-    }
+    &:focus-visible { outline: 2px solid $plex-accent; outline-offset: 2px; }
 
     &__icon {
         grid-area: icon;
@@ -344,14 +278,10 @@ $radius-lg: 16px;
         display: grid;
         place-items: center;
 
-        mat-icon {
-            font-size: 22px;
-            height: 22px;
-            width: 22px;
-        }
+        mat-icon { font-size: 22px; height: 22px; width: 22px; }
 
         &--add {
-            background: rgba(255, 255, 255, 0.05);
+            background: rgba(255, 255, 255, .05);
             color: $plex-text-muted;
         }
     }
@@ -360,7 +290,7 @@ $radius-lg: 16px;
         grid-area: name;
         font-size: 15px;
         font-weight: 600;
-        color: #ffffff;
+        color: #fff;
         line-height: 1.2;
         word-break: break-word;
     }
@@ -377,13 +307,9 @@ $radius-lg: 16px;
         grid-area: edit;
         color: $plex-text-faint;
         opacity: 0;
-        transition: opacity 0.15s ease;
+        transition: opacity .15s;
 
-        mat-icon {
-            font-size: 18px;
-            height: 18px;
-            width: 18px;
-        }
+        mat-icon { font-size: 18px; height: 18px; width: 18px; }
     }
 
     &--add {
@@ -392,17 +318,9 @@ $radius-lg: 16px;
 
         &:hover {
             border-color: $plex-accent;
-            background: rgba(98, 210, 250, 0.04);
+            background: rgba(98, 210, 250, .04);
         }
     }
-}
-
-/* ------------------------------- Action grid ------------------------------ */
-
-.action-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 14px;
 }
 
 .action-tile {
@@ -410,32 +328,26 @@ $radius-lg: 16px;
     text-align: left;
     background: $plex-surface-2;
     border: 1px solid $plex-border;
-    border-radius: $radius-md;
+    border-radius: 12px;
     padding: 16px 18px;
     color: $plex-text;
     cursor: pointer;
     display: flex;
     align-items: center;
     gap: 14px;
-    transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+    transition: transform .12s ease, border-color .15s, background .15s, box-shadow .15s;
 
     &:hover:not([disabled]) {
-        border-color: rgba(98, 210, 250, 0.45);
+        border-color: rgba(98, 210, 250, .45);
         background: lighten($plex-surface-2, 2%);
         transform: translateY(-1px);
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+        box-shadow: 0 6px 18px rgba(0, 0, 0, .25);
     }
 
-    &:focus-visible {
-        outline: 2px solid $plex-accent;
-        outline-offset: 2px;
-    }
+    &:focus-visible { outline: 2px solid $plex-accent; outline-offset: 2px; }
 
     &--disabled,
-    &[disabled] {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
+    &[disabled] { opacity: .5; cursor: not-allowed; }
 
     &__icon {
         flex: 0 0 auto;
@@ -447,28 +359,20 @@ $radius-lg: 16px;
         background: $plex-accent-soft;
         color: $plex-accent;
 
-        mat-icon {
-            font-size: 22px;
-            height: 22px;
-            width: 22px;
-        }
+        mat-icon { font-size: 22px; height: 22px; width: 22px; }
 
-        &--blue   { background: rgba(98,  210, 250, 0.15); color: $plex-accent; }
-        &--teal   { background: rgba(45,  212, 191, 0.15); color: $plex-teal; }
-        &--amber  { background: rgba(245, 158,  11, 0.15); color: $plex-warn; }
-        &--violet { background: rgba(167, 139, 250, 0.15); color: $plex-violet; }
+        &--blue   { background: rgba(98, 210, 250, .15); color: $plex-accent; }
+        &--teal   { background: rgba(45, 212, 191, .15); color: #2dd4bf; }
+        &--amber  { background: rgba(245, 158,  11, .15); color: #f59e0b; }
+        &--violet { background: rgba(167, 139, 250, .15); color: #a78bfa; }
     }
 
-    &__body {
-        display: flex;
-        flex-direction: column;
-        min-width: 0;
-    }
+    &__body { display: flex; flex-direction: column; min-width: 0; }
 
     &__title {
         font-size: 14px;
         font-weight: 600;
-        color: #ffffff;
+        color: #fff;
         line-height: 1.2;
     }
 
@@ -480,72 +384,44 @@ $radius-lg: 16px;
     }
 }
 
-/* --------------------------------- Forms ---------------------------------- */
-
 .form-stack {
     display: flex;
     flex-direction: column;
     gap: 6px;
     margin-top: 16px;
-
-    .full-width {
-        width: 100%;
-    }
 }
 
-.full-width {
-    width: 100%;
-}
-
-/* --------------------------------- Callout -------------------------------- */
+.full-width { width: 100%; }
 
 .callout {
     display: flex;
     align-items: center;
     gap: 12px;
     padding: 14px 16px;
-    border-radius: $radius-md;
+    border-radius: 12px;
     font-size: 13px;
     line-height: 1.5;
     margin-top: 16px;
 
-    &__text {
-        flex: 1;
-    }
-
-    &__action {
-        flex: 0 0 auto;
-    }
-
-    mat-icon {
-        flex: 0 0 auto;
-        font-size: 20px;
-        height: 20px;
-        width: 20px;
-    }
+    &__text { flex: 1; }
+    mat-icon { flex: 0 0 auto; font-size: 20px; height: 20px; width: 20px; }
 
     &--info {
-        background: rgba(98, 210, 250, 0.08);
-        border: 1px solid rgba(98, 210, 250, 0.25);
+        background: rgba(98, 210, 250, .08);
+        border: 1px solid rgba(98, 210, 250, .25);
         color: $plex-text;
 
-        mat-icon {
-            color: $plex-accent;
-        }
+        mat-icon { color: $plex-accent; }
     }
 
     &--muted {
-        background: rgba(255, 255, 255, 0.03);
+        background: rgba(255, 255, 255, .03);
         border: 1px solid $plex-border-soft;
         color: $plex-text-muted;
 
-        mat-icon {
-            color: $plex-text-faint;
-        }
+        mat-icon { color: $plex-text-faint; }
     }
 }
-
-/* -------------------------------- Save bar -------------------------------- */
 
 .save-bar {
     position: sticky;
@@ -556,28 +432,17 @@ $radius-lg: 16px;
     gap: 16px;
     padding: 14px 18px 14px 22px;
     margin-top: 8px;
-    background: rgba(19, 27, 41, 0.92);
+    background: rgba(19, 27, 41, .92);
     backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
     border: 1px solid $plex-border;
-    border-radius: $radius-md;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+    border-radius: 12px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, .45);
     z-index: 5;
 
-    &__hint {
-        font-size: 13px;
-        color: $plex-text-muted;
-    }
-
-    &__btn {
-        min-width: 160px;
-    }
+    &__hint { font-size: 13px; color: $plex-text-muted; }
+    &__btn { min-width: 160px; }
 }
 
-/* --------------------------------- Buttons -------------------------------- */
-
-.btn-primary.mat-mdc-raised-button,
-.btn-primary.mat-mdc-unelevated-button,
 .btn-primary {
     display: inline-flex;
     align-items: center;
@@ -586,62 +451,43 @@ $radius-lg: 16px;
     height: 42px;
     border-radius: 10px;
     font-weight: 600;
-    letter-spacing: 0.01em;
 }
 
-/* ------------------------- Material form-field tweaks --------------------- */
-
 ::ng-deep .plex-page {
-    .mat-mdc-form-field {
-        width: 100%;
-    }
+    .mat-mdc-form-field { width: 100%; }
 
     .mat-mdc-text-field-wrapper {
-        background: rgba(255, 255, 255, 0.03);
+        background: rgba(255, 255, 255, .03);
         border-radius: 10px;
     }
 
-    .mdc-notched-outline__leading,
-    .mdc-notched-outline__notch,
-    .mdc-notched-outline__trailing {
-        border-color: $plex-border !important;
-    }
+    .mdc-notched-outline > * { border-color: $plex-border !important; }
 
-    .mat-mdc-form-field:hover .mdc-notched-outline__leading,
-    .mat-mdc-form-field:hover .mdc-notched-outline__notch,
-    .mat-mdc-form-field:hover .mdc-notched-outline__trailing {
+    .mat-mdc-form-field:hover .mdc-notched-outline > * {
         border-color: lighten($plex-border, 10%) !important;
     }
 
-    .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
-    .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
-    .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+    .mat-mdc-form-field.mat-focused .mdc-notched-outline > * {
         border-color: $plex-accent !important;
     }
 
-    .mat-mdc-form-field-label,
-    .mdc-floating-label {
-        color: $plex-text-muted !important;
-    }
+    .mdc-floating-label { color: $plex-text-muted !important; }
 
-    .mat-mdc-input-element,
-    input.mat-mdc-input-element {
+    .mat-mdc-input-element {
         color: $plex-text !important;
         caret-color: $plex-accent;
     }
 
     .mat-mdc-select-value,
-    .mat-mdc-select-arrow {
-        color: $plex-text !important;
-    }
+    .mat-mdc-select-arrow { color: $plex-text !important; }
 }
 
-/* ------------------------------ Responsiveness ---------------------------- */
+@media (max-width: 1024px) {
+    .grid-2 { grid-template-columns: 1fr; }
+}
 
 @media (max-width: 720px) {
-    .plex-page {
-        padding: 20px 16px 140px;
-    }
+    .plex-page { padding: 20px 16px 140px; }
 
     .page-header {
         grid-template-columns: auto 1fr;
@@ -650,28 +496,15 @@ $radius-lg: 16px;
         &__status {
             grid-column: 1 / -1;
             flex-direction: row;
-            align-items: center;
             justify-content: flex-start;
         }
 
-        &__title {
-            font-size: 24px;
-        }
+        &__title { font-size: 24px; }
     }
 
-    .surface {
-        padding: 18px 16px;
-    }
+    .surface { padding: 18px 16px; }
 
-    .row-toggle {
-        grid-template-columns: auto 1fr;
-
-        mat-slide-toggle {
-            grid-column: 1 / -1;
-            justify-self: end;
-        }
-    }
-
+    .row-toggle,
     .setting-row {
         grid-template-columns: auto 1fr;
 
@@ -685,8 +518,6 @@ $radius-lg: 16px;
         flex-direction: column;
         align-items: stretch;
 
-        &__btn {
-            width: 100%;
-        }
+        &__btn { width: 100%; }
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
@@ -1,300 +1,692 @@
 @use "./styles/shared.scss" as *;
-.small-middle-container {
-    margin: auto;
-    width: 95%;
-    margin-top: 10px;
-}
 
-.col-8 {
-    display: inline-table;
-}
-.col-md-5 {
-    display: inline-table;
-}
+/* ----------------------------------------------------------------------------
+   Plex settings page
+   Design tokens are defined locally so the component is self-contained while
+   still feeling at home in the Ombi dark theme.
+---------------------------------------------------------------------------- */
 
+$plex-bg:           #0b1220;
+$plex-surface:      #131b29;
+$plex-surface-2:    #1a2333;
+$plex-border:       #232c3f;
+$plex-border-soft:  #1d2536;
+$plex-text:         #e6ebf5;
+$plex-text-muted:   #9aa6bd;
+$plex-text-faint:   #6e7a92;
+$plex-accent:       #62d2fa;
+$plex-accent-soft:  rgba(98, 210, 250, 0.14);
+$plex-success:      #4ade80;
+$plex-warn:         #f59e0b;
+$plex-danger:       #ef4444;
+$plex-violet:       #a78bfa;
+$plex-teal:         #2dd4bf;
 
-.align-right {
-    float: right;
-    width:100%;
-    text-align:right;
-}
+$radius-sm: 8px;
+$radius-md: 12px;
+$radius-lg: 16px;
 
-::ng-deep div .mat-tab-body-content {
-    overflow: hidden;
-}
-.server-card {
-    margin: 0em 1em 1em 0;
-    width: 13em;
-    min-height: 8em;
-  
-    button {
-      text-align: center;
-      align-content: center;
-      white-space: normal;
-      overflow-wrap: anywhere;
-      height: 100%;
-      width: 100%;
-    }
-  
-    i {
-      margin-top: 0.25em;
-    }
-  
-    h3 {
-      margin: 0;
-    }
-  }
+/* ---------------------------------- Page ---------------------------------- */
 
-.plex-settings-container {
-    padding: 20px;
-    max-width: 1400px;
+.plex-page {
+    max-width: 1200px;
     margin: 0 auto;
-}
-
-.settings-card {
-    margin-bottom: 20px;
-    background: transparent;
-    box-shadow: 0 2px 12px 0 rgba(0,0,0,0.25);
-    border-radius: 12px;
-    border: 1px solid #353a45;
-}
-
-.section-header {
+    padding: 32px 28px 140px;
+    color: $plex-text;
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-}
-
-.settings-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    flex-direction: column;
     gap: 24px;
-    margin-bottom: 30px;
 }
 
-.setting-card {
-    height: 100%;
-    background: transparent;
-    border-radius: 10px;
-    border: 1px solid #353a45;
-    box-shadow: 0 1px 6px 0 rgba(0,0,0,0.18);
-    color: #f1f3f6;
-}
+/* --------------------------------- Header --------------------------------- */
 
-.setting-card.disabled {
-    opacity: 0.6;
-}
-
-.setting-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 10px;
-    font-weight: 600;
-    color: #fff;
-}
-
-.setting-description {
-    color: #e0e3ea;
-    font-size: 15px;
-    margin: 0;
-    font-weight: 400;
-    line-height: 1.6;
-}
-
-.main-content {
+.page-header {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 36px;
-    margin-top: 36px;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 24px;
+    padding: 28px 32px;
+    border-radius: $radius-lg;
+    background:
+        radial-gradient(120% 140% at 0% 0%, rgba(98, 210, 250, 0.10) 0%, transparent 60%),
+        linear-gradient(180deg, $plex-surface-2 0%, $plex-surface 100%);
+    border: 1px solid $plex-border;
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 8px 30px rgba(0, 0, 0, 0.25);
+
+    &__icon {
+        width: 56px;
+        height: 56px;
+        border-radius: 14px;
+        background: $plex-accent-soft;
+        color: $plex-accent;
+        display: grid;
+        place-items: center;
+
+        mat-icon {
+            font-size: 32px;
+            height: 32px;
+            width: 32px;
+        }
+    }
+
+    &__eyebrow {
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: $plex-text-faint;
+    }
+
+    &__title {
+        margin: 4px 0 6px;
+        font-size: 30px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        line-height: 1.1;
+        color: #ffffff;
+    }
+
+    &__subtitle {
+        margin: 0;
+        font-size: 14px;
+        color: $plex-text-muted;
+        line-height: 1.5;
+        max-width: 60ch;
+    }
+
+    &__status {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 8px;
+    }
 }
 
-.servers-grid {
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    border: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.04);
+
+    &__dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: currentColor;
+        box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.04);
+    }
+
+    &--on {
+        color: $plex-success;
+        background: rgba(74, 222, 128, 0.12);
+        border-color: rgba(74, 222, 128, 0.30);
+    }
+
+    &--off {
+        color: $plex-text-faint;
+        background: rgba(255, 255, 255, 0.04);
+        border-color: rgba(255, 255, 255, 0.08);
+    }
+}
+
+.server-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: $plex-text-muted;
+
+    mat-icon {
+        font-size: 14px;
+        height: 14px;
+        width: 14px;
+    }
+}
+
+/* --------------------------------- Surface -------------------------------- */
+
+.surface {
+    background: $plex-surface;
+    border: 1px solid $plex-border;
+    border-radius: $radius-lg;
+    padding: 24px 28px;
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset;
+
+    &--hero {
+        padding: 20px 24px;
+    }
+}
+
+.section-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+
+    &__title {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        color: #ffffff;
+    }
+
+    &__desc {
+        margin: 4px 0 0;
+        font-size: 13px;
+        color: $plex-text-muted;
+        line-height: 1.5;
+    }
+}
+
+/* --------------------------------- Layout --------------------------------- */
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1.15fr 1fr;
+    gap: 24px;
+}
+
+@media (max-width: 1024px) {
+    .grid-2 {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* --------------------------- Toggle / setting row ------------------------- */
+
+.row-toggle {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 18px;
+
+    &__media {
+        width: 44px;
+        height: 44px;
+        border-radius: 12px;
+        background: $plex-accent-soft;
+        color: $plex-accent;
+        display: grid;
+        place-items: center;
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+        color: #ffffff;
+    }
+
+    &__desc {
+        margin: 4px 0 0;
+        font-size: 13px;
+        color: $plex-text-muted;
+        line-height: 1.5;
+        max-width: 70ch;
+    }
+}
+
+.setting-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-top: 1px solid $plex-border-soft;
+}
+
+.setting-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 18px;
+    padding: 18px 4px;
+    border-bottom: 1px solid $plex-border-soft;
+    transition: opacity 0.15s ease;
+
+    &:last-child {
+        border-bottom: 0;
+    }
+
+    &--disabled {
+        opacity: 0.55;
+    }
+
+    &__media {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        background: rgba(255, 255, 255, 0.04);
+        color: $plex-text-muted;
+        display: grid;
+        place-items: center;
+
+        mat-icon {
+            font-size: 22px;
+            height: 22px;
+            width: 22px;
+        }
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+        color: #ffffff;
+    }
+
+    &__desc {
+        margin: 4px 0 0;
+        font-size: 13px;
+        color: $plex-text-muted;
+        line-height: 1.5;
+        max-width: 70ch;
+    }
+}
+
+/* --------------------------------- Servers -------------------------------- */
+
+.server-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 18px;
+    gap: 14px;
 }
 
-.server-card {
-    text-align: center;
-    background: transparent;
-    border-radius: 10px;
-    border: 1px solid #353a45;
-    box-shadow: 0 1px 6px 0 rgba(0,0,0,0.18);
-    color: #f1f3f6;
-}
-
-.server-card button {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
-    color: #f1f3f6;
-    font-weight: 500;
-}
-
-.server-card mat-icon {
-    font-size: 32px;
-    height: 32px;
-    width: 32px;
-    margin-bottom: 10px;
-    color: #90caf9;
-}
-
-.sync-actions-grid {
+.server-tile {
+    position: relative;
+    appearance: none;
+    text-align: left;
+    background: $plex-surface-2;
+    border: 1px solid $plex-border;
+    border-radius: $radius-md;
+    padding: 18px 16px 16px;
+    color: $plex-text;
+    cursor: pointer;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 18px;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+        "icon name edit"
+        "icon meta meta";
+    column-gap: 12px;
+    row-gap: 4px;
+    transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover {
+        border-color: rgba(98, 210, 250, 0.45);
+        background: lighten($plex-surface-2, 2%);
+        transform: translateY(-1px);
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+
+        .server-tile__edit {
+            opacity: 1;
+        }
+    }
+
+    &:focus-visible {
+        outline: 2px solid $plex-accent;
+        outline-offset: 2px;
+    }
+
+    &__icon {
+        grid-area: icon;
+        width: 38px;
+        height: 38px;
+        border-radius: 10px;
+        background: $plex-accent-soft;
+        color: $plex-accent;
+        display: grid;
+        place-items: center;
+
+        mat-icon {
+            font-size: 22px;
+            height: 22px;
+            width: 22px;
+        }
+
+        &--add {
+            background: rgba(255, 255, 255, 0.05);
+            color: $plex-text-muted;
+        }
+    }
+
+    &__name {
+        grid-area: name;
+        font-size: 15px;
+        font-weight: 600;
+        color: #ffffff;
+        line-height: 1.2;
+        word-break: break-word;
+    }
+
+    &__meta {
+        grid-area: meta;
+        font-size: 12px;
+        color: $plex-text-faint;
+        line-height: 1.3;
+        word-break: break-all;
+    }
+
+    &__edit {
+        grid-area: edit;
+        color: $plex-text-faint;
+        opacity: 0;
+        transition: opacity 0.15s ease;
+
+        mat-icon {
+            font-size: 18px;
+            height: 18px;
+            width: 18px;
+        }
+    }
+
+    &--add {
+        border-style: dashed;
+        background: transparent;
+
+        &:hover {
+            border-color: $plex-accent;
+            background: rgba(98, 210, 250, 0.04);
+        }
+    }
 }
 
-.sync-actions-grid button {
+/* ------------------------------- Action grid ------------------------------ */
+
+.action-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 14px;
+}
+
+.action-tile {
+    appearance: none;
+    text-align: left;
+    background: $plex-surface-2;
+    border: 1px solid $plex-border;
+    border-radius: $radius-md;
+    padding: 16px 18px;
+    color: $plex-text;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover:not([disabled]) {
+        border-color: rgba(98, 210, 250, 0.45);
+        background: lighten($plex-surface-2, 2%);
+        transform: translateY(-1px);
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+    }
+
+    &:focus-visible {
+        outline: 2px solid $plex-accent;
+        outline-offset: 2px;
+    }
+
+    &--disabled,
+    &[disabled] {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    &__icon {
+        flex: 0 0 auto;
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        background: $plex-accent-soft;
+        color: $plex-accent;
+
+        mat-icon {
+            font-size: 22px;
+            height: 22px;
+            width: 22px;
+        }
+
+        &--blue   { background: rgba(98,  210, 250, 0.15); color: $plex-accent; }
+        &--teal   { background: rgba(45,  212, 191, 0.15); color: $plex-teal; }
+        &--amber  { background: rgba(245, 158,  11, 0.15); color: $plex-warn; }
+        &--violet { background: rgba(167, 139, 250, 0.15); color: $plex-violet; }
+    }
+
+    &__body {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+    }
+
+    &__title {
+        font-size: 14px;
+        font-weight: 600;
+        color: #ffffff;
+        line-height: 1.2;
+    }
+
+    &__desc {
+        margin-top: 4px;
+        font-size: 12px;
+        color: $plex-text-muted;
+        line-height: 1.4;
+    }
+}
+
+/* --------------------------------- Forms ---------------------------------- */
+
+.form-stack {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    padding: 24px;
-    color: #f1f3f6;
-    background: transparent;
-    border: 1px solid #353a45;
-    border-radius: 10px;
-    font-weight: 500;
-    box-shadow: 0 1px 6px 0 rgba(0,0,0,0.18);
-}
+    gap: 6px;
+    margin-top: 16px;
 
-.sync-actions-grid mat-icon {
-    font-size: 32px;
-    height: 32px;
-    width: 32px;
-    margin-bottom: 10px;
-    color: #90caf9;
-}
-
-.credentials-card {
-    padding: 24px;
-    background: transparent;
-    border-radius: 10px;
-    border: 1px solid #353a45;
-    box-shadow: 0 1px 6px 0 rgba(0,0,0,0.18);
-    color: #f1f3f6;
-}
-
-.credentials-description {
-    color: #e0e3ea;
-    margin-bottom: 20px;
-    font-size: 15px;
-    font-weight: 400;
-}
-
-mat-card-title, h2, h3 {
-    color: #fff !important;
-    font-weight: 700 !important;
-    letter-spacing: 0.5px;
-}
-
-mat-card-header {
-    border-bottom: 1px solid #353a45;
-    margin-bottom: 16px;
-}
-
-mat-form-field {
-    color: #f1f3f6 !important;
-}
-
-mat-label, .mat-form-field-label {
-    color: #b0b6c3 !important;
-    font-weight: 500;
-}
-
-input[matInput], .mat-input-element {
-    color: #f1f3f6 !important;
-    background: transparent !important;
-}
-
-mat-select {
-    color: #f1f3f6 !important;
-    background: transparent !important;
+    .full-width {
+        width: 100%;
+    }
 }
 
 .full-width {
     width: 100%;
 }
 
-.mt-3 {
-    margin-top: 1rem;
-}
+/* --------------------------------- Callout -------------------------------- */
 
-.mat-slide-toggle.mat-checked .mat-slide-toggle-bar {
-    background-color: #90caf9 !important;
-}
-
-.mat-slide-toggle-thumb {
-    background-color: #2196f3 !important;
-}
-
-button[mat-flat-button], button[mat-raised-button], button[mat-stroked-button], button[mat-button] {
-    font-weight: 600;
-    letter-spacing: 0.2px;
-    color: #f1f3f6;
-    background: #2196f3;
-    border-radius: 6px;
-    box-shadow: 0 1px 4px 0 rgba(0,0,0,0.12);
-    transition: background 0.2s;
-}
-button[mat-flat-button]:hover, button[mat-raised-button]:hover, button[mat-stroked-button]:hover, button[mat-button]:hover {
-    background: #42a5f5;
-}
-
-@media (max-width: 1200px) {
-    .main-content {
-        grid-template-columns: 1fr;
-    }
-}
-
-@media (max-width: 768px) {
-    .settings-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .servers-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .sync-actions-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-.watchlist-errors-btn-row {
-    display: flex;
-    justify-content: center;
-    margin-top: 18px;
-}
-
-.info-banner {
+.callout {
     display: flex;
     align-items: center;
-    background: #23272f;
-    color: #e0e3ea;
-    border: 1px solid #1976d2;
-    box-shadow: 0 1px 6px 0 rgba(0,0,0,0.12);
-    border-radius: 8px;
-    padding: 16px 20px;
-    margin-top: 18px;
-    margin-bottom: 0;
-    font-size: 16px;
-    font-weight: 500;
     gap: 12px;
+    padding: 14px 16px;
+    border-radius: $radius-md;
+    font-size: 13px;
+    line-height: 1.5;
+    margin-top: 16px;
+
+    &__text {
+        flex: 1;
+    }
+
+    &__action {
+        flex: 0 0 auto;
+    }
+
+    mat-icon {
+        flex: 0 0 auto;
+        font-size: 20px;
+        height: 20px;
+        width: 20px;
+    }
+
+    &--info {
+        background: rgba(98, 210, 250, 0.08);
+        border: 1px solid rgba(98, 210, 250, 0.25);
+        color: $plex-text;
+
+        mat-icon {
+            color: $plex-accent;
+        }
+    }
+
+    &--muted {
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid $plex-border-soft;
+        color: $plex-text-muted;
+
+        mat-icon {
+            color: $plex-text-faint;
+        }
+    }
 }
 
-.info-banner mat-icon {
-    font-size: 28px;
-    color: #42a5f5;
+/* -------------------------------- Save bar -------------------------------- */
+
+.save-bar {
+    position: sticky;
+    bottom: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 18px 14px 22px;
+    margin-top: 8px;
+    background: rgba(19, 27, 41, 0.92);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid $plex-border;
+    border-radius: $radius-md;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+    z-index: 5;
+
+    &__hint {
+        font-size: 13px;
+        color: $plex-text-muted;
+    }
+
+    &__btn {
+        min-width: 160px;
+    }
 }
 
-.info-banner button[mat-button] {
-    margin-left: 16px;
+/* --------------------------------- Buttons -------------------------------- */
+
+.btn-primary.mat-mdc-raised-button,
+.btn-primary.mat-mdc-unelevated-button,
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 42px;
+    border-radius: 10px;
     font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+/* ------------------------- Material form-field tweaks --------------------- */
+
+::ng-deep .plex-page {
+    .mat-mdc-form-field {
+        width: 100%;
+    }
+
+    .mat-mdc-text-field-wrapper {
+        background: rgba(255, 255, 255, 0.03);
+        border-radius: 10px;
+    }
+
+    .mdc-notched-outline__leading,
+    .mdc-notched-outline__notch,
+    .mdc-notched-outline__trailing {
+        border-color: $plex-border !important;
+    }
+
+    .mat-mdc-form-field:hover .mdc-notched-outline__leading,
+    .mat-mdc-form-field:hover .mdc-notched-outline__notch,
+    .mat-mdc-form-field:hover .mdc-notched-outline__trailing {
+        border-color: lighten($plex-border, 10%) !important;
+    }
+
+    .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+    .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+    .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+        border-color: $plex-accent !important;
+    }
+
+    .mat-mdc-form-field-label,
+    .mdc-floating-label {
+        color: $plex-text-muted !important;
+    }
+
+    .mat-mdc-input-element,
+    input.mat-mdc-input-element {
+        color: $plex-text !important;
+        caret-color: $plex-accent;
+    }
+
+    .mat-mdc-select-value,
+    .mat-mdc-select-arrow {
+        color: $plex-text !important;
+    }
+}
+
+/* ------------------------------ Responsiveness ---------------------------- */
+
+@media (max-width: 720px) {
+    .plex-page {
+        padding: 20px 16px 140px;
+    }
+
+    .page-header {
+        grid-template-columns: auto 1fr;
+        padding: 20px;
+
+        &__status {
+            grid-column: 1 / -1;
+            flex-direction: row;
+            align-items: center;
+            justify-content: flex-start;
+        }
+
+        &__title {
+            font-size: 24px;
+        }
+    }
+
+    .surface {
+        padding: 18px 16px;
+    }
+
+    .row-toggle {
+        grid-template-columns: auto 1fr;
+
+        mat-slide-toggle {
+            grid-column: 1 / -1;
+            justify-self: end;
+        }
+    }
+
+    .setting-row {
+        grid-template-columns: auto 1fr;
+
+        mat-slide-toggle {
+            grid-column: 1 / -1;
+            justify-self: end;
+        }
+    }
+
+    .save-bar {
+        flex-direction: column;
+        align-items: stretch;
+
+        &__btn {
+            width: 100%;
+        }
+    }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
@@ -94,7 +94,7 @@ $plex-accent-soft:  rgba(98, 210, 250, 0.14);
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        background: currentColor;
+        background: currentcolor;
         box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.04);
     }
 

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
@@ -292,7 +292,7 @@ $plex-accent-soft:  rgba(98, 210, 250, 0.14);
         font-weight: 600;
         color: #fff;
         line-height: 1.2;
-        word-break: break-word;
+        overflow-wrap: anywhere;
     }
 
     &__meta {

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.spec.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.spec.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+
 import { PlexComponent } from './plex.component';
-import { of, throwError, EMPTY } from 'rxjs';
 import { PlexSyncType } from './components/models';
+import { JobService, NotificationService, PlexService, SettingsService } from '../../services';
 
 function createComponent() {
   const mockSettingsService = {
@@ -30,31 +34,39 @@ function createComponent() {
     open: vi.fn().mockReturnValue({ afterClosed: () => of({ closed: true }) }),
   };
 
-  const comp = new PlexComponent(
-    mockSettingsService as any,
-    mockNotify as any,
-    mockPlexService as any,
-    mockJobService as any,
-    mockDialog as any,
-  );
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: SettingsService, useValue: mockSettingsService },
+      { provide: NotificationService, useValue: mockNotify },
+      { provide: PlexService, useValue: mockPlexService },
+      { provide: JobService, useValue: mockJobService },
+      { provide: MatDialog, useValue: mockDialog },
+    ],
+  });
+
+  const comp = TestBed.runInInjectionContext(() => new PlexComponent());
 
   return { comp, mockSettingsService, mockNotify, mockPlexService, mockJobService, mockDialog };
 }
 
 describe('PlexComponent', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
   describe('ngOnInit', () => {
     it('should load plex settings', () => {
       const { comp, mockSettingsService } = createComponent();
       comp.ngOnInit();
       expect(mockSettingsService.getPlex).toHaveBeenCalled();
-      expect(comp.settings).toBeDefined();
+      expect(comp.settings()).toBeDefined();
     });
 
     it('should initialize servers array when null', () => {
       const { comp, mockSettingsService } = createComponent();
       mockSettingsService.getPlex.mockReturnValue(of({ servers: null, enable: true }));
       comp.ngOnInit();
-      expect(comp.settings.servers).toEqual([]);
+      expect(comp.settings()!.servers).toEqual([]);
     });
   });
 
@@ -67,7 +79,7 @@ describe('PlexComponent', () => {
 
       comp.requestServers();
       expect(mockPlexService.getServers).toHaveBeenCalledWith('admin', 'pass');
-      expect(comp.serversButton).toBe(true);
+      expect(comp.loadedServers()).toBeDefined();
       expect(mockNotify.success).toHaveBeenCalledWith('Found the servers! Please select one!');
     });
 
@@ -122,21 +134,21 @@ describe('PlexComponent', () => {
     it('should filter out empty server names and save', () => {
       const { comp, mockSettingsService, mockNotify } = createComponent();
       comp.ngOnInit();
-      comp.settings.servers = [
+      comp.settings()!.servers = [
         { name: 'Server1', ip: '127.0.0.1', serverHostname: '' } as any,
         { name: '', ip: '' } as any,
       ];
 
       comp.save();
       expect(mockSettingsService.savePlex).toHaveBeenCalled();
-      expect(comp.settings.servers).toHaveLength(1);
+      expect(comp.settings()!.servers).toHaveLength(1);
       expect(mockNotify.success).toHaveBeenCalledWith('Successfully saved Plex settings');
     });
 
     it('should error when serverHostname does not start with http', () => {
       const { comp, mockNotify, mockSettingsService } = createComponent();
       comp.ngOnInit();
-      comp.settings.servers = [
+      comp.settings()!.servers = [
         { name: 'Server1', ip: '127.0.0.1', serverHostname: 'plex.example.com' } as any,
       ];
 
@@ -150,7 +162,7 @@ describe('PlexComponent', () => {
     it('should allow valid http hostname', () => {
       const { comp, mockSettingsService } = createComponent();
       comp.ngOnInit();
-      comp.settings.servers = [
+      comp.settings()!.servers = [
         { name: 'Server1', ip: '127.0.0.1', serverHostname: 'https://plex.example.com' } as any,
       ];
 
@@ -186,13 +198,6 @@ describe('PlexComponent', () => {
       comp.runSync(PlexSyncType.WatchlistImport);
       expect(mockJobService.runPlexWatchlistImport).toHaveBeenCalled();
       expect(mockNotify.success).toHaveBeenCalledWith('Triggered the Watchlist Import');
-    });
-  });
-
-  describe('ngOnDestroy', () => {
-    it('should complete subscriptions', () => {
-      const { comp } = createComponent();
-      expect(() => comp.ngOnDestroy()).not.toThrow();
     });
   });
 });

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -251,6 +251,8 @@ export class PlexComponent implements OnInit {
         job$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((x) => {
             if (x) {
                 this.notificationService.success(message);
+            } else {
+                this.notificationService.error("Could not trigger the job. Please try again.");
             }
         });
     }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -67,6 +67,10 @@ export class PlexComponent implements OnInit {
         return ++this.nextServerId;
     }
 
+    private notifySettingsChanged(): void {
+        this.settings.update((s) => (s ? { ...s } : s));
+    }
+
     public requestServers(): void {
         this.plexService.getServers(this.username, this.password).pipe(
             takeUntilDestroyed(this.destroyRef),
@@ -115,6 +119,7 @@ export class PlexComponent implements OnInit {
         }
 
         settings.servers = settings.servers.filter((x) => x.name !== "");
+        this.notifySettingsChanged();
 
         const invalid = settings.servers.some(
             (server) => server.serverHostname && server.serverHostname.length > 0 && !server.serverHostname.startsWith("http"),
@@ -178,9 +183,11 @@ export class PlexComponent implements OnInit {
                     const idx = settings.servers.findIndex((s) => s.id === x.server.id);
                     if (idx >= 0) {
                         settings.servers[idx] = x.server;
+                        this.notifySettingsChanged();
                         this.save("Server updated");
                     } else {
                         settings.servers.push(x.server);
+                        this.notifySettingsChanged();
                         this.save("Server added");
                     }
                 }
@@ -216,6 +223,7 @@ export class PlexComponent implements OnInit {
                         return;
                     }
                     current.servers.push(x.server);
+                    this.notifySettingsChanged();
                     this.save("Server added");
                 }
             });
@@ -233,6 +241,7 @@ export class PlexComponent implements OnInit {
         const index = settings.servers.indexOf(server, 0);
         if (index > -1) {
             settings.servers.splice(index, 1);
+            this.notifySettingsChanged();
         }
         this.save("Server removed");
     }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -163,7 +163,7 @@ export class PlexComponent implements OnInit {
         const dialogRef = this.dialog.open(PlexServerDialogComponent, {
             width: "700px",
             data,
-            panelClass: "modal-panel",
+            panelClass: ["modal-panel", "plex-dialog-panel"],
         });
 
         dialogRef.afterClosed()
@@ -209,7 +209,7 @@ export class PlexComponent implements OnInit {
         const dialogRef = this.dialog.open(PlexServerDialogComponent, {
             width: "700px",
             data: { server: initial },
-            panelClass: "modal-panel",
+            panelClass: ["modal-panel", "plex-dialog-panel"],
         });
 
         dialogRef.afterClosed()
@@ -231,7 +231,7 @@ export class PlexComponent implements OnInit {
     }
 
     public openWatchlistUserLog(): void {
-        this.dialog.open(PlexWatchlistComponent, { width: "700px", panelClass: "modal-panel" });
+        this.dialog.open(PlexWatchlistComponent, { width: "700px", panelClass: ["modal-panel", "plex-dialog-panel"] });
     }
 
     private removeServer(server: IPlexServer): void {

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -1,97 +1,75 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
-import { EMPTY, Subject } from "rxjs";
-import { catchError, takeUntil } from "rxjs/operators";
-import { CommonModule } from "@angular/common";
-import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormsModule } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
-import { MatCardModule } from "@angular/material/card";
-import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatDialog, MatDialogModule } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
-import { MatTabsModule } from "@angular/material/tabs";
-import { MatTooltipModule } from "@angular/material/tooltip";
-import { MatIconModule } from "@angular/material/icon";
-import { TranslateModule } from "@ngx-translate/core";
-import { ButtonModule } from "primeng/button";
-import { ConfirmDialogModule } from "primeng/confirmdialog";
-import { DialogModule } from "primeng/dialog";
-import { TableModule } from "primeng/table";
+import { EMPTY, Observable } from "rxjs";
+import { catchError } from "rxjs/operators";
 
-import { IPlexServer, IPlexDeviceResponse, IPlexServerViewModel, IPlexSettings } from "../../interfaces";
+import { IPlexDeviceResponse, IPlexServer, IPlexServerViewModel, IPlexSettings } from "../../interfaces";
 import { JobService, NotificationService, PlexService, SettingsService } from "../../services";
-import { PlexWatchlistComponent } from "./components/watchlist/plex-watchlist.component";
 import { PlexServerDialogComponent } from "./components/plex-server-dialog/plex-server-dialog.component";
+import { PlexWatchlistComponent } from "./components/watchlist/plex-watchlist.component";
 import { PlexServerDialogData, PlexSyncType } from "./components/models";
 
 @Component({
     standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
-        CommonModule,
         FormsModule,
-        ReactiveFormsModule,
         MatButtonModule,
-        MatCardModule,
-        MatCheckboxModule,
         MatDialogModule,
         MatFormFieldModule,
+        MatIconModule,
         MatInputModule,
         MatSelectModule,
         MatSlideToggleModule,
-        MatTabsModule,
-        MatTooltipModule,
-        MatIconModule,
-        TranslateModule,
-        ButtonModule,
-        ConfirmDialogModule,
-        DialogModule,
-        TableModule
     ],
     templateUrl: "./plex.component.html",
-    styleUrls: ["./plex.component.scss"]
+    styleUrls: ["./plex.component.scss"],
 })
-export class PlexComponent implements OnInit, OnDestroy {
-    public settings: IPlexSettings;
-    public loadedServers: IPlexServerViewModel; // This comes from the api call for the user to select a server
-    public serversButton = false;
-    selected = new UntypedFormControl(0);
+export class PlexComponent implements OnInit {
+    private readonly settingsService = inject(SettingsService);
+    private readonly notificationService = inject(NotificationService);
+    private readonly plexService = inject(PlexService);
+    private readonly jobService = inject(JobService);
+    private readonly dialog = inject(MatDialog);
+    private readonly destroyRef = inject(DestroyRef);
 
-    public username: string;
-    public password: string;
+    public readonly settings = signal<IPlexSettings | undefined>(undefined);
+    public readonly loadedServers = signal<IPlexServerViewModel | undefined>(undefined);
 
-    private subscriptions = new Subject<void>();
-    public PlexSyncType = PlexSyncType;
+    public username = "";
+    public password = "";
 
-    constructor(
-        private settingsService: SettingsService,
-        private notificationService: NotificationService,
-        private plexService: PlexService,
-        private jobService: JobService,
-        private dialog: MatDialog) { }
+    public readonly PlexSyncType = PlexSyncType;
 
-    public ngOnInit() {
-        this.settingsService.getPlex().subscribe(x => {
-            this.settings = x;
-
-            if (!this.settings.servers) {
-                this.settings.servers = [];
-            }
-        });
+    public ngOnInit(): void {
+        this.settingsService.getPlex()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((x) => {
+                if (!x.servers) {
+                    x.servers = [];
+                }
+                this.settings.set(x);
+            });
     }
 
-    public requestServers() {
+    public requestServers(): void {
         this.plexService.getServers(this.username, this.password).pipe(
-            takeUntil(this.subscriptions),
+            takeUntilDestroyed(this.destroyRef),
             catchError(() => {
                 this.notificationService.error("There was an issue. Please make sure your username and password are correct");
                 return EMPTY;
-            })
-        ).subscribe(x => {
+            }),
+        ).subscribe((x) => {
             if (x.success) {
-                this.loadedServers = x;
-                this.serversButton = true;
+                this.loadedServers.set(x);
                 this.notificationService.success("Found the servers! Please select one!");
             } else {
                 this.notificationService.warning("Error When Requesting Plex Servers", "Please make sure your username and password are correct");
@@ -99,161 +77,163 @@ export class PlexComponent implements OnInit, OnDestroy {
         });
     }
 
-    public selectServer(selectedDevice: IPlexDeviceResponse) {
-        const server = <IPlexServer> { name: "New" + this.settings.servers.length + "*", id: Math.floor(Math.random() * (99999 - 0 + 1) + 1) };
-
-        var splitServers = selectedDevice.localAddresses.split(",");
-        if (splitServers.length > 1) {
-            server.ip = splitServers[splitServers.length - 1];
-        } else {
-            server.ip = selectedDevice.localAddresses;
+    public selectServer(selectedDevice: IPlexDeviceResponse): void {
+        const settings = this.settings();
+        if (!settings) {
+            return;
         }
+
+        const server = <IPlexServer>{
+            name: "New" + settings.servers.length + "*",
+            id: Math.floor(Math.random() * (99999 - 0 + 1) + 1),
+        };
+
+        const splitServers = selectedDevice.localAddresses.split(",");
+        server.ip = splitServers.length > 1 ? splitServers[splitServers.length - 1] : selectedDevice.localAddresses;
         server.name = selectedDevice.name;
         server.machineIdentifier = selectedDevice.machineIdentifier;
         server.plexAuthToken = selectedDevice.accessToken;
         server.port = parseInt(selectedDevice.port);
-        server.ssl = selectedDevice.scheme === "http" ? false : true;
+        server.ssl = selectedDevice.scheme !== "http";
         server.serverHostname = "";
 
         this.notificationService.success(`Selected ${server.name}!`);
         this.newServer(server);
     }
 
-    public save() {
-        const filtered = this.settings.servers.filter(x => x.name !== "");
-        this.settings.servers = filtered;
-        let invalid = false;
-
-        this.settings.servers.forEach(server => {
-            if (server.serverHostname && server.serverHostname.length > 0 && !server.serverHostname.startsWith("http")) {
-                invalid = true;
-            }
-        });
-
-        if (invalid) {
-            this.notificationService.error("Please ensure that your External Hostname is a full URL including the Scheme (http/https)")
+    public save(): void {
+        const settings = this.settings();
+        if (!settings) {
             return;
         }
 
-        this.settingsService.savePlex(this.settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved Plex settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Plex settings");
-            }
-        });
+        settings.servers = settings.servers.filter((x) => x.name !== "");
+
+        const invalid = settings.servers.some(
+            (server) => server.serverHostname && server.serverHostname.length > 0 && !server.serverHostname.startsWith("http"),
+        );
+
+        if (invalid) {
+            this.notificationService.error("Please ensure that your External Hostname is a full URL including the Scheme (http/https)");
+            return;
+        }
+
+        this.settingsService.savePlex(settings)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((x) => {
+                if (x) {
+                    this.notificationService.success("Successfully saved Plex settings");
+                } else {
+                    this.notificationService.success("There was an error when saving the Plex settings");
+                }
+            });
     }
 
-    public runSync(type: PlexSyncType) {
+    public runSync(type: PlexSyncType): void {
         switch (type) {
             case PlexSyncType.Full:
-                this.runCacher();
+                this.runJob(this.jobService.runPlexCacher(), "Triggered the Plex Full Sync");
                 return;
             case PlexSyncType.RecentlyAdded:
-                this.runRecentlyAddedCacher();
+                this.runJob(this.jobService.runPlexRecentlyAddedCacher(), "Triggered the Plex Recently Added Sync");
                 return;
             case PlexSyncType.ClearAndReSync:
-                this.clearDataAndResync();
+                this.runJob(this.jobService.clearMediaserverData(), "Triggered the Clear MediaServer Resync");
                 return;
             case PlexSyncType.WatchlistImport:
-                this.runWatchlistImport();
+                this.runJob(this.jobService.runPlexWatchlistImport(), "Triggered the Watchlist Import");
                 return;
         }
     }
 
-    public edit(server: IPlexServer) {
-        const data: PlexServerDialogData = {
-            server: server,
-          };
-          const dialog = this.dialog.open(PlexServerDialogComponent, {
+    public edit(server: IPlexServer): void {
+        const data: PlexServerDialogData = { server };
+        const dialogRef = this.dialog.open(PlexServerDialogComponent, {
             width: "700px",
-            data: data,
+            data,
             panelClass: "modal-panel",
-          });
-          dialog.afterClosed().subscribe((x) => {
-            if (x.deleted) {
-                this.removeServer(server);
-            }
-            if (x.server) {
-                var idx = this.settings.servers.findIndex(server => server.id === x.server.id);
-                if (idx >= 0) {
-                    this.settings.servers[idx] = x.server;
-                } else {
-                    this.settings.servers.push(x.server);
+        });
+
+        dialogRef.afterClosed()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((x) => {
+                if (!x) {
+                    return;
                 }
-
-                this.save();
-            }
-          });
+                if (x.deleted) {
+                    this.removeServer(server);
+                }
+                if (x.server) {
+                    const settings = this.settings();
+                    if (!settings) {
+                        return;
+                    }
+                    const idx = settings.servers.findIndex((s) => s.id === x.server.id);
+                    if (idx >= 0) {
+                        settings.servers[idx] = x.server;
+                    } else {
+                        settings.servers.push(x.server);
+                    }
+                    this.save();
+                }
+            });
     }
 
-    public newServer(server: IPlexServer) {
-        if(!server) {
-            server = <IPlexServer> { name: "New" + this.settings.servers.length + "*", id: Math.floor(Math.random() * (99999 - 0 + 1) + 1) };
+    public newServer(server?: IPlexServer): void {
+        const settings = this.settings();
+        if (!settings) {
+            return;
         }
-       const dialog = this.dialog.open(PlexServerDialogComponent, {
+
+        const initial = server ?? <IPlexServer>{
+            name: "New" + settings.servers.length + "*",
+            id: Math.floor(Math.random() * (99999 - 0 + 1) + 1),
+        };
+
+        const dialogRef = this.dialog.open(PlexServerDialogComponent, {
             width: "700px",
-            data: {server: server},
+            data: { server: initial },
             panelClass: "modal-panel",
-          });
-          dialog.afterClosed().subscribe((x) => {
-            if (x.closed) {
-                return;
-            }
-            if (x.server) {
-                this.settings.servers.push(x.server);
-                this.save();
-            }
-          });
+        });
+
+        dialogRef.afterClosed()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((x) => {
+                if (!x || x.closed) {
+                    return;
+                }
+                if (x.server) {
+                    const current = this.settings();
+                    if (!current) {
+                        return;
+                    }
+                    current.servers.push(x.server);
+                    this.save();
+                }
+            });
     }
 
-    private removeServer(server: IPlexServer) {
-        const index = this.settings.servers.indexOf(server, 0);
+    public openWatchlistUserLog(): void {
+        this.dialog.open(PlexWatchlistComponent, { width: "700px", panelClass: "modal-panel" });
+    }
+
+    private removeServer(server: IPlexServer): void {
+        const settings = this.settings();
+        if (!settings) {
+            return;
+        }
+        const index = settings.servers.indexOf(server, 0);
         if (index > -1) {
-            this.settings.servers.splice(index, 1);
-            this.selected.setValue(this.settings.servers.length - 1);
+            settings.servers.splice(index, 1);
         }
         this.save();
     }
 
-    private runCacher(): void {
-        this.jobService.runPlexCacher().subscribe(x => {
+    private runJob(job$: Observable<boolean>, message: string): void {
+        job$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((x) => {
             if (x) {
-                this.notificationService.success("Triggered the Plex Full Sync");
+                this.notificationService.success(message);
             }
         });
-    }
-
-    private runRecentlyAddedCacher(): void {
-        this.jobService.runPlexRecentlyAddedCacher().subscribe(x => {
-            if (x) {
-                this.notificationService.success("Triggered the Plex Recently Added Sync");
-            }
-        });
-    }
-
-    private clearDataAndResync(): void {
-        this.jobService.clearMediaserverData().subscribe(x => {
-            if (x) {
-                this.notificationService.success("Triggered the Clear MediaServer Resync");
-            }
-        });
-    }
-
-    private runWatchlistImport(): void {
-        this.jobService.runPlexWatchlistImport().subscribe(x => {
-            if (x) {
-                this.notificationService.success("Triggered the Watchlist Import");
-            }
-        });
-    }
-
-    public openWatchlistUserLog(): void {
-        this.dialog.open(PlexWatchlistComponent, { width: "700px", panelClass: 'modal-panel' });
-    }
-
-    public ngOnDestroy() {
-        this.subscriptions.next();
-        this.subscriptions.complete();
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -49,6 +49,8 @@ export class PlexComponent implements OnInit {
 
     public readonly PlexSyncType = PlexSyncType;
 
+    private nextServerId = 0;
+
     public ngOnInit(): void {
         this.settingsService.getPlex()
             .pipe(takeUntilDestroyed(this.destroyRef))
@@ -56,8 +58,13 @@ export class PlexComponent implements OnInit {
                 if (!x.servers) {
                     x.servers = [];
                 }
+                this.nextServerId = x.servers.reduce((max, s) => Math.max(max, s.id ?? 0), 0);
                 this.settings.set(x);
             });
+    }
+
+    private generateServerId(): number {
+        return ++this.nextServerId;
     }
 
     public requestServers(): void {
@@ -85,7 +92,7 @@ export class PlexComponent implements OnInit {
 
         const server = <IPlexServer>{
             name: "New" + settings.servers.length + "*",
-            id: Math.floor(Math.random() * (99999 - 0 + 1) + 1),
+            id: this.generateServerId(),
         };
 
         const splitServers = selectedDevice.localAddresses.split(",");
@@ -124,7 +131,7 @@ export class PlexComponent implements OnInit {
                 if (x) {
                     this.notificationService.success("Successfully saved Plex settings");
                 } else {
-                    this.notificationService.success("There was an error when saving the Plex settings");
+                    this.notificationService.error("There was an error when saving the Plex settings");
                 }
             });
     }
@@ -187,7 +194,7 @@ export class PlexComponent implements OnInit {
 
         const initial = server ?? <IPlexServer>{
             name: "New" + settings.servers.length + "*",
-            id: Math.floor(Math.random() * (99999 - 0 + 1) + 1),
+            id: this.generateServerId(),
         };
 
         const dialogRef = this.dialog.open(PlexServerDialogComponent, {

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -174,6 +174,7 @@ export class PlexComponent implements OnInit {
                 }
                 if (x.deleted) {
                     this.removeServer(server);
+                    return;
                 }
                 if (x.server) {
                     const settings = this.settings();

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.ts
@@ -108,7 +108,7 @@ export class PlexComponent implements OnInit {
         this.newServer(server);
     }
 
-    public save(): void {
+    public save(successMessage = "Successfully saved Plex settings"): void {
         const settings = this.settings();
         if (!settings) {
             return;
@@ -129,7 +129,7 @@ export class PlexComponent implements OnInit {
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe((x) => {
                 if (x) {
-                    this.notificationService.success("Successfully saved Plex settings");
+                    this.notificationService.success(successMessage);
                 } else {
                     this.notificationService.error("There was an error when saving the Plex settings");
                 }
@@ -178,10 +178,11 @@ export class PlexComponent implements OnInit {
                     const idx = settings.servers.findIndex((s) => s.id === x.server.id);
                     if (idx >= 0) {
                         settings.servers[idx] = x.server;
+                        this.save("Server updated");
                     } else {
                         settings.servers.push(x.server);
+                        this.save("Server added");
                     }
-                    this.save();
                 }
             });
     }
@@ -215,7 +216,7 @@ export class PlexComponent implements OnInit {
                         return;
                     }
                     current.servers.push(x.server);
-                    this.save();
+                    this.save("Server added");
                 }
             });
     }
@@ -233,7 +234,7 @@ export class PlexComponent implements OnInit {
         if (index > -1) {
             settings.servers.splice(index, 1);
         }
-        this.save();
+        this.save("Server removed");
     }
 
     private runJob(job$: Observable<boolean>, message: string): void {

--- a/src/Ombi/ClientApp/src/test-setup.ts
+++ b/src/Ombi/ClientApp/src/test-setup.ts
@@ -1,2 +1,9 @@
 import 'zone.js';
 import '@angular/compiler';
+import { getTestBed } from '@angular/core/testing';
+import {
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());


### PR DESCRIPTION
Restructure the Plex settings page around a clearer information
hierarchy: a hero header with status pills, a master enable toggle,
side-by-side servers and Plex.tv discovery, color-coded sync action
tiles, a dedicated watchlist section, and a sticky save bar. Refresh
the styling with a tighter token system, hover/focus states, callouts,
and responsive breakpoints while keeping all bindings and ids stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Plex settings page with interactive server tiles (add/edit/remove), "Discover with Plex.tv" flow, selectable discovered servers, rebuilt sync action tiles, consolidated watchlist controls and a sticky save bar.

* **Style**
  * Full visual refresh: themed layout, responsive grids, tiles, status pills, callouts, improved focus/disabled behaviours and dialog styling.

* **Refactor**
  * Modernised state and lifecycle handling for more predictable updates and simplified job/dialog flows.

* **Tests**
  * Updated test setup and tests to align with the new UI and behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->