### PR TITLE
refactor(notifications): extract shared base class + shell

### DIFF
--- a/src/Ombi/ClientApp/src/app/settings/massemail/massemail.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/massemail/massemail.component.html
@@ -1,62 +1,117 @@
-<div class="small-middle-container">
-<fieldset>
-    <legend>Mass Email</legend>
-<div class="row">
-    <div class="col-md-6">
-
-        <div class="form-group">
-            <mat-form-field>
-                <mat-label>Subject</mat-label>
-                <input matInput type="text" id="subject" name="subject" placeholder="Subject" [(ngModel)]="subject" [ngClass]="{'form-error': missingSubject}">
-                <small *ngIf="missingSubject" class="error-text">Hey! We need a subject!</small>
-            </mat-form-field>
-        </div>
-
-        <div class="form-group">
-            <mat-form-field appearance="outline">
-              <mat-label>Content</mat-label>
-              <textarea matInput rows="10" type="text" id="themeContent" name="themeContent" [(ngModel)]="message" placeholder="This supports HTML"></textarea>
-            </mat-form-field>
-        </div>
-
-        <div class="form-group">
-            <label for="logo" class="control-label">Message Preview</label>
-            <br/>
-            <small>May appear differently on email clients</small>
-            <mat-divider></mat-divider>
-            <div [innerHTML]="message"></div>
-            <mat-divider></mat-divider>
-        </div>
-
-        <small>This will send out the Mass email BCC'ing all of the selected users rather than sending individual messages</small>
-        <div class="md-form-field">
-            <mat-slide-toggle [(ngModel)]="bcc">BCC</mat-slide-toggle>
-        </div>
-        <br>
-        <br>
-        <div class="form-group">
-            <div>
-                <button type="submit" id="save" (click)="send()" class="mat-focus-indicator btn-spacing mat-raised-button mat-button-base mat-accent">Send</button>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-6">
-        <!--Users Section-->
-         <label class="control-label">Recipients with Email Addresses</label>
-        <div class="form-group">
-            <div class="md-form-field">
-                <mat-slide-toggle (change)="selectAllUsers($event)">Select All</mat-slide-toggle>
-              </div>
-            </div>
-
-            <div class="form-group" *ngFor="let u of users">
-                <div class="md-form-field">
-                    <mat-slide-toggle id="user{{u.user.id}}" [(ngModel)]="u.selected">{{u.user.userName}} ({{u.user.emailAddress}})</mat-slide-toggle>
-                  </div>
+<section class="mass-email">
+    <div class="mass-email__layout">
+        <mat-card appearance="outlined" class="mass-email__card mass-email__card--main">
+            <mat-card-header>
+                <div mat-card-avatar class="mass-email__avatar" aria-hidden="true">
+                    <mat-icon>forward_to_inbox</mat-icon>
                 </div>
+                <mat-card-title>Mass email</mat-card-title>
+                <mat-card-subtitle>Send a one-off email to any subset of your Ombi users.</mat-card-subtitle>
+            </mat-card-header>
+
+            @if (sending) {
+                <mat-progress-bar mode="indeterminate" aria-label="Sending mass email"></mat-progress-bar>
+            }
+
+            <mat-card-content class="mass-email__content">
+                @if (!emailEnabled) {
+                    <div class="mass-email__warning" role="status">
+                        <mat-icon aria-hidden="true">warning</mat-icon>
+                        <span>Email notifications are not configured yet. Configure SMTP under
+                            <strong>Notifications &rarr; Email</strong> before sending.</span>
+                    </div>
+                }
+
+                <mat-form-field appearance="outline" class="mass-email__field">
+                    <mat-label>Subject</mat-label>
+                    <input matInput name="subject"
+                           [(ngModel)]="subject"
+                           [class.mass-email__error]="missingSubject"
+                           autocomplete="off">
+                    @if (missingSubject) {
+                        <mat-error>Hey! We need a subject!</mat-error>
+                    }
+                </mat-form-field>
+
+                <mat-form-field appearance="outline" class="mass-email__field">
+                    <mat-label>Content</mat-label>
+                    <textarea matInput rows="10" name="content"
+                              [(ngModel)]="message"
+                              placeholder="HTML is supported."></textarea>
+                    <mat-hint>HTML is supported. Preview is shown below.</mat-hint>
+                </mat-form-field>
+
+                <div class="mass-email__preview">
+                    <div class="mass-email__preview-header">
+                        <mat-icon aria-hidden="true">visibility</mat-icon>
+                        <span>Message preview</span>
+                        <small>Appearance varies between email clients.</small>
+                    </div>
+                    <mat-divider></mat-divider>
+                    <div class="mass-email__preview-body" [innerHTML]="message"></div>
+                    <mat-divider></mat-divider>
+                </div>
+
+                <div class="mass-email__bcc">
+                    <mat-slide-toggle color="primary" [(ngModel)]="bcc"
+                                      matTooltip="When enabled, recipients are BCC'd into a single email instead of receiving individual messages.">
+                        BCC recipients
+                    </mat-slide-toggle>
+                </div>
+
+                <div class="mass-email__actions">
+                    <button mat-flat-button color="primary" type="button"
+                            [disabled]="sending || selectedCount === 0"
+                            (click)="send()">
+                        <mat-icon>send</mat-icon>
+                        {{ sending ? 'Sending…' : 'Send to ' + selectedCount + ' user' + (selectedCount === 1 ? '' : 's') }}
+                    </button>
+                </div>
+            </mat-card-content>
+        </mat-card>
+
+        <mat-card appearance="outlined" class="mass-email__card mass-email__card--recipients">
+            <mat-card-header>
+                <div mat-card-avatar class="mass-email__avatar" aria-hidden="true">
+                    <mat-icon>group</mat-icon>
+                </div>
+                <mat-card-title>Recipients</mat-card-title>
+                <mat-card-subtitle>
+                    @if (loadingUsers) {
+                        Loading users…
+                    } @else {
+                        {{ selectedCount }} of {{ users.length }} selected
+                    }
+                </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+                @if (!loadingUsers) {
+                    @if (users.length) {
+                        <div class="mass-email__select-all">
+                            <mat-slide-toggle color="primary"
+                                              [checked]="allSelected"
+                                              (change)="selectAllUsers($event)">
+                                Select all
+                            </mat-slide-toggle>
+                        </div>
+                        <mat-divider></mat-divider>
+                        <ul class="mass-email__user-list">
+                            @for (u of users; track u.user.id) {
+                                <li>
+                                    <mat-slide-toggle color="primary"
+                                                      [id]="'user' + u.user.id"
+                                                      [(ngModel)]="u.selected">
+                                        <span class="mass-email__user-name">{{ u.user.userName }}</span>
+                                        <span class="mass-email__user-email">{{ u.user.emailAddress }}</span>
+                                    </mat-slide-toggle>
+                                </li>
+                            }
+                        </ul>
+                    } @else {
+                        <p class="mass-email__empty">No users with email addresses found.</p>
+                    }
+                }
+            </mat-card-content>
+        </mat-card>
     </div>
-</div>
-
-
-</fieldset>
-</div>
+</section>

--- a/src/Ombi/ClientApp/src/app/settings/massemail/massemail.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/massemail/massemail.component.scss
@@ -1,5 +1,164 @@
-.small-middle-container{
-	margin: auto;
-	width: 85%;
-	margin-top:10px;
+:host {
+    display: block;
+    width: 100%;
+}
+
+.mass-email {
+    display: block;
+    margin: 24px auto;
+    width: min(1280px, 95%);
+
+    &__layout {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+        align-items: start;
+
+        @media (max-width: 1024px) {
+            grid-template-columns: minmax(0, 1fr);
+        }
+    }
+
+    &__card {
+        border-radius: 16px;
+        overflow: hidden;
+        transition: box-shadow 200ms ease;
+
+        &:hover {
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+        }
+    }
+
+    &__avatar {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: rgba(63, 81, 181, 0.12);
+        color: var(--mdc-theme-primary, #3f51b5);
+
+        mat-icon {
+            font-size: 22px;
+            width: 22px;
+            height: 22px;
+        }
+    }
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding-top: 8px;
+    }
+
+    &__warning {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        padding: 12px 14px;
+        border-radius: 10px;
+        background: rgba(255, 152, 0, 0.12);
+        color: inherit;
+        font-size: 0.9rem;
+
+        mat-icon {
+            color: #ff9800;
+            font-size: 20px;
+            width: 20px;
+            height: 20px;
+        }
+    }
+
+    &__field {
+        width: 100%;
+    }
+
+    &__error ::ng-deep input {
+        color: #f44336;
+    }
+
+    &__preview {
+        border: 1px solid rgba(0, 0, 0, 0.12);
+        border-radius: 10px;
+        padding: 12px 14px;
+        background: rgba(0, 0, 0, 0.02);
+
+        &-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+            font-weight: 500;
+
+            mat-icon {
+                font-size: 18px;
+                width: 18px;
+                height: 18px;
+                opacity: 0.75;
+            }
+
+            small {
+                margin-left: auto;
+                opacity: 0.7;
+                font-weight: 400;
+            }
+        }
+
+        &-body {
+            min-height: 60px;
+            padding: 8px 0;
+            word-break: break-word;
+        }
+    }
+
+    &__bcc {
+        padding-top: 4px;
+    }
+
+    &__actions {
+        display: flex;
+        justify-content: flex-end;
+        padding-top: 4px;
+
+        button {
+            min-width: 200px;
+
+            mat-icon {
+                margin-right: 6px;
+            }
+        }
+    }
+
+    &__select-all {
+        padding: 8px 0;
+    }
+
+    &__user-list {
+        list-style: none;
+        margin: 0;
+        padding: 8px 0 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        max-height: 540px;
+        overflow-y: auto;
+    }
+
+    &__user-name {
+        font-weight: 500;
+        margin-right: 6px;
+    }
+
+    &__user-email {
+        opacity: 0.7;
+        font-size: 0.85rem;
+    }
+
+    &__empty {
+        margin: 16px 0;
+        opacity: 0.7;
+        font-style: italic;
+    }
 }

--- a/src/Ombi/ClientApp/src/app/settings/massemail/massemail.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/massemail/massemail.component.ts
@@ -1,51 +1,55 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
 import { MatCheckboxModule } from "@angular/material/checkbox";
+import { MatDividerModule } from "@angular/material/divider";
 import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
 
 import { IMassEmailModel, IMassEmailUserModel } from "../../interfaces";
 import { IdentityService, NotificationMessageService, NotificationService, SettingsService } from "../../services";
-import { MatDividerModule } from "@angular/material/divider";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
+        FormsModule,
         ReactiveFormsModule,
         MatButtonModule,
+        MatCardModule,
         MatCheckboxModule,
+        MatDividerModule,
         MatFormFieldModule,
+        MatIconModule,
         MatInputModule,
-        MatSelectModule,
+        MatProgressBarModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        FormsModule,
-        MatDividerModule
     ],
-    providers: [
-        NotificationMessageService
-    ],
+    providers: [NotificationMessageService],
     templateUrl: "./massemail.component.html",
