### PR TITLE
Fix Plex user import crash on unauthorized token (#5418)

### DIFF
--- a/src/Ombi.Api/Api.cs
+++ b/src/Ombi.Api/Api.cs
@@ -117,17 +117,27 @@ namespace Ombi.Api
                 // Only cache successful responses
                 if (!httpResponseMessage.IsSuccessStatusCode)
                 {
-                    // For failed responses, don't cache - just deserialize and return
+                    // For failed responses, don't cache. The body is usually an error payload
+                    // (e.g. Plex returns an <errors> document on a 401) that does not match the
+                    // expected success type, so attempt to deserialize it but fall back to the
+                    // default value rather than throwing a misleading deserialization exception.
                     var errorString = await httpResponseMessage.Content.ReadAsStringAsync(cancellationToken);
                     LogDebugContent(errorString);
-                    if (request.ContentType == ContentType.Json)
+                    try
                     {
-                        request.OnBeforeDeserialization?.Invoke(errorString);
-                        return JsonConvert.DeserializeObject<T>(errorString, Settings);
-                    }
-                    else
-                    {
+                        if (request.ContentType == ContentType.Json)
+                        {
+                            request.OnBeforeDeserialization?.Invoke(errorString);
+                            return JsonConvert.DeserializeObject<T>(errorString, Settings);
+                        }
+
                         return DeserializeXml<T>(errorString);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogWarning(ex,
+                            $"Could not deserialize the error response from {request.FullUri} (Status Code: {httpResponseMessage.StatusCode}) into {typeof(T).Name}, returning default");
+                        return default;
                     }
                 }
 

--- a/src/Ombi.Api/Api.cs
+++ b/src/Ombi.Api/Api.cs
@@ -48,32 +48,45 @@ namespace Ombi.Api
 
                 try
                 {
-                    return await _cacheService.GetOrAddAsync(cacheKey, async () =>
+                    var wasSuccessful = true;
+                    var cachedResult = await _cacheService.GetOrAddAsync(cacheKey, async () =>
                     {
                         Logger.LogDebug($"ApiCache: MISS for {request.HttpMethod.Method} {request.FullUri}");
-                        return await ExecuteRequest<T>(request, cancellationToken);
+                        var (value, requestSucceeded) = await ExecuteRequest<T>(request, cancellationToken);
+                        wasSuccessful = requestSucceeded;
+                        return value;
                     }, DateTimeOffset.UtcNow.Add(request.CacheDuration.Value));
+
+                    // Don't keep unsuccessful responses in the cache, otherwise a transient
+                    // failure (e.g. an expired token returning a 401) would be served from the
+                    // cache for the entire cache duration.
+                    if (!wasSuccessful)
+                    {
+                        _cacheService.Remove(cacheKey);
+                    }
+
+                    return cachedResult;
                 }
                 catch (JsonException ex)
                 {
                     // Deserialization failed - evict cache and retry
                     Logger.LogWarning(ex, $"ApiCache: Deserialization failed for {request.FullUri}, evicting and retrying");
                     _cacheService.Remove(cacheKey);
-                    return await ExecuteRequest<T>(request, cancellationToken);
+                    return (await ExecuteRequest<T>(request, cancellationToken)).value;
                 }
                 catch (Exception ex)
                 {
                     // Cache service failed - log and proceed without cache
                     Logger.LogWarning(ex, $"ApiCache: Cache read failed for {request.FullUri}, proceeding without cache");
-                    return await ExecuteRequest<T>(request, cancellationToken);
+                    return (await ExecuteRequest<T>(request, cancellationToken)).value;
                 }
             }
 
             // No caching - execute request directly
-            return await ExecuteRequest<T>(request, cancellationToken);
+            return (await ExecuteRequest<T>(request, cancellationToken)).value;
         }
 
-        private async Task<T> ExecuteRequest<T>(Request request, CancellationToken cancellationToken)
+        private async Task<(T value, bool wasSuccessful)> ExecuteRequest<T>(Request request, CancellationToken cancellationToken)
         {
             using (var httpRequestMessage = new HttpRequestMessage(request.HttpMethod, request.FullUri))
             {
@@ -128,16 +141,16 @@ namespace Ombi.Api
                         if (request.ContentType == ContentType.Json)
                         {
                             request.OnBeforeDeserialization?.Invoke(errorString);
-                            return JsonConvert.DeserializeObject<T>(errorString, Settings);
+                            return (JsonConvert.DeserializeObject<T>(errorString, Settings), false);
                         }
 
-                        return DeserializeXml<T>(errorString);
+                        return (DeserializeXml<T>(errorString), false);
                     }
                     catch (Exception ex)
                     {
                         Logger.LogWarning(ex,
                             $"Could not deserialize the error response from {request.FullUri} (Status Code: {httpResponseMessage.StatusCode}) into {typeof(T).Name}, returning default");
-                        return default;
+                        return (default, false);
                     }
                 }
 
