### PR TITLE
refactor(identity): require ApplicationUrl for password reset emails

### DIFF
--- a/src/Ombi/Controllers/V1/IdentityController.cs
+++ b/src/Ombi/Controllers/V1/IdentityController.cs
@@ -797,12 +797,6 @@ namespace Ombi.Controllers.V1
             var emailSettings = await EmailSettings.GetSettingsAsync();
 
             var appUrl = customizationSettings.AddToUrl("/token?token=");
-            if (string.IsNullOrEmpty(appUrl))
-            {
-                _log.LogWarning("Password reset requested but ApplicationUrl is not configured; cannot build reset link.");
-                return defaultMessage;
-            }
-            var url = appUrl;
 
             if (user.UserType == UserType.PlexUser)
             {
@@ -828,6 +822,12 @@ namespace Ombi.Controllers.V1
             }
             else
             {
+                if (string.IsNullOrEmpty(appUrl))
+                {
+                    _log.LogWarning("Password reset requested but ApplicationUrl is not configured; cannot build reset link.");
+                    return defaultMessage;
+                }
+
                 // We have the user
                 var token = await UserManager.GeneratePasswordResetTokenAsync(user);
                 var encodedToken = WebUtility.UrlEncode(token);
@@ -838,7 +838,7 @@ namespace Ombi.Controllers.V1
                     Subject = $"{appName} Password Reset",
                     Message =
                         $"You recently made a request to reset your {appName} account. Please click the link below to complete the process.<br/><br/>" +
-                        $"<a href=\"{url}{encodedToken}\"> Reset </a>"
+                        $"<a href=\"{appUrl}{encodedToken}\"> Reset </a>"
                 }, emailSettings);
             }
 

--- a/src/Ombi/Controllers/V1/IdentityController.cs
+++ b/src/Ombi/Controllers/V1/IdentityController.cs
@@ -797,9 +797,12 @@ namespace Ombi.Controllers.V1
             var emailSettings = await EmailSettings.GetSettingsAsync();
 
             var appUrl = customizationSettings.AddToUrl("/token?token=");
-            var url = (string.IsNullOrEmpty(appUrl)
-                ? $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}/token?token="
-                : appUrl);
+            if (string.IsNullOrEmpty(appUrl))
+            {
+                _log.LogWarning("Password reset requested but ApplicationUrl is not configured; cannot build reset link.");
+                return defaultMessage;
+            }
+            var url = appUrl;
 
             if (user.UserType == UserType.PlexUser)
             {


### PR DESCRIPTION
## Summary

- Simplify the reset-link construction in `IdentityController.SubmitResetPassword` by removing the implicit fallback to `HttpContext.Request.Host` when the `ApplicationUrl` customization setting is empty.
- The reset link is now sourced from `CustomizationSettings.ApplicationUrl` only; if it isn't configured the endpoint logs a warning and returns the existing generic response without sending mail.
- Collapses the conditional URL construction to a single source of truth and keeps the response shape identical across all user-type branches (unknown email, no ApplicationUrl, successful send).

## Test plan

- [x] Build the solution (`dotnet build src/Ombi.sln`).
- [x] With `ApplicationUrl` blank in Customization settings and SMTP configured, POST to `/api/v1/Identity/reset` and confirm: response body is the generic "If this account exists you should recieve a password reset link." message, no email is sent, and the new warning appears in the log.
- [x] With `ApplicationUrl` set (e.g. `http://localhost:5000`), POST to `/api/v1/Identity/reset` and confirm the email is delivered with a link built from `ApplicationUrl`, and that the link successfully completes `POST /api/v1/Identity/resetpassword` followed by login via `POST /api/v1/token`.
- [x] Confirm the existing Plex and Emby Connect branches are unaffected when `ApplicationUrl` is configured (their content uses hardcoded external links and does not depend on the constructed URL).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfPpATzfzVCLhqpxKQMhBM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password reset now strictly uses the configured application URL when building reset links. If the application URL is not set, reset emails and tokens will not be generated (a success-like response is still returned) and a warning is logged. Please ensure your application URL is configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ombi-app/Ombi/pull/5415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->