-    styleUrls: ["./massemail.component.scss"]
+    styleUrls: ["./massemail.component.scss"],
 })
 export class MassEmailComponent implements OnInit {
 
     public users: IMassEmailUserModel[] = [];
-    public message: string;
-    public subject: string;
-    public bcc: boolean;
+    public message = "";
+    public subject = "";
+    public bcc = false;
+    public sending = false;
 
     public missingSubject = false;
 
-    public emailEnabled: boolean;
+    public emailEnabled = false;
+    public loadingUsers = true;
 
     constructor(private readonly notification: NotificationService,
                 private readonly identityService: IdentityService,
@@ -54,39 +58,36 @@ export class MassEmailComponent implements OnInit {
     }
 
     public ngOnInit(): void {
-       this.identityService.getUsers().subscribe(x => {
-        x.forEach(u => {
-            if (u.emailAddress) {
-                this.users.push({
-                    user: u,
-                    selected: false,
-                });
-            }
+        this.identityService.getUsers().subscribe(x => {
+            this.users = x
+                .filter(u => !!u.emailAddress)
+                .map(u => ({ user: u, selected: false }));
+            this.loadingUsers = false;
         });
-       });
-       this.settingsService.getEmailSettingsEnabled().subscribe(x => this.emailEnabled = x);
+        this.settingsService.getEmailSettingsEnabled().subscribe(x => this.emailEnabled = x);
     }
 
-    public selectAllUsers(event: any) {
+    public selectAllUsers(event: { checked: boolean }): void {
         this.users.forEach(u => u.selected = event.checked);
     }
 
-    public send() {
-        if(!this.subject) {
+    public get selectedCount(): number {
+        return this.users.filter(u => u.selected).length;
+    }
+
+    public get allSelected(): boolean {
+        return this.users.length > 0 && this.selectedCount === this.users.length;
+    }
+
+    public send(): void {
+        if (!this.subject) {
             this.missingSubject = true;
             return;
         }
-        // if(!this.emailEnabled) {
-        //     this.notification.error("You have not yet setup your email notifications, do that first!");
-        //     return;
-        // }
         this.missingSubject = false;
-        // Where(x => x.selected).Select(x => x.user)
-        const selectedUsers = this.users.filter(u => {
-            return u.selected;
-        }).map(u => u.user);
 
-        if(selectedUsers.length <=0) {
+        const selectedUsers = this.users.filter(u => u.selected).map(u => u.user);
+        if (selectedUsers.length <= 0) {
             this.notification.error("You need to select at least one user to send the email");
             return;
         }
@@ -97,9 +98,13 @@ export class MassEmailComponent implements OnInit {
             body: this.message,
             bcc: this.bcc,
         };
-        this.notification.info("Sending","Sending mass email... Please wait");
-        this.notificationMessageService.sendMassEmail(model).subscribe(x => {
-            this.notification.success("We have sent the mass email to the users selected!");
+
+        this.sending = true;
+        this.notification.info("Sending", "Sending mass email... Please wait");
+        this.notificationMessageService.sendMassEmail(model).subscribe({
+            next: () => this.notification.success("We have sent the mass email to the users selected!"),
+            complete: () => this.sending = false,
+            error: () => this.sending = false,
         });
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/cloudmobile.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/cloudmobile.component.html
@@ -1,54 +1,79 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Mobile Notifications</legend>
+<ombi-notification-shell
+    providerName="Mobile"
+    icon="smartphone"
+    description="Send push notifications to the Ombi mobile apps. Devices register themselves once a user signs in."
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    [showTest]="false"
+    [requireDirtyToSave]="false"
+    (submitted)="onSubmit($event)">
 
-        <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
-            <div class="row">
-                <div class="col">
-
-                    <table *ngIf="devices" mat-table [dataSource]="devices" class="mat-elevation-z8">
-
-                        <ng-container matColumnDef="select">
-                            <th mat-header-cell *matHeaderCellDef>
-
-                            </th>
-                            <td mat-cell *matCellDef="let row">
-                                <mat-slide-toggle (click)="$event.stopPropagation()" (change)="$event ? selection.toggle(row) : null" [checked]="selection.isSelected(row)">
-                                </mat-slide-toggle>
-                            </td>
-                        </ng-container>
-                        <ng-container matColumnDef="username">
-                            <th mat-header-cell *matHeaderCellDef> Username </th>
-                            <td mat-cell *matCellDef="let element"> {{element.username}} </td>
-                        </ng-container>
-
-                        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-                        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-                    </table>
-
-
-                    <div class="md-form-field">
-                        <mat-form-field>
-                            <mat-label>Message</mat-label>
-                            <textarea matInput [(ngModel)]="message" [ngModelOptions]="{standalone: true}"></textarea>
-                        </mat-form-field>
-                    </div>
-                    <div class="md-form-field">
-                        <button mat-raised-button type="button" color="primary" (click)="sendMessage(form)" [disabled]="selection.selected.length === 0">Send Notification</button>
-                    </div>
-                </div>
-                <div class="col">
-                    <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-                </div>
-
+    <div class="notification-field--full cloudmobile">
+        <header class="cloudmobile__header">
+            <mat-icon aria-hidden="true">campaign</mat-icon>
+            <div>
+                <h3>Broadcast a notification</h3>
+                <p>Send a one-off push to the selected users. Useful for announcements or testing devices.</p>
             </div>
+        </header>
 
-            <div class="md-form-field ">
-                <div>
-                    <button mat-raised-button type="submit " color="accent" [disabled]="form.invalid ">Submit</button>
-                </div>
+        @if (devices.data.length) {
+            <table mat-table [dataSource]="devices" class="cloudmobile__table mat-elevation-z1">
+                <ng-container matColumnDef="select">
+                    <th mat-header-cell *matHeaderCellDef>
+                        <mat-checkbox color="primary"
+                                      [checked]="allSelected()"
+                                      [indeterminate]="someSelected()"
+                                      (change)="toggleAll()"
+                                      aria-label="Select all users">
+                        </mat-checkbox>
+                    </th>
+                    <td mat-cell *matCellDef="let row">
+                        <mat-checkbox color="primary"
+                                      (click)="$event.stopPropagation()"
+                                      (change)="$event ? selection.toggle(row) : null"
+                                      [checked]="selection.isSelected(row)"
+                                      [aria-label]="'Select ' + row.username">
+                        </mat-checkbox>
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="username">
+                    <th mat-header-cell *matHeaderCellDef>User</th>
+                    <td mat-cell *matCellDef="let row">{{ row.username }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="deviceCount">
+                    <th mat-header-cell *matHeaderCellDef>Devices</th>
+                    <td mat-cell *matCellDef="let row">{{ deviceCount(row) }}</td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+            </table>
+
+            <mat-form-field appearance="outline" class="cloudmobile__message">
+                <mat-label>Message</mat-label>
+                <textarea matInput rows="4"
+                          [(ngModel)]="message"
+                          [ngModelOptions]="{ standalone: true }"
+                          placeholder="What would you like to say?"></textarea>
+            </mat-form-field>
+
+            <div class="cloudmobile__actions">
+                <button mat-stroked-button color="accent" type="button"
+                        [disabled]="sending || !selection.selected.length"
+                        (click)="sendBroadcast()">
+                    <mat-icon>send</mat-icon>
+                    {{ sending ? 'Sending…' : 'Send notification' }}
+                </button>
             </div>
-        </form>
-    </fieldset>
-</div>
+        } @else {
+            <p class="cloudmobile__empty">
+                No devices have registered with this Ombi instance yet. Once a user signs into the
+                mobile app their device will appear here.
+            </p>
+        }
+    </div>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/cloudmobile.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/cloudmobile.component.scss
@@ -1,0 +1,57 @@
+.cloudmobile {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding-top: 4px;
+
+    &__header {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+
+        mat-icon {
+            font-size: 22px;
+            width: 22px;
+            height: 22px;
+            color: var(--mdc-theme-primary, #3f51b5);
+        }
+
+        h3 {
+            margin: 0 0 2px 0;
+            font-size: 1rem;
+            font-weight: 500;
+        }
+
+        p {
+            margin: 0;
+            opacity: 0.75;
+            font-size: 0.85rem;
+        }
+    }
+
+    &__table {
+        width: 100%;
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    &__message {
+        width: 100%;
+    }
+
+    &__actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+
+        mat-icon {
+            margin-right: 6px;
+        }
+    }
+
+    &__empty {
+        margin: 0;
+        opacity: 0.7;
+        font-style: italic;
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/notifications/cloudmobile.coponent.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/cloudmobile.coponent.ts
@@ -1,113 +1,127 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder } from "@angular/forms";
+import { SelectionModel } from "@angular/cdk/collections";
 import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
+import { MatTableDataSource, MatTableModule } from "@angular/material/table";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { UntypedFormBuilder, UntypedFormGroup } from "@angular/forms";
+import { Observable } from "rxjs";
 
-import { IMobileNotifcationSettings, IMobileUsersViewModel, INotificationTemplates, NotificationType, ICloudMobileDevices, ICloudMobileModel } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { MobileService, SettingsService } from "../../services";
+import { ICloudMobileModel, IMobileNotifcationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
 import { CloudMobileService } from "../../services/cloudmobile.service";
-import { SelectionModel } from "@angular/cdk/collections";
-import { MatTableDataSource, MatTableModule } from "@angular/material/table";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
-        ReactiveFormsModule,
         FormsModule,
-        NotificationTemplate,
+        ReactiveFormsModule,
         MatButtonModule,
+        MatCardModule,
         MatCheckboxModule,
         MatFormFieldModule,
+        MatIconModule,
         MatInputModule,
         MatSelectModule,
         MatSlideToggleModule,
+        MatTableModule,
         MatTooltipModule,
         TranslateModule,
-        MatTableModule
+        NotificationShellComponent,
     ],
-    providers: [
-        CloudMobileService
-    ],
+    providers: [CloudMobileService],
     templateUrl: "./cloudmobile.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
+    styleUrls: ["./cloudmobile.component.scss"],
 })
-export class CloudMobileComponent implements OnInit {
+export class CloudMobileComponent extends NotificationBaseComponent<IMobileNotifcationSettings> {
 
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
-    public devices: MatTableDataSource<ICloudMobileModel>;
+    protected readonly providerName = "Mobile";
+
+    public devices = new MatTableDataSource<ICloudMobileModel>([]);
     public selection = new SelectionModel<ICloudMobileModel>(true, []);
-    displayedColumns: string[] = ['select', 'username'];
-    public message: string;
+    public displayedColumns: string[] = ["select", "username", "deviceCount"];
+    public message = "";
+    public sending = false;
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private mobileService: CloudMobileService) { }
-
-    public async ngOnInit() {
-        this.settingsService.getMobileNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-            });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService,
+                private readonly mobileService: CloudMobileService) {
+        super(settingsService, notificationService, fb, testerService);
+        this.mobileService.getDevices().subscribe(result => {
+            this.devices.data = result ?? [];
         });
-
-        var result = await this.mobileService.getDevices().toPromise();
-            if (result.length > 0) {
-                this.devices = new MatTableDataSource(result);
-            }
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IMobileNotifcationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveMobileNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Mobile settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Mobile settings");
-            }
-        });
-
+    protected loadSettings(): Observable<IMobileNotifcationSettings> {
+        return this.settingsService.getMobileNotificationSettings();
     }
 
-    public async sendMessage(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
+    protected saveSettings(settings: IMobileNotifcationSettings): Observable<boolean> {
+        return this.settingsService.saveMobileNotificationSettings(settings);
+    }
+
+    protected testSettings(_settings: IMobileNotifcationSettings): Observable<boolean> {
+        return new Observable<boolean>(sub => { sub.next(false); sub.complete(); });
+    }
+
+    protected buildForm(x: IMobileNotifcationSettings) {
+        return {
+            enabled: [x.enabled],
+        };
+    }
+
+    public toggleAll(): void {
+        if (this.allSelected()) {
+            this.selection.clear();
+        } else {
+            this.devices.data.forEach(row => this.selection.select(row));
+        }
+    }
+
+    public allSelected(): boolean {
+        return this.devices.data.length > 0
+            && this.selection.selected.length === this.devices.data.length;
+    }
+
+    public someSelected(): boolean {
+        return this.selection.selected.length > 0 && !this.allSelected();
+    }
+
+    public deviceCount(row: ICloudMobileModel): number {
+        return row.devices?.length ?? 0;
+    }
+
+    public async sendBroadcast(): Promise<void> {
+        if (!this.selection.selected.length) {
+            this.notificationService.warning("Warning", "Please select at least one user to send the notification");
             return;
         }
-        if (this.selection.selected.length <= 0) {
-            this.notificationService.warning("Warning", "Please select a user to send the test notification");
+        if (!this.message?.trim()) {
+            this.notificationService.error("Please enter a message before sending");
             return;
         }
 
-        await this.selection.selected.forEach(async (u) => {
-            await this.mobileService.send(u.userId, this.message);
-           
-            this.notificationService.success(
-                "Successfully sent a Mobile message");
-            
-            
-        });
+        this.sending = true;
+        try {
+            await Promise.all(
+                this.selection.selected.map(user => this.mobileService.send(user.userId, this.message)),
+            );
+            this.notificationService.success("Mobile notification sent to the selected users");
+        } finally {
+            this.sending = false;
+        }
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/discord.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/discord.component.html
@@ -1,67 +1,40 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset class="top-space">
-        <legend>Discord Notifications</legend>
-        <div class="row">
-            <div class="col-md-8">
-                <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
-                    <div class="row">
-                        <div class="col-md-12 col-12 col-sm-12">
-                            <div>
-                                <div class="md-form-field">
-                                    <mat-slide-toggle formControlName="enabled" id="enable">Enable</mat-slide-toggle>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Webhook Url</mat-label>
-                                <input matInput formControlName="webhookUrl">
-                            </mat-form-field>
-                            <mat-form-field appearance="outline">
-                                <mat-label>Username</mat-label>
-                                <input matInput formControlName="username">
-                            </mat-form-field>
-                                <mat-slide-toggle matTooltip="This when enabled will not show the user who did the action e.g. Requested a new movie" formControlName="hideUser">Hide Users in notification</mat-slide-toggle>
-   
-                        </div>
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Icon</mat-label>
-                                <input matInput formControlName="icon">
-                            </mat-form-field>
-                            <div>
-                                <img [src]="form.value.icon" style="width: 300px" />
-                            </div>
-                        </div>
-                        
-                    </div>
-                    <div class="row top-space">
+<ombi-notification-shell
+    providerName="Discord"
+    icon="forum"
+    description="Post requests, approvals and issue updates straight into a Discord channel."
+    docsUrl="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                        <div class="form-group">
-                            <div>
-                                <button mat-raised-button type="button" class="btn-spacing" color="accent"
-                                    (click)="test(form)" [disabled]="form.invalid">Test <div id="spinner"></div>
-                                    </button>
-                            </div>
-                        </div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Webhook URL</mat-label>
+        <input matInput formControlName="webhookUrl" autocomplete="off"
+               placeholder="https://discord.com/api/webhooks/...">
+        @if (form?.get('webhookUrl')?.hasError('required')) {
+            <mat-error>Webhook URL is <strong>required</strong></mat-error>
+        }
+        <mat-hint>Server settings &rarr; Integrations &rarr; Webhooks</mat-hint>
+    </mat-form-field>
 
-                        <div class="form-group">
-                            <div>
-                                <button mat-raised-button type="submit" class="btn-spacing" color="primary"
-                                    [disabled]="form.invalid">Submit</button>
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Username override</mat-label>
+        <input matInput formControlName="username" autocomplete="off">
+        <mat-hint>Optional. Defaults to the webhook's username.</mat-hint>
+    </mat-form-field>
 
+    <mat-form-field appearance="outline">
+        <mat-label>Avatar URL</mat-label>
+        <input matInput formControlName="icon" autocomplete="off">
+        <mat-hint>Optional. Square image, served over HTTPS.</mat-hint>
+    </mat-form-field>
 
-            <div class="col-md-4">
-                <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-            </div>
-        </div>
-    </fieldset>
-</div>
+    <div class="notification-field--full">
+        <mat-slide-toggle color="primary" formControlName="hideUser"
+                          matTooltip="When enabled, the user who triggered the action is omitted from the message.">
+            Hide users in notifications
+        </mat-slide-toggle>
+    </div>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/discord.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/discord.component.html
@@ -9,32 +9,36 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Webhook URL</mat-label>
-        <input matInput formControlName="webhookUrl" autocomplete="off"
-               placeholder="https://discord.com/api/webhooks/...">
-        @if (form?.get('webhookUrl')?.hasError('required')) {
-            <mat-error>Webhook URL is <strong>required</strong></mat-error>
-        }
-        <mat-hint>Server settings &rarr; Integrations &rarr; Webhooks</mat-hint>
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Webhook URL</mat-label>
+                <input matInput formControlName="webhookUrl" autocomplete="off"
+                       placeholder="https://discord.com/api/webhooks/...">
+                @if (form.get('webhookUrl')?.hasError('required')) {
+                    <mat-error>Webhook URL is <strong>required</strong></mat-error>
+                }
+                <mat-hint>Server settings &rarr; Integrations &rarr; Webhooks</mat-hint>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Username override</mat-label>
-        <input matInput formControlName="username" autocomplete="off">
-        <mat-hint>Optional. Defaults to the webhook's username.</mat-hint>
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Username override</mat-label>
+                <input matInput formControlName="username" autocomplete="off">
+                <mat-hint>Optional. Defaults to the webhook's username.</mat-hint>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Avatar URL</mat-label>
-        <input matInput formControlName="icon" autocomplete="off">
-        <mat-hint>Optional. Square image, served over HTTPS.</mat-hint>
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Avatar URL</mat-label>
+                <input matInput formControlName="icon" autocomplete="off">
+                <mat-hint>Optional. Square image, served over HTTPS.</mat-hint>
+            </mat-form-field>
 
-    <div class="notification-field--full">
-        <mat-slide-toggle color="primary" formControlName="hideUser"
-                          matTooltip="When enabled, the user who triggered the action is omitted from the message.">
-            Hide users in notifications
-        </mat-slide-toggle>
-    </div>
+            <div class="notification-field--full">
+                <mat-slide-toggle color="primary" formControlName="hideUser"
+                                  matTooltip="When enabled, the user who triggered the action is omitted from the message.">
+                    Hide users in notifications
+                </mat-slide-toggle>
+            </div>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/discord.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/discord.component.ts
@@ -1,97 +1,66 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { IDiscordNotifcationSettings, INotificationTemplates, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { IDiscordNotifcationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./discord.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class DiscordComponent implements OnInit {
+export class DiscordComponent extends NotificationBaseComponent<IDiscordNotifcationSettings> {
 
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+    protected readonly providerName = "Discord";
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
-
-    public ngOnInit() {
-        this.settingsService.getDiscordNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                username: [x.username],
-                webhookUrl: [x.webhookUrl, [Validators.required]],
-                icon: [x.icon],
-                hideUser: [x.hideUser]
-
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IDiscordNotifcationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveDiscordNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Discord settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Discord settings");
-            }
-        });
-
+    protected override get testSuccessMessage(): string {
+        return "Successfully sent a Discord message, please check the discord channel";
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected loadSettings(): Observable<IDiscordNotifcationSettings> {
+        return this.settingsService.getDiscordNotificationSettings();
+    }
 
-        this.testerService.discordTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully sent a Discord message, please check the discord channel");
-            } else {
-                this.notificationService.error("There was an error when sending the Discord message. Please check your settings");
-            }
-        });
+    protected saveSettings(settings: IDiscordNotifcationSettings): Observable<boolean> {
+        return this.settingsService.saveDiscordNotificationSettings(settings);
+    }
 
+    protected testSettings(settings: IDiscordNotifcationSettings): Observable<boolean> {
+        return this.testerService.discordTest(settings);
+    }
+
+    protected buildForm(x: IDiscordNotifcationSettings) {
+        return {
+            enabled: [x.enabled],
+            username: [x.username],
+            webhookUrl: [x.webhookUrl, [Validators.required]],
+            icon: [x.icon],
+            hideUser: [x.hideUser],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.html
@@ -9,71 +9,75 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline">
-        <mat-label>SMTP host</mat-label>
-        <input matInput formControlName="host" autocomplete="off"
-               placeholder="smtp.example.com">
-        @if (form?.get('host')?.hasError('required')) {
-            <mat-error>Host is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline">
+                <mat-label>SMTP host</mat-label>
+                <input matInput formControlName="host" autocomplete="off"
+                       placeholder="smtp.example.com">
+                @if (form.get('host')?.hasError('required')) {
+                    <mat-error>Host is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>SMTP port</mat-label>
-        <input matInput type="number" formControlName="port" autocomplete="off">
-        @if (form?.get('port')?.hasError('required')) {
-            <mat-error>Port is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>SMTP port</mat-label>
+                <input matInput type="number" formControlName="port" autocomplete="off">
+                @if (form.get('port')?.hasError('required')) {
+                    <mat-error>Port is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Sender address</mat-label>
-        <input matInput type="email" formControlName="senderAddress" autocomplete="off"
-               matTooltip="The email address that the emails will be sent from.">
-        @if (form?.get('senderAddress')?.hasError('required')) {
-            <mat-error>Sender address is <strong>required</strong></mat-error>
-        }
-        @if (form?.get('senderAddress')?.hasError('email')) {
-            <mat-error>Sender address must be a valid email address.</mat-error>
-        }
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Sender address</mat-label>
+                <input matInput type="email" formControlName="senderAddress" autocomplete="off"
+                       matTooltip="The email address that the emails will be sent from.">
+                @if (form.get('senderAddress')?.hasError('required')) {
+                    <mat-error>Sender address is <strong>required</strong></mat-error>
+                }
+                @if (form.get('senderAddress')?.hasError('email')) {
+                    <mat-error>Sender address must be a valid email address.</mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Sender name</mat-label>
-        <input matInput formControlName="senderName" autocomplete="off"
-               matTooltip="The friendly name shown in the FROM field of the email.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Sender name</mat-label>
+                <input matInput formControlName="senderName" autocomplete="off"
+                       matTooltip="The friendly name shown in the FROM field of the email.">
+            </mat-form-field>
 
-    @if (form?.controls?.['username']?.validator) {
-        <mat-form-field appearance="outline">
-            <mat-label>Username</mat-label>
-            <input matInput formControlName="username" autocomplete="username"
-                   matTooltip="SMTP username when authentication is enabled.">
-            @if (form?.get('username')?.hasError('required')) {
-                <mat-error>Username is <strong>required</strong></mat-error>
+            @if (form.controls['username']?.validator) {
+                <mat-form-field appearance="outline">
+                    <mat-label>Username</mat-label>
+                    <input matInput formControlName="username" autocomplete="username"
+                           matTooltip="SMTP username when authentication is enabled.">
+                    @if (form.get('username')?.hasError('required')) {
+                        <mat-error>Username is <strong>required</strong></mat-error>
+                    }
+                </mat-form-field>
+
+                <mat-form-field appearance="outline">
+                    <mat-label>Password</mat-label>
+                    <input matInput type="password" formControlName="password" autocomplete="current-password"
+                           matTooltip="SMTP password when authentication is enabled.">
+                    @if (form.get('password')?.hasError('required')) {
+                        <mat-error>Password is <strong>required</strong></mat-error>
+                    }
+                </mat-form-field>
             }
-        </mat-form-field>
 
-        <mat-form-field appearance="outline">
-            <mat-label>Password</mat-label>
-            <input matInput type="password" formControlName="password" autocomplete="current-password"
-                   matTooltip="SMTP password when authentication is enabled.">
-            @if (form?.get('password')?.hasError('required')) {
-                <mat-error>Password is <strong>required</strong></mat-error>
-            }
-        </mat-form-field>
+            <div class="notification-field--full"
+                 style="display:flex; flex-direction:column; gap:12px; padding-top:4px;">
+                <mat-slide-toggle color="primary" formControlName="authentication">
+                    Enable SMTP authentication
+                </mat-slide-toggle>
+                <mat-slide-toggle color="primary" formControlName="disableTLS">
+                    Disable TLS / SSL
+                </mat-slide-toggle>
+                <mat-slide-toggle color="primary" formControlName="disableCertificateChecking">
+                    Disable certificate checking
+                </mat-slide-toggle>
+            </div>
+        </ng-container>
     }
-
-    <div class="notification-field--full"
-         style="display:flex; flex-direction:column; gap:12px; padding-top:4px;">
-        <mat-slide-toggle color="primary" formControlName="authentication">
-            Enable SMTP authentication
-        </mat-slide-toggle>
-        <mat-slide-toggle color="primary" formControlName="disableTLS">
-            Disable TLS / SSL
-        </mat-slide-toggle>
-        <mat-slide-toggle color="primary" formControlName="disableCertificateChecking">
-            Disable certificate checking
-        </mat-slide-toggle>
-    </div>
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.html
@@ -1,103 +1,79 @@
-﻿<div *ngIf="emailForm" class="small-middle-container">
-    <fieldset>
-        <legend>Email Notifications</legend>
-        <div class="row">
-            <div class="col-md-8">
-                <form novalidate [formGroup]="emailForm" style="padding-top:2%;" (ngSubmit)="onSubmit(emailForm)">
-                    <div class="row">
-                        <div>
-                            <div class="md-form-field">
-                                <mat-slide-toggle formControlName="enabled">Enable</mat-slide-toggle>
-                            </div>
-                            <div class="md-form-field">
-                                <mat-slide-toggle formControlName="authentication">Enable SMTP Authentication
-                                </mat-slide-toggle>
-                            </div>
-                            <div class="md-form-field">
-                                <mat-slide-toggle formControlName="disableTLS">Disable TLS/SSL</mat-slide-toggle>
-                            </div>
-                            <div class="md-form-field">
-                                <mat-slide-toggle formControlName="disableCertificateChecking">Disable Certificate
-                                    Checking</mat-slide-toggle>
-                            </div>
-                        </div>
-                    </div>
+<ombi-notification-shell
+    providerName="Email"
+    icon="mail"
+    description="Send transactional and newsletter emails via your own SMTP server."
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    [showSubject]="true"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                    <div class="row">
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>SMTP Host</mat-label>
-                                <input matInput formControlName="host">
-                                <mat-error *ngIf="emailForm.get('host').hasError('required')">
-                                    Host is <strong>required</strong>
-                                  </mat-error>
-                            </mat-form-field>
-                            <mat-form-field appearance="outline">
-                                <mat-label>SMTP Port</mat-label>
-                                <input matInput formControlName="port">
-                                <mat-error *ngIf="emailForm.get('port').hasError('required')">
-                                    Port is <strong>required</strong>
-                                  </mat-error>
-                            </mat-form-field>
-                        </div>
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Email Sender</mat-label>
-                                <input matInput formControlName="senderAddress" matTooltip="The email address that the emails will be sent from">
-                                <mat-error *ngIf="emailForm.get('senderAddress').hasError('required')">
-                                    Email Sender Address is <strong>required</strong>
-                                  </mat-error>
-                                  <mat-error *ngIf="emailForm.get('senderAddress').hasError('email')">
-                                    Email Sender Address needs to be a valid email address
-                                  </mat-error>
-                            </mat-form-field>
-                            <mat-form-field appearance="outline">
-                                <mat-label>Sender Name</mat-label>
-                                <input matInput formControlName="senderName" matTooltip="The 'Friendly' name that will appear in the 'FROM:' part of the email">
-                            </mat-form-field>
-                        </div>
-                        <div class="md-form-field" *ngIf="emailForm.controls['username'].validator">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Username</mat-label>
-                                <input matInput formControlName="username" matTooltip="The username if authentication is enabled">
-                                <mat-error *ngIf="emailForm.get('username').hasError('required')">
-                                    Username is <strong>required</strong>
-                                  </mat-error>
-                            </mat-form-field>
+    <mat-form-field appearance="outline">
+        <mat-label>SMTP host</mat-label>
+        <input matInput formControlName="host" autocomplete="off"
+               placeholder="smtp.example.com">
+        @if (form?.get('host')?.hasError('required')) {
+            <mat-error>Host is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                            <mat-form-field appearance="outline">
-                                <mat-label>Password</mat-label>
-                                <input type="password" matInput formControlName="password" matTooltip="The password if authentication is enabled">
-                                <mat-error *ngIf="emailForm.get('password').hasError('required')">
-                                    Password is <strong>required</strong>
-                                  </mat-error>
-                            </mat-form-field>
-                        </div>
+    <mat-form-field appearance="outline">
+        <mat-label>SMTP port</mat-label>
+        <input matInput type="number" formControlName="port" autocomplete="off">
+        @if (form?.get('port')?.hasError('required')) {
+            <mat-error>Port is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                </div>
-                <div class="row top-space">
-                    <div class="form-group">
-                        <div>
-                            <button mat-raised-button type="button" class="btn-spacing" color="accent"
-                            (click)="test(emailForm)" [disabled]="emailForm.invalid">Test <div id="spinner"></div>
-                            </button>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <div>
-                            <button mat-raised-button type="submit" class="btn-spacing" color="primary"
-                                [disabled]="emailForm.invalid">Submit</button>
-                        </div>
-                    </div>
-                </div>
-                </form>
-            </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Sender address</mat-label>
+        <input matInput type="email" formControlName="senderAddress" autocomplete="off"
+               matTooltip="The email address that the emails will be sent from.">
+        @if (form?.get('senderAddress')?.hasError('required')) {
+            <mat-error>Sender address is <strong>required</strong></mat-error>
+        }
+        @if (form?.get('senderAddress')?.hasError('email')) {
+            <mat-error>Sender address must be a valid email address.</mat-error>
+        }
+    </mat-form-field>
 
+    <mat-form-field appearance="outline">
+        <mat-label>Sender name</mat-label>
+        <input matInput formControlName="senderName" autocomplete="off"
+               matTooltip="The friendly name shown in the FROM field of the email.">
+    </mat-form-field>
 
-        <div class="col-md-4">
-            <notification-templates [templates]="templates"></notification-templates>
-        </div>
-        
+    @if (form?.controls?.['username']?.validator) {
+        <mat-form-field appearance="outline">
+            <mat-label>Username</mat-label>
+            <input matInput formControlName="username" autocomplete="username"
+                   matTooltip="SMTP username when authentication is enabled.">
+            @if (form?.get('username')?.hasError('required')) {
+                <mat-error>Username is <strong>required</strong></mat-error>
+            }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+            <mat-label>Password</mat-label>
+            <input matInput type="password" formControlName="password" autocomplete="current-password"
+                   matTooltip="SMTP password when authentication is enabled.">
+            @if (form?.get('password')?.hasError('required')) {
+                <mat-error>Password is <strong>required</strong></mat-error>
+            }
+        </mat-form-field>
+    }
+
+    <div class="notification-field--full"
+         style="display:flex; flex-direction:column; gap:12px; padding-top:4px;">
+        <mat-slide-toggle color="primary" formControlName="authentication">
+            Enable SMTP authentication
+        </mat-slide-toggle>
+        <mat-slide-toggle color="primary" formControlName="disableTLS">
+            Disable TLS / SSL
+        </mat-slide-toggle>
+        <mat-slide-toggle color="primary" formControlName="disableCertificateChecking">
+            Disable certificate checking
+        </mat-slide-toggle>
     </div>
-    </fieldset>
-</div>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.ts
@@ -7,7 +7,7 @@ import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
 import { Observable, Subject } from "rxjs";
-import { takeUntil } from "rxjs/operators";
+import { startWith, takeUntil } from "rxjs/operators";
 
 import { IEmailNotificationSettings } from "../../interfaces";
 import { NotificationService, SettingsService, TesterService, ValidationService } from "../../services";
@@ -82,13 +82,14 @@ export class EmailNotificationComponent extends NotificationBaseComponent<IEmail
         };
     }
 
-    protected override onFormReady(form: UntypedFormGroup, settings: IEmailNotificationSettings): void {
-        if (settings.authentication) {
-            this.applyAuthValidators(true);
-        }
-        form.controls.authentication.valueChanges
-            .pipe(takeUntil(this.authChanges$))
-            .subscribe((auth: boolean) => this.applyAuthValidators(auth));
+    protected override onFormReady(form: UntypedFormGroup, _settings: IEmailNotificationSettings): void {
+        const authControl = form.controls.authentication;
+        authControl.valueChanges
+            .pipe(
+                startWith(authControl.value),
+                takeUntil(this.authChanges$),
+            )
+            .subscribe((auth: boolean) => this.applyAuthValidators(!!auth));
     }
 
     public override ngOnDestroy(): void {

--- a/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/emailnotification.component.ts
@@ -1,21 +1,18 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule, FormsModule } from "@angular/forms";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
+import { Observable, Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
 
-import { IEmailNotificationSettings, INotificationTemplates, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { ValidationService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
-    import { NotificationTemplate } from "./notificationtemplate.component";
+import { IEmailNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService, ValidationService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
@@ -23,103 +20,90 @@ import { SettingsService } from "../../services";
         CommonModule,
         FormsModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./emailnotification.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class EmailNotificationComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public emailForm: UntypedFormGroup;
+export class EmailNotificationComponent extends NotificationBaseComponent<IEmailNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private validationService: ValidationService,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Email";
+    private readonly authChanges$ = new Subject<void>();
 
-    public ngOnInit() {
-        this.settingsService.getEmailNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.emailForm = this.fb.group({
-                enabled: [x.enabled],
-                authentication: [x.authentication],
-                host: [x.host, [Validators.required]],
-                password: [x.password],
-                port: [x.port, [Validators.required]],
-                senderAddress: [x.senderAddress, [Validators.required, Validators.email]],
-                senderName: [x.senderName],
-                username: [x.username],
-                disableTLS: [x.disableTLS],
-                disableCertificateChecking: [x.disableCertificateChecking],
-            });
-
-            if (x.authentication) {
-                this.validationService.enableValidation(this.emailForm, "username");
-                this.validationService.enableValidation(this.emailForm, "password");
-            }
-
-            this.subscribeToAuthChanges();
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                private readonly validationService: ValidationService,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
+    public get emailForm(): UntypedFormGroup { return this.form; }
+
+    protected override get savedMessage(): string { return "Successfully saved Email settings"; }
+    protected override get saveErrorMessage(): string {
+        return "There was an error when saving the Email settings";
+    }
+    protected override get testSuccessMessage(): string {
+        return "Successfully sent an email message, please check your inbox";
+    }
+    protected override get testErrorMessage(): string {
+        return "There was an error when sending the Email message, please check your settings.";
+    }
+
+    protected loadSettings(): Observable<IEmailNotificationSettings> {
+        return this.settingsService.getEmailNotificationSettings();
+    }
+
+    protected saveSettings(settings: IEmailNotificationSettings): Observable<boolean> {
+        return this.settingsService.saveEmailNotificationSettings(settings);
+    }
+
+    protected testSettings(settings: IEmailNotificationSettings): Observable<boolean> {
+        return this.testerService.emailTest(settings);
+    }
+
+    protected buildForm(x: IEmailNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            authentication: [x.authentication],
+            host: [x.host, [Validators.required]],
+            password: [x.password],
+            port: [x.port, [Validators.required]],
+            senderAddress: [x.senderAddress, [Validators.required, Validators.email]],
+            senderName: [x.senderName],
+            username: [x.username],
+            disableTLS: [x.disableTLS],
+            disableCertificateChecking: [x.disableCertificateChecking],
+        };
+    }
+
+    protected override onFormReady(form: UntypedFormGroup, settings: IEmailNotificationSettings): void {
+        if (settings.authentication) {
+            this.applyAuthValidators(true);
         }
-
-        const settings = <IEmailNotificationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveEmailNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved Email settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Email settings");
-            }
-        });
-
+        form.controls.authentication.valueChanges
+            .pipe(takeUntil(this.authChanges$))
+            .subscribe((auth: boolean) => this.applyAuthValidators(auth));
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
+    public override ngOnDestroy(): void {
+        this.authChanges$.next();
+        this.authChanges$.complete();
+        super.ngOnDestroy();
+    }
+
+    private applyAuthValidators(authEnabled: boolean): void {
+        if (authEnabled) {
+            this.validationService.enableValidation(this.form, "username");
+            this.validationService.enableValidation(this.form, "password");
+        } else {
+            this.validationService.disableValidation(this.form, "username");
+            this.validationService.disableValidation(this.form, "password");
         }
-
-        this.testerService.emailTest(form.value).subscribe(x => {
-              if (x === true) {
-                this.notificationService.success("Successfully sent an email message, please check your inbox");
-            } else {
-                this.notificationService.error("There was an error when sending the Email message, please check your settings.");
-            }
-        });
-    }
-
-    private subscribeToAuthChanges() {
-        const authCtrl = this.emailForm.controls.authentication;
-        const changes$ = authCtrl.valueChanges;
-
-        changes$.subscribe((auth: boolean) => {
-
-            if (auth) {
-                this.validationService.enableValidation(this.emailForm, "username");
-                this.validationService.enableValidation(this.emailForm, "password");
-            } else {
-                this.validationService.disableValidation(this.emailForm, "username");
-                this.validationService.disableValidation(this.emailForm, "password");
-            }
-        });
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.html
@@ -1,66 +1,41 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Gotify Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+<ombi-notification-shell
+    providerName="Gotify"
+    icon="campaign"
+    description="Push notifications to a self-hosted Gotify server."
+    docsUrl="https://gotify.net/docs/pushmsg"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Server URL</mat-label>
+        <input matInput formControlName="baseUrl" autocomplete="off"
+               placeholder="https://gotify.example.com"
+               matTooltip="The base URL of your Gotify server.">
+        @if (form?.get('baseUrl')?.hasError('required')) {
+            <mat-error>Server URL is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Base URL</mat-label>
-                        <input matInput type="text" id="baseUrl" name="baseUrl" [ngClass]="{'form-error': form.get('baseUrl').hasError('required')}" formControlName="baseUrl" pTooltip="Enter the URL of your gotify server.">
-                    </mat-form-field>
-                </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Application token</mat-label>
+        <input matInput formControlName="applicationToken" autocomplete="off"
+               matTooltip="Generated under Apps in your Gotify server.">
+        @if (form?.get('applicationToken')?.hasError('required')) {
+            <mat-error>Application token is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Application Token</mat-label>
-                        <input matInput type="text" id="applicationToken" name="applicationToken" [ngClass]="{'form-error': form.get('applicationToken').hasError('required')}" formControlName="applicationToken" pTooltip="Enter your Application token from Gotify.">
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Priority</mat-label>
-
-                        <mat-select id="priority" name="priority" formControlName="priority" pTooltip="The priority you want your gotify notifications sent as.">
-                          <mat-option value="4">Normal</mat-option>
-                          <mat-option value="8">High</mat-option>
-                          <mat-option value="2">Low</mat-option>
-                          <mat-option value="0">Lowest</mat-option>
-                        </mat-select>
-                    </mat-form-field>
-                    <div>
-                    </div>
-                </div>
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-
-        <div class="col-md-6">
-            <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Priority</mat-label>
+        <mat-select formControlName="priority"
+                    matTooltip="Higher priority surfaces messages more aggressively on the client.">
+            <mat-option value="0">Lowest</mat-option>
+            <mat-option value="2">Low</mat-option>
+            <mat-option value="4">Normal</mat-option>
+            <mat-option value="8">High</mat-option>
+        </mat-select>
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.html
@@ -9,33 +9,37 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline">
-        <mat-label>Server URL</mat-label>
-        <input matInput formControlName="baseUrl" autocomplete="off"
-               placeholder="https://gotify.example.com"
-               matTooltip="The base URL of your Gotify server.">
-        @if (form?.get('baseUrl')?.hasError('required')) {
-            <mat-error>Server URL is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline">
+                <mat-label>Server URL</mat-label>
+                <input matInput formControlName="baseUrl" autocomplete="off"
+                       placeholder="https://gotify.example.com"
+                       matTooltip="The base URL of your Gotify server.">
+                @if (form.get('baseUrl')?.hasError('required')) {
+                    <mat-error>Server URL is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Application token</mat-label>
-        <input matInput formControlName="applicationToken" autocomplete="off"
-               matTooltip="Generated under Apps in your Gotify server.">
-        @if (form?.get('applicationToken')?.hasError('required')) {
-            <mat-error>Application token is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Application token</mat-label>
+                <input matInput formControlName="applicationToken" autocomplete="off"
+                       matTooltip="Generated under Apps in your Gotify server.">
+                @if (form.get('applicationToken')?.hasError('required')) {
+                    <mat-error>Application token is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Priority</mat-label>
-        <mat-select formControlName="priority"
-                    matTooltip="Higher priority surfaces messages more aggressively on the client.">
-            <mat-option [value]="0">Lowest</mat-option>
-            <mat-option [value]="2">Low</mat-option>
-            <mat-option [value]="4">Normal</mat-option>
-            <mat-option [value]="8">High</mat-option>
-        </mat-select>
-    </mat-form-field>
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Priority</mat-label>
+                <mat-select formControlName="priority"
+                            matTooltip="Higher priority surfaces messages more aggressively on the client.">
+                    <mat-option [value]="0">Lowest</mat-option>
+                    <mat-option [value]="2">Low</mat-option>
+                    <mat-option [value]="4">Normal</mat-option>
+                    <mat-option [value]="8">High</mat-option>
+                </mat-select>
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.html
@@ -32,10 +32,10 @@
         <mat-label>Priority</mat-label>
         <mat-select formControlName="priority"
                     matTooltip="Higher priority surfaces messages more aggressively on the client.">
-            <mat-option value="0">Lowest</mat-option>
-            <mat-option value="2">Low</mat-option>
-            <mat-option value="4">Normal</mat-option>
-            <mat-option value="8">High</mat-option>
+            <mat-option [value]="0">Lowest</mat-option>
+            <mat-option [value]="2">Low</mat-option>
+            <mat-option [value]="4">Normal</mat-option>
+            <mat-option [value]="8">High</mat-option>
         </mat-select>
     </mat-form-field>
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/gotify.component.ts
@@ -1,93 +1,63 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { IGotifyNotificationSettings, INotificationTemplates, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { IGotifyNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./gotify.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class GotifyComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+export class GotifyComponent extends NotificationBaseComponent<IGotifyNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Gotify";
 
-    public ngOnInit() {
-        this.settingsService.getGotifyNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                baseUrl: [x.baseUrl, [Validators.required]],
-                applicationToken: [x.applicationToken, [Validators.required]],
-                priority: [x.priority],
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IGotifyNotificationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveGotifyNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Gotify settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Gotify settings");
-            }
-        });
-
+    protected loadSettings(): Observable<IGotifyNotificationSettings> {
+        return this.settingsService.getGotifyNotificationSettings();
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected saveSettings(settings: IGotifyNotificationSettings): Observable<boolean> {
+        return this.settingsService.saveGotifyNotificationSettings(settings);
+    }
 
-        this.testerService.gotifyTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully sent a Gotify message");
-            } else {
-                this.notificationService.error("There was an error when sending the Gotify message. Please check your settings");
-            }
-        });
+    protected testSettings(settings: IGotifyNotificationSettings): Observable<boolean> {
+        return this.testerService.gotifyTest(settings);
+    }
+
+    protected buildForm(x: IGotifyNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            baseUrl: [x.baseUrl, [Validators.required]],
+            applicationToken: [x.applicationToken, [Validators.required]],
+            priority: [x.priority],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/mattermost.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/mattermost.component.html
@@ -1,66 +1,38 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Mattermost Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+<ombi-notification-shell
+    providerName="Mattermost"
+    icon="chat"
+    description="Push notifications to a Mattermost channel through an incoming webhook."
+    docsUrl="https://docs.mattermost.com/developer/webhooks-incoming.html"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Incoming webhook URL</mat-label>
+        <input matInput formControlName="webhookUrl" autocomplete="off">
+        @if (form?.get('webhookUrl')?.hasError('required')) {
+            <mat-error>Webhook URL is <strong>required</strong></mat-error>
+        }
+        <mat-hint>Mattermost &rarr; Integrations &rarr; Incoming Webhook.</mat-hint>
+    </mat-form-field>
 
-                <div class="form-group">
-                    <small class="control-label"> Mattermost > Integrations > Incoming Webhook > Add Incoming Webhook. You will then have a Webhook</small>
-                    <mat-form-field>
-                        <mat-label>Incoming Webhook Url</mat-label>
-                        <input matInput type="text" id="webhookUrl" name="webhookUrl" formControlName="webhookUrl" [ngClass]="{'form-error': form.get('webhookUrl').hasError('required')}">
-                    </mat-form-field>
-                  </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Channel override</mat-label>
+        <input matInput formControlName="channel" autocomplete="off"
+               matTooltip="Optional. Routes messages to a different channel than the webhook default.">
+    </mat-form-field>
 
+    <mat-form-field appearance="outline">
+        <mat-label>Username override</mat-label>
+        <input matInput formControlName="username" autocomplete="off"
+               matTooltip="Optional. Defaults to the username configured on the webhook.">
+    </mat-form-field>
 
-                  <div class="form-group">
-                  <mat-form-field>
-                      <mat-label>Channel Override</mat-label>
-                      <input matInput type="text" id="channel" name="channel" formControlName="channel" pTooltip="Optional, you can override the default channel">
-                  </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                  <mat-form-field>
-                      <mat-label>Username Override</mat-label>
-                      <input matInput type="text" id="username" name="username" formControlName="username" pTooltip="Optional, this will override the username you used for the Webhook">
-                  </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                  <mat-form-field>
-                      <mat-label>Icon Override</mat-label>
-                      <input matInput type="text" id="iconUrl" name="iconUrl" formControlName="iconUrl" pTooltip="Optional, this will override the icon you use for the Webhook">
-                  </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-
-        <div class="col-md-6">
-            <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Icon URL</mat-label>
+        <input matInput formControlName="iconUrl" autocomplete="off"
+               matTooltip="Optional. Defaults to the icon configured on the webhook.">
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/mattermost.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/mattermost.component.html
@@ -9,30 +9,34 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Incoming webhook URL</mat-label>
-        <input matInput formControlName="webhookUrl" autocomplete="off">
-        @if (form?.get('webhookUrl')?.hasError('required')) {
-            <mat-error>Webhook URL is <strong>required</strong></mat-error>
-        }
-        <mat-hint>Mattermost &rarr; Integrations &rarr; Incoming Webhook.</mat-hint>
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Incoming webhook URL</mat-label>
+                <input matInput formControlName="webhookUrl" autocomplete="off">
+                @if (form.get('webhookUrl')?.hasError('required')) {
+                    <mat-error>Webhook URL is <strong>required</strong></mat-error>
+                }
+                <mat-hint>Mattermost &rarr; Integrations &rarr; Incoming Webhook.</mat-hint>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Channel override</mat-label>
-        <input matInput formControlName="channel" autocomplete="off"
-               matTooltip="Optional. Routes messages to a different channel than the webhook default.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Channel override</mat-label>
+                <input matInput formControlName="channel" autocomplete="off"
+                       matTooltip="Optional. Routes messages to a different channel than the webhook default.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Username override</mat-label>
-        <input matInput formControlName="username" autocomplete="off"
-               matTooltip="Optional. Defaults to the username configured on the webhook.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Username override</mat-label>
+                <input matInput formControlName="username" autocomplete="off"
+                       matTooltip="Optional. Defaults to the username configured on the webhook.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Icon URL</mat-label>
-        <input matInput formControlName="iconUrl" autocomplete="off"
-               matTooltip="Optional. Defaults to the icon configured on the webhook.">
-    </mat-form-field>
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Icon URL</mat-label>
+                <input matInput formControlName="iconUrl" autocomplete="off"
+                       matTooltip="Optional. Defaults to the icon configured on the webhook.">
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/mattermost.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/mattermost.component.ts
@@ -1,97 +1,66 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { IMattermostNotifcationSettings, INotificationTemplates, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { IMattermostNotifcationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./mattermost.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class MattermostComponent implements OnInit {
+export class MattermostComponent extends NotificationBaseComponent<IMattermostNotifcationSettings> {
 
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+    protected readonly providerName = "Mattermost";
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
-
-    public ngOnInit() {
-        this.settingsService.getMattermostNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                username: [x.username],
-                webhookUrl: [x.webhookUrl, [Validators.required]],
-                channel: [x.channel],
-                iconUrl: [x.iconUrl],
-
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IMattermostNotifcationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveMattermostNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Mattermost settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Mattermost settings");
-            }
-        });
-
+    protected override get testSuccessMessage(): string {
+        return "Successfully sent a Mattermost message, please check the appropriate channel";
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected loadSettings(): Observable<IMattermostNotifcationSettings> {
+        return this.settingsService.getMattermostNotificationSettings();
+    }
 
-        this.testerService.mattermostTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success( "Successfully sent a Mattermost message, please check the appropriate channel");
-            } else {
-                this.notificationService.error("There was an error when sending the Mattermost message. Please check your settings");
-            }
-        });
+    protected saveSettings(settings: IMattermostNotifcationSettings): Observable<boolean> {
+        return this.settingsService.saveMattermostNotificationSettings(settings);
+    }
 
+    protected testSettings(settings: IMattermostNotifcationSettings): Observable<boolean> {
+        return this.testerService.mattermostTest(settings);
+    }
+
+    protected buildForm(x: IMattermostNotifcationSettings) {
+        return {
+            enabled: [x.enabled],
+            username: [x.username],
+            webhookUrl: [x.webhookUrl, [Validators.required]],
+            channel: [x.channel],
+            iconUrl: [x.iconUrl],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/newsletter.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/newsletter.component.html
@@ -1,92 +1,109 @@
-﻿<settings-menu></settings-menu>
+<ombi-notification-shell
+    providerName="Newsletter"
+    icon="newspaper"
+    description="Send a recurring digest of newly added Movies, TV and Music to your users."
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    [showTemplates]="false"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-<wiki></wiki>
-<div *ngIf="settings" class="small-middle-container">
-    <fieldset>
-        <legend>Newsletter</legend>
-        <div class="col-md-6">
-
-                <div class="form-group">
-                    <div class="checkbox">
-                        <mat-slide-toggle  type="checkbox" id="enabled" [(ngModel)]="settings.enabled"  ng-checked="settings.enabled">Enable</mat-slide-toggle>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <div class="checkbox">
-                        <mat-slide-toggle  type="checkbox" id="disableTv" [(ngModel)]="settings.disableTv"  ng-checked="settings.disableTv">Disable TV</mat-slide-toggle>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <div class="checkbox">
-                        <mat-slide-toggle  type="checkbox" id="disableMovies" [(ngModel)]="settings.disableMovies"  ng-checked="settings.disableMovies">Disable Movies</mat-slide-toggle>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <div class="checkbox">
-                        <mat-slide-toggle  type="checkbox" id="disableMusic" [(ngModel)]="settings.disableMusic"  ng-checked="settings.disableMusic">Disable Music</mat-slide-toggle>
-                    </div>
-                </div>
-                 <div class="form-group">
-                    <mat-form-field appearance="outline" floatLabel=auto>
-                        <mat-label>Subject</mat-label>
-                        <input matInput id="subject" name="subject"
-                        [(ngModel)]="settings.notificationTemplate.subject" value="{{settings.notificationTemplate.subject}}">
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field appearance="outline" floatLabel=auto>
-                        <mat-label>Message</mat-label>
-                        <textarea matInput id="message" name="message"
-                        [(ngModel)]="settings.notificationTemplate.message" value="{{settings.notificationTemplate.message}}"> </textarea>
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <div>
-                        <button mat-raised-button type="submit" id="save" (click)="onSubmit()">Submit</button>
-                        <button mat-raised-button type="button" (click)="test()">Test</button>
-                        <button mat-raised-button type="button" (click)="updateDatabase()"tooltipPosition="top" matTooltip="I recommend running this with a fresh Ombi install, this will set all the current *found* content to have been sent via Newsletter,
-                        if you do not do this then everything that Ombi has found in your libraries will go out on the first email!">Update Database</button>
-                        <button mat-raised-button type="button" (click)="trigger()">Trigger now</button>
-                    </div>
-                                 </div>
-        </div>
-
-
-        <div class="col-md-6">
-            <small>NOTE: Please see the tooltip on the Update Database button - Please see the wiki for more information</small>
-            <br/>
-            <br/>
-            <small>When testing, the test newsletter will go to all users that have the Admin role, please ensure that there are valid email addresses for this. The test will also only grab the latest 10 movies and 10 shows just to give you an example.</small>
-
-            <br/>
-            <br/>
-            <div class="form-group row">
-                <div class="col-md-9">
-                    <mat-form-field appearance="outline" floatLabel=auto>
-                        <mat-label>Add External Email (For users that are not in Ombi)</mat-label>
-                        <input matInput id="emailToAdd" name="emailToAdd"
-                        [(ngModel)]="emailToAdd" value="{{emailToAdd}}">
-                    </mat-form-field>
-                </div>
-                <div class="col-md-3">
-                    <button mat-raised-button (click)="addEmail()" matTooltip="Don't forget to press the Submit button!">Add</button>
-                </div>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <div class="notification-field--full newsletter__toggles">
+                <mat-slide-toggle color="primary" formControlName="disableMovies">
+                    Disable movies
+                </mat-slide-toggle>
+                <mat-slide-toggle color="primary" formControlName="disableTv">
+                    Disable TV
+                </mat-slide-toggle>
+                <mat-slide-toggle color="primary" formControlName="disableMusic">
+                    Disable music
+                </mat-slide-toggle>
             </div>
 
-            <div class="row">
-                <div *ngFor="let email of settings.externalEmails">
-                    <div class="col-md-9">
-                        {{email}}
-                    </div>
-                    <div class="col-md-3">
-                        <button mat-raised-button (click)="deleteEmail(email)">Delete</button>
-                    </div>
-                </div>
+            <div class="notification-field--full" formGroupName="notificationTemplate">
+                <mat-form-field appearance="outline" class="newsletter__field">
+                    <mat-label>Subject</mat-label>
+                    <input matInput formControlName="subject" autocomplete="off">
+                    @if (form.get('notificationTemplate.subject')?.hasError('required')) {
+                        <mat-error>Subject is <strong>required</strong></mat-error>
+                    }
+                </mat-form-field>
+
+                <mat-form-field appearance="outline" class="newsletter__field">
+                    <mat-label>Message</mat-label>
+                    <textarea matInput rows="6" formControlName="message"></textarea>
+                    <mat-hint>HTML is supported. Newsletter-specific placeholders are documented in the wiki.</mat-hint>
+                    @if (form.get('notificationTemplate.message')?.hasError('required')) {
+                        <mat-error>Message is <strong>required</strong></mat-error>
+                    }
+                </mat-form-field>
             </div>
+        </ng-container>
+    }
+
+    <div notificationFooter class="newsletter__admin">
+        <span class="newsletter__admin-label">Admin actions</span>
+        <div class="newsletter__admin-buttons">
+            <button mat-stroked-button type="button"
+                    matTooltip="Run this on a fresh install. Marks all currently-found content as already sent so the first newsletter doesn't include everything in your library."
+                    (click)="updateDatabase()">
+                <mat-icon>storage</mat-icon>
+                Update database
+            </button>
+            <button mat-stroked-button type="button"
+                    matTooltip="Run the newsletter job immediately."
+                    (click)="triggerNow()">
+                <mat-icon>play_arrow</mat-icon>
+                Trigger now
+            </button>
         </div>
-    </fieldset>
-</div>
+    </div>
+</ombi-notification-shell>
+
+<section class="newsletter-recipients">
+    <mat-card appearance="outlined" class="newsletter-recipients__card">
+        <mat-card-header>
+            <div mat-card-avatar class="newsletter-recipients__avatar" aria-hidden="true">
+                <mat-icon>alternate_email</mat-icon>
+            </div>
+            <mat-card-title>External recipients</mat-card-title>
+            <mat-card-subtitle>Add email addresses for people who don't have an Ombi account.</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+            <form class="newsletter-recipients__form"
+                  (ngSubmit)="addEmail()" #emailForm="ngForm">
+                <mat-form-field appearance="outline" class="newsletter-recipients__input">
+                    <mat-label>Email address</mat-label>
+                    <input matInput name="emailToAdd"
+                           [(ngModel)]="emailToAdd"
+                           placeholder="someone@example.com"
+                           autocomplete="off">
+                </mat-form-field>
+                <button mat-stroked-button color="primary" type="submit"
+                        [disabled]="!emailToAdd?.trim()"
+                        matTooltip="Don't forget to save your changes!">
+                    <mat-icon>add</mat-icon>
+                    Add
+                </button>
+            </form>
+
+            @if (externalEmails.length) {
+                <mat-chip-set class="newsletter-recipients__chips" aria-label="External recipients">
+                    @for (email of externalEmails; track email) {
+                        <mat-chip (removed)="removeEmail(email)">
+                            {{ email }}
+                            <button matChipRemove [attr.aria-label]="'Remove ' + email">
+                                <mat-icon>cancel</mat-icon>
+                            </button>
+                        </mat-chip>
+                    }
+                </mat-chip-set>
+            } @else {
+                <p class="newsletter-recipients__empty">No external recipients yet.</p>
+            }
+        </mat-card-content>
+    </mat-card>
+</section>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/newsletter.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/newsletter.component.scss
@@ -1,0 +1,107 @@
+.newsletter {
+    &__toggles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px 24px;
+        padding-top: 4px;
+    }
+
+    &__field {
+        width: 100%;
+        margin-bottom: 12px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    &__admin {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 12px;
+        justify-content: flex-end;
+        padding: 12px 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.08);
+        margin-top: 8px;
+    }
+
+    &__admin-label {
+        margin-right: auto;
+        font-size: 0.85rem;
+        opacity: 0.75;
+    }
+
+    &__admin-buttons {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+
+        button mat-icon {
+            margin-right: 4px;
+            font-size: 18px;
+            width: 18px;
+            height: 18px;
+        }
+    }
+}
+
+.newsletter-recipients {
+    display: block;
+    margin: 0 auto 24px;
+    width: min(1280px, 95%);
+
+    &__card {
+        border-radius: 16px;
+        overflow: hidden;
+    }
+
+    &__avatar {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: rgba(63, 81, 181, 0.12);
+        color: var(--mdc-theme-primary, #3f51b5);
+
+        mat-icon {
+            font-size: 22px;
+            width: 22px;
+            height: 22px;
+        }
+    }
+
+    &__form {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-bottom: 12px;
+
+        button {
+            min-width: 120px;
+
+            mat-icon {
+                margin-right: 4px;
+            }
+        }
+    }
+
+    &__input {
+        flex: 1 1 320px;
+    }
+
+    &__chips {
+        ::ng-deep mat-chip {
+            font-size: 0.85rem;
+        }
+    }
+
+    &__empty {
+        margin: 0;
+        opacity: 0.7;
+        font-style: italic;
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/notifications/newsletter.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/newsletter.component.ts
@@ -1,101 +1,144 @@
-﻿import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { MatCardModule } from "@angular/material/card";
+import { MatChipsModule } from "@angular/material/chips";
+import { MatDividerModule } from "@angular/material/divider";
 import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
+import { Observable } from "rxjs";
 
-import { INewsletterNotificationSettings, NotificationType } from "../../interfaces";
-import { JobService, NotificationService, SettingsService } from "../../services";
-import { TesterService } from "../../services/applications/tester.service";
-import { SettingsMenuComponent } from "../settingsmenu.component";
-import { WikiComponent } from "../wiki.component";
+import { INewsletterNotificationSettings, INotificationTemplates } from "../../interfaces";
+import { JobService, NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
+
+const EMAIL_REGEX = /^[a-zA-Z0-9._-]+@[a-zA-Z.-]{2,}\.[a-zA-Z]{2,}$/;
 
 @Component({
     standalone: true,
-    templateUrl: "./newsletter.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"],
     imports: [
         CommonModule,
         FormsModule,
         ReactiveFormsModule,
         MatButtonModule,
-        MatCheckboxModule,
+        MatCardModule,
+        MatChipsModule,
+        MatDividerModule,
         MatFormFieldModule,
+        MatIconModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        SettingsMenuComponent,
-        WikiComponent
-    ]
+        NotificationShellComponent,
+    ],
+    templateUrl: "./newsletter.component.html",
+    styleUrls: ["./newsletter.component.scss"],
 })
-export class NewsletterComponent implements OnInit {
+export class NewsletterComponent extends NotificationBaseComponent<INewsletterNotificationSettings> {
 
-    public NotificationType = NotificationType;
-    public settings: INewsletterNotificationSettings;
-    public emailToAdd: string;
+    protected readonly providerName = "Newsletter";
+    protected override readonly attachTemplates = false;
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private testService: TesterService,
-                private jobService: JobService) { }
+    public emailToAdd = "";
+    public externalEmails: string[] = [];
+    private originalTemplate: INotificationTemplates | undefined;
 
-    public ngOnInit() {
-        this.settingsService.getNewsletterSettings().subscribe(x => {
-            this.settings = x;
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService,
+                private readonly jobService: JobService) {
+        super(settingsService, notificationService, fb, testerService);
+    }
+
+    protected override get savedMessage(): string {
+        return "Successfully saved the Newsletter settings";
+    }
+    protected override get saveErrorMessage(): string {
+        return "There was an error when saving the Newsletter settings";
+    }
+    protected override get testSuccessMessage(): string {
+        return "Test newsletter queued. It will be sent to admin users with valid email addresses.";
+    }
+
+    protected loadSettings(): Observable<INewsletterNotificationSettings> {
+        return this.settingsService.getNewsletterSettings();
+    }
+
+    protected saveSettings(settings: INewsletterNotificationSettings): Observable<boolean> {
+        const merged: INewsletterNotificationSettings = {
+            ...settings,
+            externalEmails: [...this.externalEmails],
+            notificationTemplate: {
+                ...(this.originalTemplate ?? {} as INotificationTemplates),
+                subject: settings.notificationTemplate?.subject ?? "",
+                message: settings.notificationTemplate?.message ?? "",
+            },
+        };
+        return this.settingsService.saveNewsletterSettings(merged);
+    }
+
+    protected testSettings(_settings: INewsletterNotificationSettings): Observable<boolean> {
+        return this.testerService.newsletterTest(_settings);
+    }
+
+    protected buildForm(x: INewsletterNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            disableTv: [x.disableTv],
+            disableMovies: [x.disableMovies],
+            disableMusic: [x.disableMusic],
+            notificationTemplate: this.fb.group({
+                subject: [x.notificationTemplate?.subject, [Validators.required]],
+                message: [x.notificationTemplate?.message, [Validators.required]],
+            }),
+        };
+    }
+
+    protected override onFormReady(_form: UntypedFormGroup, settings: INewsletterNotificationSettings): void {
+        this.originalTemplate = settings.notificationTemplate;
+        this.externalEmails = [...(settings.externalEmails ?? [])];
+    }
+
+    public updateDatabase(): void {
+        this.settingsService.updateNewsletterDatabase().subscribe(() => {
+            this.notificationService.success("Newsletter database updated");
         });
     }
 
-    public updateDatabase() {
-        this.settingsService.updateNewsletterDatabase().subscribe();
-        this.notificationService.success("Database updated");
-    }
-
-    public test() {
-        this.testService.newsletterTest(this.settings).subscribe();
-        this.notificationService.success("Test message queued");
-    }
-
-    public trigger() {
-        this.jobService.runNewsletter().subscribe();
-        this.notificationService.success("Triggered newsletter job");
-    }
-
-    public onSubmit() {
-              this.settingsService.saveNewsletterSettings(this.settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Newsletter settings");
-            } else {
-                this.notificationService.error("There was an error when saving the Newsletter settings");
-            }
+    public triggerNow(): void {
+        this.jobService.runNewsletter().subscribe(() => {
+            this.notificationService.success("Newsletter job triggered");
         });
-
     }
-    public addEmail() {
 
-        if (this.emailToAdd) {
-            const emailRegex = "[a-zA-Z0-9.-_]{1,}@[a-zA-Z.-]{2,}[.]{1}[a-zA-Z]{2,}";
-            const match = this.emailToAdd.match(emailRegex)!;
-            if (match && match.length > 0) {
-                this.settings.externalEmails.push(this.emailToAdd);
-                this.emailToAdd = "";
-            } else {
-                this.notificationService.error("Please enter a valid email address");
-            }
+    public addEmail(): void {
+        const candidate = this.emailToAdd?.trim();
+        if (!candidate) {
+            return;
         }
+        if (!EMAIL_REGEX.test(candidate)) {
+            this.notificationService.error("Please enter a valid email address");
+            return;
+        }
+        if (this.externalEmails.includes(candidate)) {
+            this.notificationService.warning("Already added", "That email address is already in the list");
+            return;
+        }
+        this.externalEmails = [...this.externalEmails, candidate];
+        this.emailToAdd = "";
+        this.form?.markAsDirty();
     }
 
-    public deleteEmail(email: string) {
-        const index = this.settings.externalEmails.indexOf(email);    // <-- Not supported in <IE9
-        if (index !== -1) {
-                this.settings.externalEmails.splice(index, 1);
-            }
+    public removeEmail(email: string): void {
+        this.externalEmails = this.externalEmails.filter(e => e !== email);
+        this.form?.markAsDirty();
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/ntfy.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/ntfy.component.html
@@ -9,40 +9,44 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline">
-        <mat-label>Server URL</mat-label>
-        <input matInput formControlName="baseUrl" autocomplete="off"
-               placeholder="https://ntfy.sh"
-               matTooltip="The base URL of your ntfy server.">
-        @if (form?.get('baseUrl')?.hasError('required')) {
-            <mat-error>Server URL is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline">
+                <mat-label>Server URL</mat-label>
+                <input matInput formControlName="baseUrl" autocomplete="off"
+                       placeholder="https://ntfy.sh"
+                       matTooltip="The base URL of your ntfy server.">
+                @if (form.get('baseUrl')?.hasError('required')) {
+                    <mat-error>Server URL is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Topic</mat-label>
-        <input matInput formControlName="topic" autocomplete="off"
-               matTooltip="Subscribers receive messages published to this topic.">
-        @if (form?.get('topic')?.hasError('required')) {
-            <mat-error>Topic is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Topic</mat-label>
+                <input matInput formControlName="topic" autocomplete="off"
+                       matTooltip="Subscribers receive messages published to this topic.">
+                @if (form.get('topic')?.hasError('required')) {
+                    <mat-error>Topic is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Authorization header</mat-label>
-        <input matInput formControlName="authorizationHeader" autocomplete="off"
-               matTooltip="Optional. Bearer token or Basic auth value for protected servers.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Authorization header</mat-label>
+                <input matInput formControlName="authorizationHeader" autocomplete="off"
+                       matTooltip="Optional. Bearer token or Basic auth value for protected servers.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Priority</mat-label>
-        <mat-select formControlName="priority"
-                    matTooltip="Higher priorities trigger more aggressive notifications on the client.">
-            <mat-option [value]="1">Min</mat-option>
-            <mat-option [value]="2">Low</mat-option>
-            <mat-option [value]="3">Default</mat-option>
-            <mat-option [value]="4">High</mat-option>
-            <mat-option [value]="5">Max</mat-option>
-        </mat-select>
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Priority</mat-label>
+                <mat-select formControlName="priority"
+                            matTooltip="Higher priorities trigger more aggressive notifications on the client.">
+                    <mat-option [value]="1">Min</mat-option>
+                    <mat-option [value]="2">Low</mat-option>
+                    <mat-option [value]="3">Default</mat-option>
+                    <mat-option [value]="4">High</mat-option>
+                    <mat-option [value]="5">Max</mat-option>
+                </mat-select>
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/ntfy.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/ntfy.component.html
@@ -1,75 +1,48 @@
+<ombi-notification-shell
+    providerName="ntfy"
+    icon="notifications_active"
+    description="Publish notifications to a public or self-hosted ntfy.sh topic."
+    docsUrl="https://docs.ntfy.sh/publish/"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Ntfy Notifications</legend>
-        <div class="row">
-            <div class="col-md-8">
-                <form novalidate [formGroup]="form" style="padding-top:2%;" (ngSubmit)="onSubmit(form)">
-                    <div class="row">
-                        <div>
-                            <div class="md-form-field">
-                                <mat-slide-toggle formControlName="enabled">Enable</mat-slide-toggle>
-                            </div>
-                        </div>
-                    </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Server URL</mat-label>
+        <input matInput formControlName="baseUrl" autocomplete="off"
+               placeholder="https://ntfy.sh"
+               matTooltip="The base URL of your ntfy server.">
+        @if (form?.get('baseUrl')?.hasError('required')) {
+            <mat-error>Server URL is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                    <div class="row">
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Base URL</mat-label>
-                                <input matInput formControlName="baseUrl" matTooltip="Enter the URL of your ntfy server">
-                                <mat-error *ngIf="form.get('baseUrl').hasError('required')">
-                                    Base URL is <strong>required</strong>
-                                </mat-error>
-                            </mat-form-field>
-                            <mat-form-field appearance="outline">
-                                <mat-label>Topic</mat-label>
-                                <input matInput formControlName="topic" matTooltip="Enter the topic to publish to">
-                                <mat-error *ngIf="form.get('topic').hasError('required')">
-                                    Topic is <strong>required</strong>
-                                </mat-error>
-                            </mat-form-field>
-                        </div>
-                        <div class="md-form-field">
-                            <mat-form-field appearance="outline">
-                                <mat-label>Authorization Header</mat-label>
-                                <input matInput formControlName="authorizationHeader" matTooltip="Optional: Bearer token or Basic auth for secured servers">
-                            </mat-form-field>
-                            <mat-form-field appearance="outline">
-                                <mat-label>Priority</mat-label>
-                                <mat-select formControlName="priority" matTooltip="The priority you want your ntfy notifications sent as">
-                                    <mat-option [value]="5">Max</mat-option>
-                                    <mat-option [value]="4">High</mat-option>
-                                    <mat-option [value]="3">Default</mat-option>
-                                    <mat-option [value]="2">Low</mat-option>
-                                    <mat-option [value]="1">Min</mat-option>
-                                </mat-select>
-                            </mat-form-field>
-                        </div>
-                    </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Topic</mat-label>
+        <input matInput formControlName="topic" autocomplete="off"
+               matTooltip="Subscribers receive messages published to this topic.">
+        @if (form?.get('topic')?.hasError('required')) {
+            <mat-error>Topic is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                    <div class="row top-space">
-                        <div class="form-group">
-                            <div>
-                                <button mat-raised-button type="button" class="btn-spacing" color="accent"
-                                    (click)="test(form)" [disabled]="form.invalid">Test <div id="spinner"></div>
-                                </button>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <div>
-                                <button mat-raised-button type="submit" class="btn-spacing" color="primary"
-                                    [disabled]="form.invalid">Submit</button>
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Authorization header</mat-label>
+        <input matInput formControlName="authorizationHeader" autocomplete="off"
+               matTooltip="Optional. Bearer token or Basic auth value for protected servers.">
+    </mat-form-field>
 
-            <div class="col-md-4">
-                <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-            </div>
-
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline">
+        <mat-label>Priority</mat-label>
+        <mat-select formControlName="priority"
+                    matTooltip="Higher priorities trigger more aggressive notifications on the client.">
+            <mat-option [value]="1">Min</mat-option>
+            <mat-option [value]="2">Low</mat-option>
+            <mat-option [value]="3">Default</mat-option>
+            <mat-option [value]="4">High</mat-option>
+            <mat-option [value]="5">Max</mat-option>
+        </mat-select>
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/ntfy.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/ntfy.component.ts
@@ -1,94 +1,64 @@
-import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INtfyNotificationSettings, INotificationTemplates, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { INtfyNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./ntfy.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class NtfyComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+export class NtfyComponent extends NotificationBaseComponent<INtfyNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Ntfy";
 
-    public ngOnInit() {
-        this.settingsService.getNtfyNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                baseUrl: [x.baseUrl, [Validators.required]],
-                topic: [x.topic, [Validators.required]],
-                authorizationHeader: [x.authorizationHeader],
-                priority: [x.priority],
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <INtfyNotificationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveNtfyNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Ntfy settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Ntfy settings");
-            }
-        });
-
+    protected loadSettings(): Observable<INtfyNotificationSettings> {
+        return this.settingsService.getNtfyNotificationSettings();
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected saveSettings(settings: INtfyNotificationSettings): Observable<boolean> {
+        return this.settingsService.saveNtfyNotificationSettings(settings);
+    }
 
-        this.testerService.ntfyTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully sent a Ntfy message");
-            } else {
-                this.notificationService.error("There was an error when sending the Ntfy message. Please check your settings");
-            }
-        });
+    protected testSettings(settings: INtfyNotificationSettings): Observable<boolean> {
+        return this.testerService.ntfyTest(settings);
+    }
+
+    protected buildForm(x: INtfyNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            baseUrl: [x.baseUrl, [Validators.required]],
+            topic: [x.topic, [Validators.required]],
+            authorizationHeader: [x.authorizationHeader],
+            priority: [x.priority],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushbullet.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushbullet.component.html
@@ -9,18 +9,22 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Access token</mat-label>
-        <input matInput formControlName="accessToken" autocomplete="off">
-        @if (form?.get('accessToken')?.hasError('required')) {
-            <mat-error>Access token is <strong>required</strong></mat-error>
-        }
-        <mat-hint>Found under Account in your Pushbullet settings.</mat-hint>
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Access token</mat-label>
+                <input matInput formControlName="accessToken" autocomplete="off">
+                @if (form.get('accessToken')?.hasError('required')) {
+                    <mat-error>Access token is <strong>required</strong></mat-error>
+                }
+                <mat-hint>Found under Account in your Pushbullet settings.</mat-hint>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Channel tag</mat-label>
-        <input matInput formControlName="channelTag" autocomplete="off"
-               matTooltip="Optional. Broadcast to everyone subscribed to this channel.">
-    </mat-form-field>
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Channel tag</mat-label>
+                <input matInput formControlName="channelTag" autocomplete="off"
+                       matTooltip="Optional. Broadcast to everyone subscribed to this channel.">
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushbullet.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushbullet.component.html
@@ -1,48 +1,26 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Pushbullet Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+<ombi-notification-shell
+    providerName="Pushbullet"
+    icon="phone_iphone"
+    description="Send notifications to all of your devices via Pushbullet."
+    docsUrl="https://www.pushbullet.com/#settings/account"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Access token</mat-label>
+        <input matInput formControlName="accessToken" autocomplete="off">
+        @if (form?.get('accessToken')?.hasError('required')) {
+            <mat-error>Access token is <strong>required</strong></mat-error>
+        }
+        <mat-hint>Found under Account in your Pushbullet settings.</mat-hint>
+    </mat-form-field>
 
-                <small>You can find this here: <a href="https://www.pushbullet.com/#settings/account" target="_blank">https://www.pushbullet.com/#settings/account </a></small>
-
-                <mat-form-field>
-                    <mat-label>Access Token</mat-label>
-                    <input matInput type="text" id="accessToken" name="accessToken" formControlName="accessToken" [ngClass]="{'form-error': form.get('accessToken').hasError('required')}">
-                </mat-form-field>
-
-                <mat-form-field>
-                    <mat-label>Channel Tag</mat-label>
-                    <input matInput type="text" id="channelTag" name="channelTag" formControlName="channelTag" pTooltip="Optional, this is if you want to send a message to everyone subscribed to a channel">
-                </mat-form-field>
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-
-        <div class="col-md-6">
-            <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Channel tag</mat-label>
+        <input matInput formControlName="channelTag" autocomplete="off"
+               matTooltip="Optional. Broadcast to everyone subscribed to this channel.">
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushbullet.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushbullet.component.ts
@@ -1,93 +1,60 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INotificationTemplates, IPushbulletNotificationSettings, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { IPushbulletNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./pushbullet.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class PushbulletComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+export class PushbulletComponent extends NotificationBaseComponent<IPushbulletNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Pushbullet";
 
-    public ngOnInit() {
-        this.settingsService.getPushbulletNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                channelTag: [x.channelTag],
-                accessToken: [x.accessToken, [Validators.required]],
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IPushbulletNotificationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.savePushbulletNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Pushbullet settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Pushbullet settings");
-            }
-        });
-
+    protected loadSettings(): Observable<IPushbulletNotificationSettings> {
+        return this.settingsService.getPushbulletNotificationSettings();
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected saveSettings(settings: IPushbulletNotificationSettings): Observable<boolean> {
+        return this.settingsService.savePushbulletNotificationSettings(settings);
+    }
 
-        this.testerService.pushbulletTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully sent a Pushbullet message");
-            } else {
-                this.notificationService.error("There was an error when sending the Pushbullet message. Please check your settings");
-            }
-        });
+    protected testSettings(settings: IPushbulletNotificationSettings): Observable<boolean> {
+        return this.testerService.pushbulletTest(settings);
+    }
 
+    protected buildForm(x: IPushbulletNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            channelTag: [x.channelTag],
+            accessToken: [x.accessToken, [Validators.required]],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.html
@@ -28,10 +28,10 @@
         <mat-label>Priority</mat-label>
         <mat-select formControlName="priority"
                     matTooltip="Higher priority surfaces messages more aggressively on the device.">
-            <mat-option value="-2">Lowest</mat-option>
-            <mat-option value="-1">Low</mat-option>
-            <mat-option value="0">Normal</mat-option>
-            <mat-option value="1">High</mat-option>
+            <mat-option [value]="-2">Lowest</mat-option>
+            <mat-option [value]="-1">Low</mat-option>
+            <mat-option [value]="0">Normal</mat-option>
+            <mat-option [value]="1">High</mat-option>
         </mat-select>
     </mat-form-field>
 

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.html
@@ -1,95 +1,47 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Pushover Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+<ombi-notification-shell
+    providerName="Pushover"
+    icon="phonelink_ring"
+    description="Send native push notifications to your phone, tablet or desktop."
+    docsUrl="https://pushover.net/api"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Application token</mat-label>
+        <input matInput formControlName="accessToken" autocomplete="off"
+               matTooltip="Your application's API token from Pushover.">
+        @if (form?.get('accessToken')?.hasError('required')) {
+            <mat-error>Application token is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
+    <mat-form-field appearance="outline">
+        <mat-label>User or group key</mat-label>
+        <input matInput formControlName="userToken" autocomplete="off"
+               matTooltip="Your user key, or a delivery group key.">
+    </mat-form-field>
 
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Access Token</mat-label>
-                        <input matInput type="text" id="accessToken" name="accessToken" [ngClass]="{'form-error': form.get('accessToken').hasError('required')}" formControlName="accessToken" pTooltip="Enter your API Key from Pushover.">
-                    </mat-form-field>
-                </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Priority</mat-label>
+        <mat-select formControlName="priority"
+                    matTooltip="Higher priority surfaces messages more aggressively on the device.">
+            <mat-option value="-2">Lowest</mat-option>
+            <mat-option value="-1">Low</mat-option>
+            <mat-option value="0">Normal</mat-option>
+            <mat-option value="1">High</mat-option>
+        </mat-select>
+    </mat-form-field>
 
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>User Token</mat-label>
-                        <input matInput type="text" id="userToken" name="userToken" formControlName="userToken" pTooltip="Your user or group key from Pushover.">
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                      <mat-label>Priority</mat-label>
-                      <mat-select id="priority" name="priority" formControlName="priority" pTooltip="The priority you want your pushover notifications sent as.">
-                        <mat-option value="0">Normal</mat-option>
-                        <mat-option value="1">High</mat-option>
-                        <mat-option value="-1">Low</mat-option>
-                        <mat-option value="-2">Lowest</mat-option>
-                      </mat-select>
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Sound</mat-label>
-                        <mat-select id="sound" name="sound" formControlName="sound" pTooltip="The sound you want your pushover notifications sent with.">
-                            <mat-option value="pushover">Pushover</mat-option>
-                            <mat-option value="bike">Bike</mat-option>
-                            <mat-option value="bugle">Bugle</mat-option>
-                            <mat-option value="cashregister">Cash Register</mat-option>
-                            <mat-option value="classical">Classical</mat-option>
-                            <mat-option value="cosmic">Cosmic</mat-option>
-                            <mat-option value="falling">Falling</mat-option>
-                            <mat-option value="gamelan">Gamelan</mat-option>
-                            <mat-option value="incoming">Incoming</mat-option>
-                            <mat-option value="intermission">Intermission</mat-option>
-                            <mat-option value="magic">Magic</mat-option>
-                            <mat-option value="mechanical">Mechanical</mat-option>
-                            <mat-option value="pianobar">Piano Bar</mat-option>
-                            <mat-option value="siren">Siren</mat-option>
-                            <mat-option value="spacealarm">Space Alarm</mat-option>
-                            <mat-option value="tugboat">Tug Boat</mat-option>
-                            <mat-option value="alien">Alien Alarm (long)</mat-option>
-                            <mat-option value="climb">Climb (long)</mat-option>
-                            <mat-option value="persistent">Persistent (long)</mat-option>
-                            <mat-option value="echo">Pushover Echo (long)</mat-option>
-                            <mat-option value="updown">Up Down (long)</mat-option>
-                            <mat-option value="none">None</mat-option>
-                        </mat-select>
-                      </mat-form-field>
-                  </div>
-
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-
-        <div class="col-md-6">
-            <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline">
+        <mat-label>Sound</mat-label>
+        <mat-select formControlName="sound"
+                    matTooltip="The notification sound played on the device.">
+            @for (sound of sounds; track sound.value) {
+                <mat-option [value]="sound.value">{{ sound.label }}</mat-option>
+            }
+        </mat-select>
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.html
@@ -9,39 +9,43 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline">
-        <mat-label>Application token</mat-label>
-        <input matInput formControlName="accessToken" autocomplete="off"
-               matTooltip="Your application's API token from Pushover.">
-        @if (form?.get('accessToken')?.hasError('required')) {
-            <mat-error>Application token is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline">
+                <mat-label>Application token</mat-label>
+                <input matInput formControlName="accessToken" autocomplete="off"
+                       matTooltip="Your application's API token from Pushover.">
+                @if (form.get('accessToken')?.hasError('required')) {
+                    <mat-error>Application token is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>User or group key</mat-label>
-        <input matInput formControlName="userToken" autocomplete="off"
-               matTooltip="Your user key, or a delivery group key.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>User or group key</mat-label>
+                <input matInput formControlName="userToken" autocomplete="off"
+                       matTooltip="Your user key, or a delivery group key.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Priority</mat-label>
-        <mat-select formControlName="priority"
-                    matTooltip="Higher priority surfaces messages more aggressively on the device.">
-            <mat-option [value]="-2">Lowest</mat-option>
-            <mat-option [value]="-1">Low</mat-option>
-            <mat-option [value]="0">Normal</mat-option>
-            <mat-option [value]="1">High</mat-option>
-        </mat-select>
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Priority</mat-label>
+                <mat-select formControlName="priority"
+                            matTooltip="Higher priority surfaces messages more aggressively on the device.">
+                    <mat-option [value]="-2">Lowest</mat-option>
+                    <mat-option [value]="-1">Low</mat-option>
+                    <mat-option [value]="0">Normal</mat-option>
+                    <mat-option [value]="1">High</mat-option>
+                </mat-select>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Sound</mat-label>
-        <mat-select formControlName="sound"
-                    matTooltip="The notification sound played on the device.">
-            @for (sound of sounds; track sound.value) {
-                <mat-option [value]="sound.value">{{ sound.label }}</mat-option>
-            }
-        </mat-select>
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Sound</mat-label>
+                <mat-select formControlName="sound"
+                            matTooltip="The notification sound played on the device.">
+                    @for (sound of sounds; track sound.value) {
+                        <mat-option [value]="sound.value">{{ sound.label }}</mat-option>
+                    }
+                </mat-select>
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/pushover.component.ts
@@ -1,94 +1,91 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INotificationTemplates, IPushoverNotificationSettings, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { IPushoverNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
+
+interface PushoverSound { value: string; label: string; }
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./pushover.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class PushoverComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+export class PushoverComponent extends NotificationBaseComponent<IPushoverNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Pushover";
 
-    public ngOnInit() {
-        this.settingsService.getPushoverNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
+    public readonly sounds: ReadonlyArray<PushoverSound> = [
+        { value: "pushover", label: "Pushover" },
+        { value: "bike", label: "Bike" },
+        { value: "bugle", label: "Bugle" },
+        { value: "cashregister", label: "Cash Register" },
+        { value: "classical", label: "Classical" },
+        { value: "cosmic", label: "Cosmic" },
+        { value: "falling", label: "Falling" },
+        { value: "gamelan", label: "Gamelan" },
+        { value: "incoming", label: "Incoming" },
+        { value: "intermission", label: "Intermission" },
+        { value: "magic", label: "Magic" },
+        { value: "mechanical", label: "Mechanical" },
+        { value: "pianobar", label: "Piano Bar" },
+        { value: "siren", label: "Siren" },
+        { value: "spacealarm", label: "Space Alarm" },
+        { value: "tugboat", label: "Tug Boat" },
+        { value: "alien", label: "Alien Alarm (long)" },
+        { value: "climb", label: "Climb (long)" },
+        { value: "persistent", label: "Persistent (long)" },
+        { value: "echo", label: "Pushover Echo (long)" },
+        { value: "updown", label: "Up Down (long)" },
+        { value: "none", label: "None" },
+    ];
 
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                userToken: [x.userToken],
-                accessToken: [x.accessToken, [Validators.required]],
-                priority: [x.priority],
-                sound: [x.sound],
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IPushoverNotificationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.savePushoverNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success( "Successfully saved the Pushover settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Pushover settings");
-            }
-        });
-
+    protected loadSettings(): Observable<IPushoverNotificationSettings> {
+        return this.settingsService.getPushoverNotificationSettings();
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected saveSettings(settings: IPushoverNotificationSettings): Observable<boolean> {
+        return this.settingsService.savePushoverNotificationSettings(settings);
+    }
 
-        this.testerService.pushoverTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success( "Successfully sent a Pushover message");
-            } else {
-                this.notificationService.error("There was an error when sending the Pushover message. Please check your settings");
-            }
-        });
+    protected testSettings(settings: IPushoverNotificationSettings): Observable<boolean> {
+        return this.testerService.pushoverTest(settings);
+    }
+
+    protected buildForm(x: IPushoverNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            userToken: [x.userToken],
+            accessToken: [x.accessToken, [Validators.required]],
+            priority: [x.priority],
+            sound: [x.sound],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-base.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-base.component.ts
@@ -85,7 +85,7 @@ export abstract class NotificationBaseComponent<T extends INotificationSettings>
                 if (ok) {
                     this.notificationService.success(this.savedMessage);
                 } else {
-                    this.notificationService.success(this.saveErrorMessage);
+                    this.notificationService.error(this.saveErrorMessage);
                 }
             });
     }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-base.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-base.component.ts
@@ -1,0 +1,124 @@
+import { Directive, OnDestroy, OnInit } from "@angular/core";
+import { UntypedFormBuilder, UntypedFormGroup } from "@angular/forms";
+import { Observable, Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
+
+import { INotificationSettings, INotificationTemplates, NotificationType } from "../../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../../services";
+
+type NotificationPayload<T> = T & { notificationTemplates?: INotificationTemplates[] };
+
+@Directive()
+export abstract class NotificationBaseComponent<T extends INotificationSettings>
+    implements OnInit, OnDestroy {
+
+    public readonly NotificationType = NotificationType;
+    public templates: INotificationTemplates[] = [];
+    public form!: UntypedFormGroup;
+    public loading = true;
+
+    private readonly destroy$ = new Subject<void>();
+
+    protected constructor(
+        protected readonly settingsService: SettingsService,
+        protected readonly notificationService: NotificationService,
+        protected readonly fb: UntypedFormBuilder,
+        protected readonly testerService: TesterService,
+    ) { }
+
+    protected abstract readonly providerName: string;
+    protected abstract loadSettings(): Observable<T>;
+    protected abstract saveSettings(settings: T): Observable<boolean>;
+    protected abstract testSettings(settings: T): Observable<boolean>;
+    protected abstract buildForm(settings: T): { [key: string]: unknown };
+
+    protected validate(_settings: T): string | null { return null; }
+    protected onFormReady(_form: UntypedFormGroup, _settings: T): void { /* no-op */ }
+    protected attachTemplates: boolean = true;
+
+    protected get savedMessage(): string {
+        return `Successfully saved the ${this.providerName} settings`;
+    }
+    protected get saveErrorMessage(): string {
+        return `There was an error when saving the ${this.providerName} settings`;
+    }
+    protected get testSuccessMessage(): string {
+        return `Successfully sent a ${this.providerName} message`;
+    }
+    protected get testErrorMessage(): string {
+        return `There was an error when sending the ${this.providerName} message. Please check your settings`;
+    }
+
+    public ngOnInit(): void {
+        this.loadSettings()
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(settings => {
+                const payload = settings as NotificationPayload<T>;
+                this.templates = payload?.notificationTemplates ?? [];
+                this.form = this.fb.group(this.buildForm(settings));
+                this.onFormReady(this.form, settings);
+                this.loading = false;
+            });
+    }
+
+    public ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    public onSubmit(form: UntypedFormGroup = this.form): void {
+        if (!form || form.invalid) {
+            this.notificationService.error("Please check your entered values");
+            return;
+        }
+
+        const settings = this.materialise(form);
+        const validationError = this.validate(settings);
+        if (validationError) {
+            this.notificationService.error(validationError);
+            return;
+        }
+
+        this.saveSettings(settings)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(ok => {
+                if (ok) {
+                    this.notificationService.success(this.savedMessage);
+                } else {
+                    this.notificationService.success(this.saveErrorMessage);
+                }
+            });
+    }
+
+    public test(form: UntypedFormGroup = this.form): void {
+        if (!form || form.invalid) {
+            this.notificationService.error("Please check your entered values");
+            return;
+        }
+
+        const settings = form.value as T;
+        const validationError = this.validate(settings);
+        if (validationError) {
+            this.notificationService.error(validationError);
+            return;
+        }
+
+        this.testSettings(settings)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(ok => {
+                if (ok) {
+                    this.notificationService.success(this.testSuccessMessage);
+                } else {
+                    this.notificationService.error(this.testErrorMessage);
+                }
+            });
+    }
+
+    private materialise(form: UntypedFormGroup): T {
+        const settings = form.value as NotificationPayload<T>;
+        if (this.attachTemplates) {
+            settings.notificationTemplates = this.templates;
+        }
+        return settings as T;
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.html
@@ -1,0 +1,99 @@
+<section class="notification-shell">
+    <div class="notification-shell__layout" [class.notification-shell__layout--single]="!showTemplates">
+        <mat-card appearance="outlined" class="notification-shell__card notification-shell__card--main">
+            <mat-card-header class="notification-shell__header">
+                <div mat-card-avatar class="notification-shell__avatar" aria-hidden="true">
+                    <mat-icon>{{ icon }}</mat-icon>
+                </div>
+                <mat-card-title class="notification-shell__title">
+                    {{ providerName }} notifications
+                    @if (form && showEnabledToggle) {
+                        <span class="notification-shell__status"
+                              [class.notification-shell__status--on]="isEnabled"
+                              [attr.aria-label]="isEnabled ? 'Enabled' : 'Disabled'">
+                            {{ isEnabled ? 'Enabled' : 'Disabled' }}
+                        </span>
+                    }
+                </mat-card-title>
+                @if (description) {
+                    <mat-card-subtitle>{{ description }}</mat-card-subtitle>
+                }
+            </mat-card-header>
+
+            @if (loading) {
+                <mat-progress-bar mode="indeterminate" class="notification-shell__progress" aria-label="Loading settings"></mat-progress-bar>
+            }
+
+            <mat-card-content class="notification-shell__content">
+                @if (form) {
+                    <form novalidate [formGroup]="form" (ngSubmit)="onSubmit()" class="notification-shell__form">
+                        @if (showEnabledToggle) {
+                            <div class="notification-shell__enable-row">
+                                <mat-slide-toggle color="primary"
+                                                  [formControlName]="enabledControlName"
+                                                  id="enable">
+                                    Enable {{ providerName }} notifications
+                                </mat-slide-toggle>
+                                @if (docsUrl) {
+                                    <a class="notification-shell__docs" mat-stroked-button color="primary"
+                                       [href]="docsUrl" target="_blank" rel="noopener noreferrer">
+                                        <mat-icon>menu_book</mat-icon>
+                                        {{ docsLabel }}
+                                    </a>
+                                }
+                            </div>
+
+                            <mat-divider class="notification-shell__divider"></mat-divider>
+                        }
+
+                        <div class="notification-shell__fields">
+                            <ng-content></ng-content>
+                        </div>
+
+                        <ng-content select="[notificationFooter]"></ng-content>
+
+                        <div class="notification-shell__actions">
+                            @if (showTest) {
+                                <button mat-stroked-button color="accent" type="button"
+                                        [disabled]="form.invalid"
+                                        (click)="onTest()">
+                                    <mat-icon>send</mat-icon>
+                                    {{ testLabel }}
+                                </button>
+                            }
+                            <button mat-flat-button color="primary" type="submit"
+                                    [disabled]="form.invalid || form.pristine">
+                                <mat-icon>save</mat-icon>
+                                {{ submitLabel }}
+                            </button>
+                        </div>
+                    </form>
+                } @else if (!loading) {
+                    <p class="notification-shell__empty">Settings are unavailable.</p>
+                }
+            </mat-card-content>
+        </mat-card>
+
+        @if (showTemplates) {
+            <mat-card appearance="outlined" class="notification-shell__card notification-shell__card--templates">
+                <mat-card-header>
+                    <div mat-card-avatar class="notification-shell__avatar" aria-hidden="true">
+                        <mat-icon>description</mat-icon>
+                    </div>
+                    <mat-card-title>Message templates</mat-card-title>
+                    <mat-card-subtitle>Customise how each notification reads.</mat-card-subtitle>
+                </mat-card-header>
+                <mat-card-content>
+                    @if (templates && templates.length) {
+                        <notification-templates
+                            [templates]="templates"
+                            [showSubject]="showSubject">
+                        </notification-templates>
+                    } @else {
+                        <p class="notification-shell__empty">No templates available.</p>
+                    }
+                </mat-card-content>
+            </mat-card>
+        }
+    </div>
+</section>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.html
@@ -62,7 +62,7 @@
                                 </button>
                             }
                             <button mat-flat-button color="primary" type="submit"
-                                    [disabled]="form.invalid || form.pristine">
+                                    [disabled]="form.invalid || (requireDirtyToSave && form.pristine)">
                                 <mat-icon>save</mat-icon>
                                 {{ submitLabel }}
                             </button>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.scss
@@ -1,0 +1,157 @@
+:host {
+    display: block;
+    width: 100%;
+}
+
+.notification-shell {
+    display: block;
+    margin: 24px auto;
+    width: min(1280px, 95%);
+
+    &__layout {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+        align-items: start;
+
+        &--single {
+            grid-template-columns: minmax(0, 1fr);
+        }
+
+        @media (max-width: 1024px) {
+            grid-template-columns: minmax(0, 1fr);
+        }
+    }
+
+    &__card {
+        border-radius: 16px;
+        overflow: hidden;
+        transition: box-shadow 200ms ease, transform 200ms ease;
+
+        &:hover {
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+        }
+    }
+
+    &__header {
+        padding-top: 8px;
+    }
+
+    &__avatar {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: rgba(63, 81, 181, 0.12);
+        color: var(--mdc-theme-primary, #3f51b5);
+
+        mat-icon {
+            font-size: 22px;
+            width: 22px;
+            height: 22px;
+        }
+    }
+
+    &__title {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-weight: 500;
+    }
+
+    &__status {
+        font-size: 0.7rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding: 4px 10px;
+        border-radius: 999px;
+        background: rgba(158, 158, 158, 0.18);
+        color: rgba(255, 255, 255, 0.78);
+
+        &--on {
+            background: rgba(46, 204, 113, 0.18);
+            color: #2ecc71;
+        }
+    }
+
+    &__progress {
+        margin-bottom: 8px;
+    }
+
+    &__content {
+        padding-top: 8px;
+    }
+
+    &__form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    &__enable-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    &__docs {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+
+        mat-icon {
+            font-size: 18px;
+            width: 18px;
+            height: 18px;
+        }
+    }
+
+    &__divider {
+        margin: 4px 0 8px 0;
+    }
+
+    &__fields {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px 20px;
+
+        @media (max-width: 720px) {
+            grid-template-columns: minmax(0, 1fr);
+        }
+
+        ::ng-deep mat-form-field {
+            width: 100%;
+        }
+
+        ::ng-deep .notification-field--full {
+            grid-column: 1 / -1;
+        }
+    }
+
+    &__actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+        flex-wrap: wrap;
+        padding-top: 8px;
+
+        button {
+            min-width: 140px;
+        }
+
+        mat-icon {
+            margin-right: 6px;
+        }
+    }
+
+    &__empty {
+        margin: 16px 0;
+        opacity: 0.7;
+        font-style: italic;
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.scss
@@ -26,7 +26,7 @@
     &__card {
         border-radius: 16px;
         overflow: hidden;
-        transition: box-shadow 200ms ease, transform 200ms ease;
+        transition: box-shadow 200ms ease;
 
         &:hover {
             box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
@@ -69,11 +69,13 @@
         padding: 4px 10px;
         border-radius: 999px;
         background: rgba(158, 158, 158, 0.18);
-        color: rgba(255, 255, 255, 0.78);
+        color: var(--mdc-theme-on-surface, currentColor);
+        opacity: 0.7;
 
         &--on {
             background: rgba(46, 204, 113, 0.18);
             color: #2ecc71;
+            opacity: 1;
         }
     }
 

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { ReactiveFormsModule, UntypedFormGroup } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
+import { MatDividerModule } from "@angular/material/divider";
+import { MatIconModule } from "@angular/material/icon";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatSlideToggleModule } from "@angular/material/slide-toggle";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { TranslateModule } from "@ngx-translate/core";
+
+import { INotificationTemplates } from "../../../interfaces";
+import { NotificationTemplate } from "../notificationtemplate.component";
+
+@Component({
+    selector: "ombi-notification-shell",
+    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatDividerModule,
+        MatIconModule,
+        MatProgressBarModule,
+        MatProgressSpinnerModule,
+        MatSlideToggleModule,
+        MatTooltipModule,
+        TranslateModule,
+        NotificationTemplate,
+    ],
+    templateUrl: "./notification-shell.component.html",
+    styleUrls: ["./notification-shell.component.scss"],
+})
+export class NotificationShellComponent {
+    @Input({ required: true }) providerName!: string;
+    @Input() icon: string = "notifications";
+    @Input() description?: string;
+    @Input() docsUrl?: string;
+    @Input() docsLabel: string = "Setup guide";
+
+    @Input() form: UntypedFormGroup | null = null;
+    @Input() loading: boolean = false;
+
+    @Input() templates: INotificationTemplates[] | null = null;
+    @Input() showTemplates: boolean = true;
+    @Input() showSubject: boolean = false;
+
+    @Input() showEnabledToggle: boolean = true;
+    @Input() enabledControlName: string = "enabled";
+
+    @Input() submitLabel: string = "Save changes";
+    @Input() testLabel: string = "Send test";
+    @Input() showTest: boolean = true;
+
+    @Output() readonly submitted = new EventEmitter<UntypedFormGroup>();
+    @Output() readonly tested = new EventEmitter<UntypedFormGroup>();
+
+    public onSubmit(): void {
+        if (this.form) {
+            this.submitted.emit(this.form);
+        }
+    }
+
+    public onTest(): void {
+        if (this.form) {
+            this.tested.emit(this.form);
+        }
+    }
+
+    public get isEnabled(): boolean {
+        return !!this.form?.get(this.enabledControlName)?.value;
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/shared/notification-shell.component.ts
@@ -55,6 +55,7 @@ export class NotificationShellComponent {
     @Input() submitLabel: string = "Save changes";
     @Input() testLabel: string = "Send test";
     @Input() showTest: boolean = true;
+    @Input() requireDirtyToSave: boolean = true;
 
     @Output() readonly submitted = new EventEmitter<UntypedFormGroup>();
     @Output() readonly tested = new EventEmitter<UntypedFormGroup>();

--- a/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.html
@@ -1,76 +1,46 @@
-﻿
+<ombi-notification-shell
+    providerName="Slack"
+    icon="tag"
+    description="Send rich notifications to a Slack channel via an incoming webhook."
+    docsUrl="https://api.slack.com/messaging/webhooks"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Slack Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Webhook URL</mat-label>
+        <input matInput formControlName="webhookUrl" autocomplete="off"
+               placeholder="https://hooks.slack.com/services/...">
+        @if (form?.get('webhookUrl')?.hasError('required')) {
+            <mat-error>Webhook URL is <strong>required</strong></mat-error>
+        }
+        <mat-hint>Create one at api.slack.com &rarr; Incoming Webhooks.</mat-hint>
+    </mat-form-field>
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Username override</mat-label>
+        <input matInput formControlName="username" autocomplete="off"
+               matTooltip="Optional. Defaults to the username configured for the webhook.">
+    </mat-form-field>
 
+    <mat-form-field appearance="outline">
+        <mat-label>Channel override</mat-label>
+        <input matInput formControlName="channel" autocomplete="off"
+               matTooltip="Optional. Routes messages to a different channel than the webhook default.">
+    </mat-form-field>
 
-                <div class="form-group">
+    <mat-form-field appearance="outline">
+        <mat-label>Emoji icon</mat-label>
+        <input matInput formControlName="iconEmoji" autocomplete="off"
+               placeholder=":robot_face:"
+               matTooltip="Optional. Cannot be combined with a URL icon.">
+    </mat-form-field>
 
-                    <small class="control-label"> Click <a target="_blank" href="https://my.slack.com/services/new/incoming-webhook/">Here</a> and follow the guide. You will then have a Webhook Url</small>
-                    <mat-form-field>
-                        <mat-label>Webhook Url</mat-label>
-                        <input matInput type="text" id="webhookUrl" name="webhookUrl" formControlName="webhookUrl"  [ngClass]="{'form-error': form.get('webhookUrl').hasError('required')}">
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Username Override</mat-label>
-                        <input matInput type="text" id="username" name="username" formControlName="username" pTooltip="Optional, this will override the username you used for the Webhook. Default is Ombi">
-                    </mat-form-field>
-                </div>
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Channel Override</mat-label>
-                        <input matInput type="text" id="channel" name="channel" formControlName="channel" pTooltip="Optional, this will override the channel you used for the Webhook">
-                    </mat-form-field>
-                </div>
-
-              <div class="form-group">
-                <mat-form-field>
-                    <mat-label>Emoji Icon Override</mat-label>
-                    <input matInput type="text" id="iconEmoji" name="iconEmoji" formControlName="iconEmoji" pTooltip="Optional, this will override the Icon you used for the Webhook">
-                </mat-form-field>
-              </div>
-              <div class="form-group">
-                <mat-form-field>
-                    <mat-label>Url Icon Override</mat-label>
-                    <input matInput type="text" id="iconUrl" name="iconUrl" formControlName="iconUrl" pTooltip="Optional, this will override the Icon you used for the Webhook">
-                </mat-form-field>
-              </div>
-
-                <small>You can find more details about the Slack API <a target="_blank" href="https://api.slack.com/custom-integrations/incoming-webhooks">Here</a></small>
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-
-        <div class="col-md-6">
-            <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline">
+        <mat-label>Icon URL</mat-label>
+        <input matInput formControlName="iconUrl" autocomplete="off"
+               matTooltip="Optional. Cannot be combined with an emoji icon.">
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.html
@@ -9,38 +9,42 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Webhook URL</mat-label>
-        <input matInput formControlName="webhookUrl" autocomplete="off"
-               placeholder="https://hooks.slack.com/services/...">
-        @if (form?.get('webhookUrl')?.hasError('required')) {
-            <mat-error>Webhook URL is <strong>required</strong></mat-error>
-        }
-        <mat-hint>Create one at api.slack.com &rarr; Incoming Webhooks.</mat-hint>
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Webhook URL</mat-label>
+                <input matInput formControlName="webhookUrl" autocomplete="off"
+                       placeholder="https://hooks.slack.com/services/...">
+                @if (form.get('webhookUrl')?.hasError('required')) {
+                    <mat-error>Webhook URL is <strong>required</strong></mat-error>
+                }
+                <mat-hint>Create one at api.slack.com &rarr; Incoming Webhooks.</mat-hint>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Username override</mat-label>
-        <input matInput formControlName="username" autocomplete="off"
-               matTooltip="Optional. Defaults to the username configured for the webhook.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Username override</mat-label>
+                <input matInput formControlName="username" autocomplete="off"
+                       matTooltip="Optional. Defaults to the username configured for the webhook.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Channel override</mat-label>
-        <input matInput formControlName="channel" autocomplete="off"
-               matTooltip="Optional. Routes messages to a different channel than the webhook default.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Channel override</mat-label>
+                <input matInput formControlName="channel" autocomplete="off"
+                       matTooltip="Optional. Routes messages to a different channel than the webhook default.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Emoji icon</mat-label>
-        <input matInput formControlName="iconEmoji" autocomplete="off"
-               placeholder=":robot_face:"
-               matTooltip="Optional. Cannot be combined with a URL icon.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Emoji icon</mat-label>
+                <input matInput formControlName="iconEmoji" autocomplete="off"
+                       placeholder=":robot_face:"
+                       matTooltip="Optional. Cannot be combined with a URL icon.">
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Icon URL</mat-label>
-        <input matInput formControlName="iconUrl" autocomplete="off"
-               matTooltip="Optional. Cannot be combined with an emoji icon.">
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Icon URL</mat-label>
+                <input matInput formControlName="iconUrl" autocomplete="off"
+                       matTooltip="Optional. Cannot be combined with an emoji icon.">
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.spec.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.spec.ts
@@ -41,7 +41,7 @@ describe('SlackComponent', () => {
     comp.form.controls['iconEmoji'].setValue(':robot:');
     comp.form.controls['iconUrl'].setValue('https://example.com/icon.png');
     comp.onSubmit(comp.form);
-    expect(mockNotify.error).toHaveBeenCalledWith('You cannot have a Emoji icon and a URL icon');
+    expect(mockNotify.error).toHaveBeenCalledWith('You cannot set both an emoji icon and a URL icon');
   });
 
   it('should error when both iconEmoji and iconUrl are set on test', () => {
@@ -50,7 +50,7 @@ describe('SlackComponent', () => {
     comp.form.controls['iconEmoji'].setValue(':robot:');
     comp.form.controls['iconUrl'].setValue('https://example.com/icon.png');
     comp.test(comp.form);
-    expect(mockNotify.error).toHaveBeenCalledWith('You cannot have a Emoji icon and a URL icon');
+    expect(mockNotify.error).toHaveBeenCalledWith('You cannot set both an emoji icon and a URL icon');
   });
 
   it('should test and notify success', () => {

--- a/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.ts
@@ -1,108 +1,74 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INotificationTemplates, ISlackNotificationSettings, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { ISlackNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./slack.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class SlackComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+export class SlackComponent extends NotificationBaseComponent<ISlackNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Slack";
 
-    public ngOnInit() {
-        this.settingsService.getSlackNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                username: [x.username],
-                webhookUrl: [x.webhookUrl, [Validators.required]],
-                iconEmoji: [x.iconEmoji],
-                iconUrl: [x.iconUrl],
-                channel: [x.channel],
-
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <ISlackNotificationSettings> form.value;
-        if (settings.iconEmoji && settings.iconUrl) {
-
-            this.notificationService.error("You cannot have a Emoji icon and a URL icon");
-            return;
-        }
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveSlackNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success( "Successfully saved the Slack settings");
-            } else {
-                this.notificationService.success( "There was an error when saving the Slack settings");
-            }
-        });
-
+    protected override get testSuccessMessage(): string {
+        return "Successfully sent a Slack message, please check the slack channel";
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected loadSettings(): Observable<ISlackNotificationSettings> {
+        return this.settingsService.getSlackNotificationSettings();
+    }
 
-        const settings = <ISlackNotificationSettings> form.value;
+    protected saveSettings(settings: ISlackNotificationSettings): Observable<boolean> {
+        return this.settingsService.saveSlackNotificationSettings(settings);
+    }
+
+    protected testSettings(settings: ISlackNotificationSettings): Observable<boolean> {
+        return this.testerService.slackTest(settings);
+    }
+
+    protected buildForm(x: ISlackNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            username: [x.username],
+            webhookUrl: [x.webhookUrl, [Validators.required]],
+            iconEmoji: [x.iconEmoji],
+            iconUrl: [x.iconUrl],
+            channel: [x.channel],
+        };
+    }
+
+    protected override validate(settings: ISlackNotificationSettings): string | null {
         if (settings.iconEmoji && settings.iconUrl) {
-
-            this.notificationService.error("You cannot have a Emoji icon and a URL icon");
-            return;
+            return "You cannot have a Emoji icon and a URL icon";
         }
-        this.testerService.slackTest(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success( "Successfully sent a Slack message, please check the slack channel");
-            } else {
-                this.notificationService.error("There was an error when sending the Slack message. Please check your settings");
-            }
-        });
-
+        return null;
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/slack.component.ts
@@ -67,7 +67,7 @@ export class SlackComponent extends NotificationBaseComponent<ISlackNotification
 
     protected override validate(settings: ISlackNotificationSettings): string | null {
         if (settings.iconEmoji && settings.iconUrl) {
-            return "You cannot have a Emoji icon and a URL icon";
+            return "You cannot set both an emoji icon and a URL icon";
         }
         return null;
     }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/telegram.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/telegram.component.html
@@ -9,32 +9,36 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline">
-        <mat-label>Bot API token</mat-label>
-        <input matInput formControlName="botApi" autocomplete="off">
-        @if (form?.get('botApi')?.hasError('required')) {
-            <mat-error>Bot API token is <strong>required</strong></mat-error>
-        }
-        <mat-hint>Created via <a href="https://core.telegram.org/bots#6-botfather" target="_blank" rel="noopener noreferrer">@BotFather</a>.</mat-hint>
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline">
+                <mat-label>Bot API token</mat-label>
+                <input matInput formControlName="botApi" autocomplete="off">
+                @if (form.get('botApi')?.hasError('required')) {
+                    <mat-error>Bot API token is <strong>required</strong></mat-error>
+                }
+                <mat-hint>Created via <a href="https://core.telegram.org/bots#6-botfather" target="_blank" rel="noopener noreferrer">@BotFather</a>.</mat-hint>
+            </mat-form-field>
 
-    <mat-form-field appearance="outline">
-        <mat-label>Chat ID</mat-label>
-        <input matInput formControlName="chatId" autocomplete="off">
-        @if (form?.get('chatId')?.hasError('required')) {
-            <mat-error>Chat ID is <strong>required</strong></mat-error>
-        }
-        <mat-hint>User, group or channel ID. Look it up via <a href="https://telegram.me/get_id_bot" target="_blank" rel="noopener noreferrer">@get_id_bot</a>.</mat-hint>
-    </mat-form-field>
+            <mat-form-field appearance="outline">
+                <mat-label>Chat ID</mat-label>
+                <input matInput formControlName="chatId" autocomplete="off">
+                @if (form.get('chatId')?.hasError('required')) {
+                    <mat-error>Chat ID is <strong>required</strong></mat-error>
+                }
+                <mat-hint>User, group or channel ID. Look it up via <a href="https://telegram.me/get_id_bot" target="_blank" rel="noopener noreferrer">@get_id_bot</a>.</mat-hint>
+            </mat-form-field>
 
-    <div class="notification-field--full"
-         style="display:flex; flex-direction:column; gap:8px;">
-        <label id="parse-mode-label"
-               style="font-size:0.875rem; opacity:0.8;">Message formatting</label>
-        <mat-radio-group formControlName="parseMode" aria-labelledby="parse-mode-label"
-                         style="display:flex; gap:24px;">
-            <mat-radio-button value="markdown" color="primary">Markdown</mat-radio-button>
-            <mat-radio-button value="html" color="primary">HTML</mat-radio-button>
-        </mat-radio-group>
-    </div>
+            <div class="notification-field--full"
+                 style="display:flex; flex-direction:column; gap:8px;">
+                <label id="parse-mode-label"
+                       style="font-size:0.875rem; opacity:0.8;">Message formatting</label>
+                <mat-radio-group formControlName="parseMode" aria-labelledby="parse-mode-label"
+                                 style="display:flex; gap:24px;">
+                    <mat-radio-button value="markdown" color="primary">Markdown</mat-radio-button>
+                    <mat-radio-button value="html" color="primary">HTML</mat-radio-button>
+                </mat-radio-group>
+            </div>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/telegram.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/telegram.component.html
@@ -1,64 +1,40 @@
-﻿
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Telegram Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+<ombi-notification-shell
+    providerName="Telegram"
+    icon="send"
+    description="Notify a user, group or channel via a Telegram bot."
+    docsUrl="https://core.telegram.org/bots#6-botfather"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
+    <mat-form-field appearance="outline">
+        <mat-label>Bot API token</mat-label>
+        <input matInput formControlName="botApi" autocomplete="off">
+        @if (form?.get('botApi')?.hasError('required')) {
+            <mat-error>Bot API token is <strong>required</strong></mat-error>
+        }
+        <mat-hint>Created via <a href="https://core.telegram.org/bots#6-botfather" target="_blank" rel="noopener noreferrer">@BotFather</a>.</mat-hint>
+    </mat-form-field>
 
+    <mat-form-field appearance="outline">
+        <mat-label>Chat ID</mat-label>
+        <input matInput formControlName="chatId" autocomplete="off">
+        @if (form?.get('chatId')?.hasError('required')) {
+            <mat-error>Chat ID is <strong>required</strong></mat-error>
+        }
+        <mat-hint>User, group or channel ID. Look it up via <a href="https://telegram.me/get_id_bot" target="_blank" rel="noopener noreferrer">@get_id_bot</a>.</mat-hint>
+    </mat-form-field>
 
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Bot API</mat-label>
-                        <input matInput type="text" id="botApi" name="botApi" formControlName="botApi" [ngClass]="{'form-error': form.get('botApi').hasError('required')}">
-                    </mat-form-field>
-                    <small>You need a bot for Telegram notifications, You can find out how to create a bot
-                        <a href="https://core.telegram.org/bots#6-botfather">here</a>.</small>
-
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Chat Id</mat-label>
-                        <input matInput type="text" id="chatId" name="chatId" formControlName="chatId" [ngClass]="{'form-error': form.get('chatId').hasError('required')}">
-                    </mat-form-field>
-                    <small>This is the Chat ID from Telegram. You can get the Chat Id from
-                        <a href="https://telegram.me/get_id_bot">here</a>. This also supports Group Chat Id's.</small>
-                </div>
-
-                <div class="form-group">
-                    <p-radioButton name="parseMode" value="markdown" formControlName="parseMode" label="Markdown Formatting"></p-radioButton>
-                </div>
-                <div class="form-group">
-                    <p-radioButton name="parseMode" value="html" formControlName="parseMode" label="Html Formatting"></p-radioButton>
-                </div>
-                <small>Select a formatting option for the messages, you can view the supported formatting <a href="https://core.telegram.org/bots/api#formatting-options">here</a>.</small>
-
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-
-        <div class="col-md-6">
-            <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-        </div>
-    </fieldset>
-</div>
+    <div class="notification-field--full"
+         style="display:flex; flex-direction:column; gap:8px;">
+        <label id="parse-mode-label"
+               style="font-size:0.875rem; opacity:0.8;">Message formatting</label>
+        <mat-radio-group formControlName="parseMode" aria-labelledby="parse-mode-label"
+                         style="display:flex; gap:24px;">
+            <mat-radio-button value="markdown" color="primary">Markdown</mat-radio-button>
+            <mat-radio-button value="html" color="primary">HTML</mat-radio-button>
+        </mat-radio-group>
+    </div>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/telegram.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/telegram.component.ts
@@ -1,23 +1,18 @@
-import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, FormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INotificationTemplates, ITelegramNotifcationSettings, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
+import { MatRadioModule } from "@angular/material/radio";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { RadioButtonModule } from "primeng/radiobutton";
-import { NotificationTemplate } from "./notificationtemplate.component";
-import { SettingsMenuComponent } from "../settingsmenu.component";
-import { WikiComponent } from "../wiki.component";
+import { Observable } from "rxjs";
+
+import { ITelegramNotifcationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
@@ -25,77 +20,49 @@ import { WikiComponent } from "../wiki.component";
         CommonModule,
         FormsModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
+        MatRadioModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        RadioButtonModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./telegram.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class TelegramComponent implements OnInit {
+export class TelegramComponent extends NotificationBaseComponent<ITelegramNotifcationSettings> {
 
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+    protected readonly providerName = "Telegram";
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
-
-    public ngOnInit() {
-        this.settingsService.getTelegramNotificationSettings().subscribe(x => {
-            this.templates = x.notificationTemplates;
-
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                botApi: [x.botApi, [Validators.required]],
-                chatId: [x.chatId, [Validators.required]],
-                parseMode: [x.parseMode, [Validators.required]],
-
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <ITelegramNotifcationSettings> form.value;
-        settings.notificationTemplates = this.templates;
-
-        this.settingsService.saveTelegramNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Telegram settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Telegram settings");
-            }
-        });
-
+    protected override get testSuccessMessage(): string {
+        return "Successfully sent a Telegram message, please check the Telegram channel";
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected loadSettings(): Observable<ITelegramNotifcationSettings> {
+        return this.settingsService.getTelegramNotificationSettings();
+    }
 
-        this.testerService.telegramTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully sent a Telegram message, please check the Telegram channel");
-            } else {
-                this.notificationService.error("There was an error when sending the Telegram message. Please check your settings");
-            }
-        });
+    protected saveSettings(settings: ITelegramNotifcationSettings): Observable<boolean> {
+        return this.settingsService.saveTelegramNotificationSettings(settings);
+    }
 
+    protected testSettings(settings: ITelegramNotifcationSettings): Observable<boolean> {
+        return this.testerService.telegramTest(settings);
+    }
+
+    protected buildForm(x: ITelegramNotifcationSettings) {
+        return {
+            enabled: [x.enabled],
+            botApi: [x.botApi, [Validators.required]],
+            chatId: [x.chatId, [Validators.required]],
+            parseMode: [x.parseMode, [Validators.required]],
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/twilio/twilio.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/twilio/twilio.component.html
@@ -1,21 +1,17 @@
-﻿
-<div *ngIf="form" class="container">
-    <fieldset>
-        <legend>Twilio</legend>
-        <span>Below are the supported integrations with Twilio</span>
-        <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+<section class="twilio">
+    <header class="twilio__header">
+        <div class="twilio__avatar" aria-hidden="true">
+            <mat-icon>contactless</mat-icon>
+        </div>
+        <div>
+            <h2 class="twilio__title">Twilio</h2>
+            <p class="twilio__subtitle">Configure the Twilio integrations available in Ombi.</p>
+        </div>
+    </header>
 
-            <mat-tab-group>
-                <mat-tab label="WhatsApp">
-                    <app-whatsapp [form]="form" [templates]="templates"></app-whatsapp>
-                </mat-tab>
-            </mat-tab-group>
-
-            <div class=" md-form-field ">
-                <div>
-                    <button mat-raised-button type="submit " color="primary" [disabled]="form.invalid ">Submit</button>
-                </div>
-            </div>
-        </form>
-    </fieldset>
-</div>
+    <mat-tab-group class="twilio__tabs" mat-stretch-tabs="false" mat-align-tabs="start" animationDuration="150ms">
+        <mat-tab label="WhatsApp">
+            <app-whatsapp></app-whatsapp>
+        </mat-tab>
+    </mat-tab-group>
+</section>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/twilio/twilio.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/twilio/twilio.component.scss
@@ -1,0 +1,47 @@
+.twilio {
+    display: block;
+    margin: 24px auto 0;
+    width: min(1280px, 95%);
+
+    &__header {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin-bottom: 12px;
+    }
+
+    &__avatar {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        background: rgba(63, 81, 181, 0.12);
+        color: var(--mdc-theme-primary, #3f51b5);
+
+        mat-icon {
+            font-size: 24px;
+            width: 24px;
+            height: 24px;
+        }
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 500;
+    }
+
+    &__subtitle {
+        margin: 0;
+        opacity: 0.75;
+        font-size: 0.9rem;
+    }
+
+    &__tabs {
+        ::ng-deep .mat-mdc-tab-body-content {
+            padding-top: 0;
+        }
+    }
+}

--- a/src/Ombi/ClientApp/src/app/settings/notifications/twilio/twilio.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/twilio/twilio.component.ts
@@ -1,82 +1,22 @@
-﻿import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INotificationTemplates, ITwilioSettings, NotificationType } from "../../../interfaces";
-import { TesterService } from "../../../services";
-import { NotificationService } from "../../../services";
-import { SettingsService } from "../../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
-import { MatSlideToggleModule } from "@angular/material/slide-toggle";
-import { MatTooltipModule } from "@angular/material/tooltip";
-import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "../notificationtemplate.component";
-import { WhatsAppComponent } from "./whatsapp.component";
+import { MatIconModule } from "@angular/material/icon";
 import { MatTabsModule } from "@angular/material/tabs";
+import { TranslateModule } from "@ngx-translate/core";
+
+import { WhatsAppComponent } from "./whatsapp.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
-        ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
-        MatFormFieldModule,
+        MatIconModule,
         MatTabsModule,
-        MatInputModule,
-        MatSelectModule,
-        MatSlideToggleModule,
-        MatTooltipModule,
         TranslateModule,
-        WhatsAppComponent
+        WhatsAppComponent,
     ],
     templateUrl: "./twilio.component.html",
+    styleUrls: ["./twilio.component.scss"],
 })
-export class TwilioComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
-
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
-
-    public ngOnInit() {
-        this.settingsService.getTwilioSettings().subscribe(x => {
-            this.templates = x.whatsAppSettings.notificationTemplates;
-
-            this.form = this.fb.group({
-                whatsAppSettings: this.fb.group({
-                    enabled: [x.whatsAppSettings.enabled],
-                    accountSid: [x.whatsAppSettings.accountSid],
-                    authToken: [x.whatsAppSettings.authToken],
-                    from: [x.whatsAppSettings.from],
-                }),
-            });
-        });
-    }
-
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <ITwilioSettings> form.value;
-        settings.whatsAppSettings.notificationTemplates = this.templates;
-
-        this.settingsService.saveTwilioSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Twilio settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Twilio settings");
-            }
-        });
-
-    }
+export class TwilioComponent {
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/twilio/whatsapp.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/twilio/whatsapp.component.html
@@ -1,37 +1,44 @@
-<div class="container" style="padding-top: 3%;">
-    <div [formGroup]="form" class="col">
-        <div formGroupName="whatsAppSettings" class="row">
-            <div class="col">
-                <div>
-                    <mat-slide-toggle formControlName="enabled">Enable</mat-slide-toggle>
-                </div>
+<ombi-notification-shell
+    providerName="WhatsApp"
+    icon="chat"
+    description="Send notifications via WhatsApp using a Twilio Programmable Messaging account."
+    docsUrl="https://www.twilio.com/docs/whatsapp"
+    [form]="form"
+    [loading]="loading"
+    [templates]="templates"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-                <div class="md-form-field">
-                    <mat-form-field>
-                        <input matInput placeholder="From Number" formControlName="from" matTooltip="The mobile number that the WhatsApp message is from, with the international prefix">
-                    </mat-form-field>
-                </div>
-                <div class="md-form-field">
-                    <mat-form-field>
-                        <input matInput placeholder="Account SID" formControlName="accountSid" matTooltip="The Account SID that you can find from the Programmable SMS Dashboard">
-                    </mat-form-field>
-                </div>
-                <div class="md-form-field">
-                    <mat-form-field>
-                        <input matInput placeholder="Authentication Token" formControlName="authToken" matTooltip="The Auth Token that you can find from the Programmable SMS Dashboard">
-                    </mat-form-field>
-                </div>
-                <div class="md-form-field">
-                    <div>
-                        <button mat-raised-button type="button" color="accent" (click)="test(form)">Test</button>
-                    </div>
-                </div>
-            </div>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline">
+                <mat-label>From number</mat-label>
+                <input matInput formControlName="from" autocomplete="off"
+                       placeholder="+14155238886"
+                       matTooltip="The mobile number that the WhatsApp message is from, with the international prefix.">
+                @if (form.get('from')?.hasError('required')) {
+                    <mat-error>From number is <strong>required</strong></mat-error>
+                }
+                <mat-hint>Use the international format including the country code.</mat-hint>
+            </mat-form-field>
 
-            <div class="col">
-                <notification-templates [templates]="templates" [showSubject]="false"></notification-templates>
-            </div>
-      
-        </div>
-    </div>
-</div>
+            <mat-form-field appearance="outline">
+                <mat-label>Account SID</mat-label>
+                <input matInput formControlName="accountSid" autocomplete="off"
+                       matTooltip="The Account SID from the Twilio Programmable Messaging dashboard.">
+                @if (form.get('accountSid')?.hasError('required')) {
+                    <mat-error>Account SID is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Authentication token</mat-label>
+                <input matInput type="password" formControlName="authToken" autocomplete="new-password"
+                       matTooltip="The Auth Token from the Twilio Programmable Messaging dashboard.">
+                @if (form.get('authToken')?.hasError('required')) {
+                    <mat-error>Auth token is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
+        </ng-container>
+    }
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/twilio/whatsapp.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/twilio/whatsapp.component.ts
@@ -1,63 +1,115 @@
-﻿import { Component, Input } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormGroup } from "@angular/forms";
-import { TesterService, NotificationService } from "../../../services";
-import { INotificationTemplates, NotificationType } from "../../../interfaces";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "../notificationtemplate.component";
-import { MatTabsModule } from "@angular/material/tabs";
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
 
-
+import { INotificationTemplates, ITwilioSettings, IWhatsAppSettings } from "../../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../../services";
+import { NotificationShellComponent } from "../shared/notification-shell.component";
 
 @Component({
     standalone: true,
+    selector: "app-whatsapp",
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
-        MatTabsModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
         TranslateModule,
-        NotificationTemplate
+        NotificationShellComponent,
     ],
     templateUrl: "./whatsapp.component.html",
-    selector: "app-whatsapp"
 })
-export class WhatsAppComponent {
+export class WhatsAppComponent implements OnInit, OnDestroy {
 
-    public NotificationType = NotificationType;
-    @Input() public templates: INotificationTemplates[];
-    @Input() public form: UntypedFormGroup;
+    public form!: UntypedFormGroup;
+    public templates: INotificationTemplates[] = [];
+    public loading = true;
 
-    constructor(private testerService: TesterService,
-                private notificationService: NotificationService) { }
+    private originalSettings!: ITwilioSettings;
+    private readonly destroy$ = new Subject<void>();
 
+    constructor(private readonly settingsService: SettingsService,
+                private readonly notificationService: NotificationService,
+                private readonly fb: UntypedFormBuilder,
+                private readonly testerService: TesterService) { }
 
-    public test(form: UntypedFormGroup) {
+    public ngOnInit(): void {
+        this.settingsService.getTwilioSettings()
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(twilio => {
+                this.originalSettings = twilio;
+                const whatsapp = twilio.whatsAppSettings;
+                this.templates = whatsapp?.notificationTemplates ?? [];
+                this.form = this.fb.group({
+                    enabled: [!!whatsapp?.enabled],
+                    from: [whatsapp?.from ?? "", [Validators.required]],
+                    accountSid: [whatsapp?.accountSid ?? "", [Validators.required]],
+                    authToken: [whatsapp?.authToken ?? "", [Validators.required]],
+                });
+                this.loading = false;
+            });
+    }
+
+    public ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    public onSubmit(form: UntypedFormGroup): void {
         if (form.invalid) {
             this.notificationService.error("Please check your entered values");
             return;
         }
+        const wrapper: ITwilioSettings = {
+            ...this.originalSettings,
+            whatsAppSettings: this.toWhatsApp(form),
+        };
+        this.settingsService.saveTwilioSettings(wrapper)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(ok => {
+                if (ok) {
+                    this.notificationService.success("Successfully saved the WhatsApp settings");
+                } else {
+                    this.notificationService.error("There was an error when saving the WhatsApp settings");
+                }
+            });
+    }
 
-        this.testerService.whatsAppTest(form.get("whatsAppSettings").value).subscribe(x => {
-            if (x) {
-                this.notificationService.success( "Successfully sent a WhatsApp message, please check the appropriate channel");
-            } else {
-                this.notificationService.error("There was an error when sending the WhatsApp message. Please check your settings");
-            }
-        });
+    public test(form: UntypedFormGroup): void {
+        if (form.invalid) {
+            this.notificationService.error("Please check your entered values");
+            return;
+        }
+        this.testerService.whatsAppTest(this.toWhatsApp(form))
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(ok => {
+                if (ok) {
+                    this.notificationService.success(
+                        "Successfully sent a WhatsApp message, please check the appropriate channel");
+                } else {
+                    this.notificationService.error(
+                        "There was an error when sending the WhatsApp message. Please check your settings");
+                }
+            });
+    }
 
+    private toWhatsApp(form: UntypedFormGroup): IWhatsAppSettings {
+        const value = form.value;
+        return {
+            enabled: value.enabled ? 1 : 0,
+            from: value.from,
+            accountSid: value.accountSid,
+            authToken: value.authToken,
+            notificationTemplates: this.templates,
+        };
     }
 }

--- a/src/Ombi/ClientApp/src/app/settings/notifications/webhook.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/webhook.component.html
@@ -8,19 +8,23 @@
     (submitted)="onSubmit($event)"
     (tested)="test($event)">
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Endpoint URL</mat-label>
-        <input matInput formControlName="webhookUrl" autocomplete="off"
-               placeholder="https://example.com/ombi-webhook"
-               matTooltip="The URL Ombi will POST notifications to.">
-        @if (form?.get('webhookUrl')?.hasError('required')) {
-            <mat-error>Endpoint URL is <strong>required</strong></mat-error>
-        }
-    </mat-form-field>
+    @if (form) {
+        <ng-container [formGroup]="form">
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Endpoint URL</mat-label>
+                <input matInput formControlName="webhookUrl" autocomplete="off"
+                       placeholder="https://example.com/ombi-webhook"
+                       matTooltip="The URL Ombi will POST notifications to.">
+                @if (form.get('webhookUrl')?.hasError('required')) {
+                    <mat-error>Endpoint URL is <strong>required</strong></mat-error>
+                }
+            </mat-form-field>
 
-    <mat-form-field appearance="outline" class="notification-field--full">
-        <mat-label>Application token</mat-label>
-        <input matInput formControlName="applicationToken" autocomplete="off"
-               matTooltip="Optional. Sent as the Access-Token header on every request.">
-    </mat-form-field>
+            <mat-form-field appearance="outline" class="notification-field--full">
+                <mat-label>Application token</mat-label>
+                <input matInput formControlName="applicationToken" autocomplete="off"
+                       matTooltip="Optional. Sent as the Access-Token header on every request.">
+            </mat-form-field>
+        </ng-container>
+    }
 </ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/webhook.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/webhook.component.html
@@ -1,44 +1,26 @@
-﻿
+<ombi-notification-shell
+    providerName="Webhook"
+    icon="webhook"
+    description="POST request payloads to a custom HTTP endpoint."
+    [form]="form"
+    [loading]="loading"
+    [showTemplates]="false"
+    (submitted)="onSubmit($event)"
+    (tested)="test($event)">
 
-<div *ngIf="form" class="small-middle-container">
-    <fieldset>
-        <legend>Webhook Notifications</legend>
-        <div class="col-md-6">
-            <form novalidate [formGroup]="form" (ngSubmit)="onSubmit(form)">
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Endpoint URL</mat-label>
+        <input matInput formControlName="webhookUrl" autocomplete="off"
+               placeholder="https://example.com/ombi-webhook"
+               matTooltip="The URL Ombi will POST notifications to.">
+        @if (form?.get('webhookUrl')?.hasError('required')) {
+            <mat-error>Endpoint URL is <strong>required</strong></mat-error>
+        }
+    </mat-form-field>
 
-                <div class="form-group">
-                    <mat-checkbox id="enable" formControlName="enabled">Enabled</mat-checkbox>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Base URL</mat-label>
-                        <input matInput type="text" id="webhookUrl" name="webhookUrl" [ngClass]="{'form-error': form.get('webhookUrl').hasError('required')}" formControlName="webhookUrl" pTooltip="Enter the URL of your webhook server.">
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <mat-form-field>
-                        <mat-label>Application Token</mat-label>
-                          <input matInput type="text" id="applicationToken" name="applicationToken" [ngClass]="{'form-error': form.get('applicationToken').hasError('required')}" formControlName="applicationToken" pTooltip="Optional authentication token. Will be sent as 'Access-Token' header.">
-                    </mat-form-field>
-                </div>
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="button" (click)="test(form)">
-                            Test
-                            <div id="spinner"></div>
-                        </button>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <div>
-                        <button [disabled]="form.invalid" mat-raised-button type="submit" id="save">Submit</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-    </fieldset>
-</div>
+    <mat-form-field appearance="outline" class="notification-field--full">
+        <mat-label>Application token</mat-label>
+        <input matInput formControlName="applicationToken" autocomplete="off"
+               matTooltip="Optional. Sent as the Access-Token header on every request.">
+    </mat-form-field>
+</ombi-notification-shell>

--- a/src/Ombi/ClientApp/src/app/settings/notifications/webhook.component.ts
+++ b/src/Ombi/ClientApp/src/app/settings/notifications/webhook.component.ts
@@ -1,88 +1,61 @@
-import { Component, OnInit } from "@angular/core";
-import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-
-import { INotificationTemplates, IWebhookNotificationSettings, NotificationType } from "../../interfaces";
-import { TesterService } from "../../services";
-import { NotificationService } from "../../services";
-import { SettingsService } from "../../services";
+import { Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCheckboxModule } from "@angular/material/checkbox";
+import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/forms";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
-import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TranslateModule } from "@ngx-translate/core";
-import { NotificationTemplate } from "./notificationtemplate.component";
+import { Observable } from "rxjs";
+
+import { IWebhookNotificationSettings } from "../../interfaces";
+import { NotificationService, SettingsService, TesterService } from "../../services";
+import { NotificationBaseComponent } from "./shared/notification-base.component";
+import { NotificationShellComponent } from "./shared/notification-shell.component";
 
 @Component({
     standalone: true,
     imports: [
         CommonModule,
         ReactiveFormsModule,
-        MatButtonModule,
-        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
-        MatSelectModule,
         MatSlideToggleModule,
         MatTooltipModule,
-        TranslateModule
+        TranslateModule,
+        NotificationShellComponent,
     ],
     templateUrl: "./webhook.component.html",
-    styleUrls: ["./notificationtemplate.component.scss"]
 })
-export class WebhookComponent implements OnInit {
-    public NotificationType = NotificationType;
-    public templates: INotificationTemplates[];
-    public form: UntypedFormGroup;
+export class WebhookComponent extends NotificationBaseComponent<IWebhookNotificationSettings> {
 
-    constructor(private settingsService: SettingsService,
-                private notificationService: NotificationService,
-                private fb: UntypedFormBuilder,
-                private testerService: TesterService) { }
+    protected readonly providerName = "Webhook";
+    protected override attachTemplates = false;
 
-    public ngOnInit() {
-        this.settingsService.getWebhookNotificationSettings().subscribe(x => {
-            this.form = this.fb.group({
-                enabled: [x.enabled],
-                webhookUrl: [x.webhookUrl, [Validators.required]],
-                applicationToken: [x.applicationToken],
-            });
-        });
+    constructor(settingsService: SettingsService,
+                notificationService: NotificationService,
+                fb: UntypedFormBuilder,
+                testerService: TesterService) {
+        super(settingsService, notificationService, fb, testerService);
     }
 
-    public onSubmit(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
-
-        const settings = <IWebhookNotificationSettings> form.value;
-
-        this.settingsService.saveWebhookNotificationSettings(settings).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully saved the Webhook settings");
-            } else {
-                this.notificationService.success("There was an error when saving the Webhook settings");
-            }
-        });
-
+    protected loadSettings(): Observable<IWebhookNotificationSettings> {
+        return this.settingsService.getWebhookNotificationSettings();
     }
 
-    public test(form: UntypedFormGroup) {
-        if (form.invalid) {
-            this.notificationService.error("Please check your entered values");
-            return;
-        }
+    protected saveSettings(settings: IWebhookNotificationSettings): Observable<boolean> {
+        return this.settingsService.saveWebhookNotificationSettings(settings);
+    }
 
-        this.testerService.webhookTest(form.value).subscribe(x => {
-            if (x) {
-                this.notificationService.success("Successfully sent a Webhook message");
-            } else {
-                this.notificationService.error("There was an error when sending the Webhook message. Please check your settings");
-            }
-        });
+    protected testSettings(settings: IWebhookNotificationSettings): Observable<boolean> {
+        return this.testerService.webhookTest(settings);
+    }
+
+    protected buildForm(x: IWebhookNotificationSettings) {
+        return {
+            enabled: [x.enabled],
+            webhookUrl: [x.webhookUrl, [Validators.required]],
+            applicationToken: [x.applicationToken],
+        };
     }
 }


### PR DESCRIPTION
Move duplicated lifecycle, save/test handling and form scaffolding from
each notification provider page into a single NotificationBaseComponent
abstract class, and lift the repeated card/header/actions/templates
layout into a presentational NotificationShellComponent.

Provider pages (Discord, Slack, Telegram, Gotify, Ntfy, Pushbullet,
Pushover, Mattermost, Webhook, Email) now declare only their
provider-specific fields and form schema. Subscriptions are cleaned up
on destroy, validation errors render inline, and the layout uses
mat-card with consistent spacing, icons and a docs link per provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardised notification shell and abstract base component introduced; provider settings pages now use the shared shell and unified submit/test events.

* **Bug Fixes**
  * Consistent validation and inline error handling across notification forms; updated test/save messaging and a refined validation path for provider-specific rules.

* **Style**
  * Unified Material form layout, labels, hints and tooltips (e.g. “Webhook URL”, “Avatar URL”, “Authorization header”); responsive shell/grid styles and streamlined templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->