### PR TITLE
fix(tv): materialize TV request search before filtering to avoid EF Core 500

### DIFF
--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -238,7 +238,6 @@ jobs:
         spec: "cypress/features/01-wizard/wizard.feature,cypress/features/login/login.feature,cypress/tests/login/login.spec.ts"
         wait-on: http://localhost:3577/
         wait-on-timeout: 600
-        spec: cypress/features/01-wizard/wizard.feature
       env:
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -645,7 +645,9 @@ namespace Ombi.Core.Engine
             {
                 allRequests = TvRepository.Get();
             }
-            var results = await allRequests.Where(x => x.Title.Contains(search, CompareOptions.IgnoreCase)).ToListAsync();
+            var results = (await allRequests.ToListAsync())
+                .Where(x => x.Title.Contains(search, CompareOptions.IgnoreCase))
+                .ToList();
 
             await FillAdditionalFields(shouldHide, results);
             return results;


### PR DESCRIPTION
## Description

Fixes #5420.

`GET /api/v1/Request/tv/search/{searchTerm}` always returned **HTTP 500**. In `TvRequestEngine.SearchTvRequest`, the `.Where(...)` clause using the custom `StringHelper.Contains(string, CompareOptions)` overload was applied to an `IQueryable` *before* materialization. EF Core attempted to translate that custom extension into SQL and failed:

```
The LINQ expression 'DbSet().Where(t => t.Title.Contains(word: __search_0, opts: IgnoreCase))' could not be translated.
```

## Fix

Materialize the query with `ToListAsync()` first, then filter in memory (LINQ-to-Objects), mirroring the working `MovieRequestEngine.SearchMovieRequest` path:

```csharp
var results = (await allRequests.ToListAsync())
    .Where(x => x.Title.Contains(search, CompareOptions.IgnoreCase))
    .ToList();
```

## Testing
- Builds locally; the TV search endpoint now filters in memory consistent with the movie endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search for TV requests now performs case-insensitive title matching, improving consistency of results.

* **Tests**
  * Expanded automated smoke tests to cover additional core flows (login and setup wizard), increasing test coverage for key user journeys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->