@@ -147,13 +160,11 @@ namespace Ombi.Api
                 if (request.ContentType == ContentType.Json)
                 {
                     request.OnBeforeDeserialization?.Invoke(receivedString);
-                    return JsonConvert.DeserializeObject<T>(receivedString, Settings);
+                    return (JsonConvert.DeserializeObject<T>(receivedString, Settings), true);
                 }
-                else
-                {
-                    // XML
-                    return DeserializeXml<T>(receivedString);
-                }
+
+                // XML
+                return (DeserializeXml<T>(receivedString), true);
             }
         }
 

--- a/src/Ombi.Schedule.Tests/PlexUserImporterTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexUserImporterTests.cs
@@ -129,6 +129,20 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
+        public async Task Import_Admin_Handles_Null_Account_When_Unauthorized()
+        {
+            // Simulates Plex returning an Unauthorized response, in which case the account cannot be retrieved.
+            _mocker.Setup<ISettingsService<UserManagementSettings>, Task<UserManagementSettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new UserManagementSettings { ImportPlexAdmin = true, ImportPlexUsers = false });
+            _mocker.Setup<IPlexApi, Task<PlexAccount>>(x => x.GetAccount(It.IsAny<string>())).ReturnsAsync((PlexAccount)null);
+
+            Assert.DoesNotThrowAsync(() => _subject.Execute(null));
+
+            _mocker.Verify<OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
+            _mocker.Verify<OmbiUserManager>(x => x.UpdateAsync(It.IsAny<OmbiUser>()), Times.Never);
+        }
+
+        [Test]
         public async Task Import_Only_Imports_Plex_Admin_Already_Exists()
         {
             _mocker.Setup<ISettingsService<UserManagementSettings>, Task<UserManagementSettings>>(x => x.GetSettingsAsync())

--- a/src/Ombi.Schedule/Jobs/Plex/PlexUserImporter.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexUserImporter.cs
@@ -202,7 +202,14 @@ namespace Ombi.Schedule.Jobs.Plex
         private async Task<OmbiUser> ImportAdmin(UserManagementSettings settings, PlexServers server, 
             List<OmbiUser> allUsers)
         {
-            var plexAdmin = (await _api.GetAccount(server.PlexAuthToken)).user;
+            var plexAdmin = (await _api.GetAccount(server.PlexAuthToken))?.user;
+
+            if (plexAdmin == null)
+            {
+                // We could not retrieve the Plex account, most likely the auth token is invalid or expired.
+                _log.LogWarning("Could not import the Plex admin, the Plex account could not be retrieved. The Plex auth token may be invalid or expired.");
+                return null;
+            }
 
             // Check if the admin is already in the DB
             var adminUserFromDb = allUsers.FirstOrDefault(x =>


### PR DESCRIPTION
## Summary

Fixes #5418, where the Plex User Importer fails to sync users and throws confusing errors.

The root trigger is an invalid/expired Plex auth token — `plex.tv` responds with `401 Unauthorized` (and `422` on the account endpoint). Two code-level issues turned that into hard crashes that obscured the real cause:

1. **Misleading XML deserialization crash** — On a non-success response, `Api.ExecuteRequest` deserialized the error body (e.g. Plex's `<errors xmlns=''>` document) using the success type's serializer, throwing:
   ```
   System.InvalidOperationException: There is an error in XML document (2, 2).
    ---> <errors xmlns=''> was not expected.
   ```
   The deserialization of error responses is now wrapped in a `try/catch`; a payload that doesn't match the expected type logs a warning and returns the default value instead of throwing.

2. **NullReferenceException in `ImportAdmin`** — `PlexUserImporter.ImportAdmin` dereferenced the result of `GetAccount(...)` without a null check. When the account can't be retrieved (unauthorized token), `plexAdmin` was null and `plexAdmin.id` threw an NRE. It now logs a warning and skips the admin import.

With these changes, an invalid Plex token degrades gracefully and is logged clearly, instead of crashing the importer job and the `GetFriends` endpoint.

## Changes
- `src/Ombi.Api/Api.cs` — tolerant deserialization of failed-response bodies.
- `src/Ombi.Schedule/Jobs/Plex/PlexUserImporter.cs` — null guard around the Plex admin account.
- `src/Ombi.Schedule.Tests/PlexUserImporterTests.cs` — test covering the unauthorized (null account) path.

## Testing
- Added unit test `Import_Admin_Handles_Null_Account_When_Unauthorized` verifying the importer does not throw and performs no user create/update when the account is null.

> Note: this addresses the robustness/error-handling bugs. The underlying user-facing fix is to re-authenticate the Plex admin so a valid token is stored.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling so failed responses are not cached, deserialisation errors are logged and do not throw, and successful responses are clearly distinguished.
  * Enhanced Plex user importer to handle missing or invalid admin accounts by logging a warning and skipping further processing instead of failing.

* **Tests**
  * Added test coverage for Plex admin import when account retrieval fails due to authorisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->