### PR TITLE
fix(http): enable automatic decompression on OmbiClient

### DIFF
--- a/src/Ombi.DependencyInjection/IocExtensions.cs
+++ b/src/Ombi.DependencyInjection/IocExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Security.Principal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -138,7 +139,16 @@ namespace Ombi.DependencyInjection
                 client.DefaultRequestHeaders.Add("User-Agent", $"Ombi/{runtimeVersion} (https://ombi.io/)");
             }).ConfigurePrimaryHttpMessageHandler(() =>
             {
-                var httpClientHandler = new HttpClientHandler();
+                var httpClientHandler = new HttpClientHandler
+                {
+                    // Some upstream APIs (notably TheMovieDb behind its CDN) may return
+                    // gzip/brotli-encoded responses even when no Accept-Encoding header is
+                    // sent. Without automatic decompression the raw compressed bytes are
+                    // handed to ReadAsStringAsync, producing UTF-8 replacement characters
+                    // (U+FFFD) and a Newtonsoft.Json "Unexpected character ... line 0,
+                    // position 0" failure (intermittent, often seen under Docker on Linux).
+                    AutomaticDecompression = DecompressionMethods.All,
+                };
                 httpClientHandler.ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true;
 
                 return httpClientHandler;


### PR DESCRIPTION
## Summary

- Enable `AutomaticDecompression = DecompressionMethods.All` on the `OmbiClient` `HttpClientHandler` so gzip/brotli/deflate responses from upstream APIs (notably TheMovieDb behind its CDN) are decompressed before `ReadAsStringAsync` and JSON deserialization.
- Fixes Discover page spinning and search failures when TMDB returns compressed bodies that were previously read as raw bytes, causing `JsonReaderException: Unexpected character ...` at line 0, position 0 (reported in #5409).

## Root cause

With `AutomaticDecompression` left at the default (`None`), compressed response bytes are interpreted as UTF-8. Invalid sequences become U+FFFD (``), which Newtonsoft.Json rejects at position 0. This is intermittent because CDN compression varies by endpoint and client path (often more visible from Docker/Linux).

## Test plan

- [ ] Run Ombi in Docker on Linux against a host exhibiting #5409
- [ ] Open Discover â€” Trending movies/TV load without infinite spinner
- [ ] Confirm logs no longer show `JsonReaderException` from `TheMovieDbApi.Trending`
- [ ] Smoke-test other `OmbiClient` integrations (Plex, Sonarr, Radarr) unchanged

Closes #5409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTTP client configuration to automatically decompress responses from upstream services, enhancing compatibility with APIs that return compressed data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ombi-app/Ombi/pull/5410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->