### PR TITLE
Harden Emby sync against partial failures (#5356)

### DIFF
--- a/src/Ombi.Helpers/OmbiQuartz.cs
+++ b/src/Ombi.Helpers/OmbiQuartz.cs
@@ -87,20 +87,39 @@ namespace Ombi.Helpers
 
         public static async Task TriggerJob(string jobName, string group)
         {
+            await TriggerJobIfNotRunning(jobName, group);
+        }
+
+        /// <summary>
+        /// Triggers the job unless it is already running. Returns whether the job was triggered,
+        /// so callers that depend on the job running (e.g. a resync after wiping data) can react.
+        /// </summary>
+        public static async Task<bool> TriggerJobIfNotRunning(string jobName, string group, IDictionary<string, object> data = null)
+        {
             await _semaphore.WaitAsync();
 
             try
             {
-                if (!(await IsJobRunning(jobName)))
+                if (await IsJobRunning(jobName))
+                {
+                    return false;
+                }
+
+                if (data != null)
+                {
+                    await Scheduler.TriggerJob(new JobKey(jobName, group), new JobDataMap(data));
+                }
+                else
                 {
                     await Scheduler.TriggerJob(new JobKey(jobName, group));
                 }
+
+                return true;
             }
             finally
             {
                 _semaphore.Release();
             }
-
         }
 
 

--- a/src/Ombi.Helpers/OmbiQuartz.cs
+++ b/src/Ombi.Helpers/OmbiQuartz.cs
@@ -26,9 +26,20 @@ namespace Ombi.Helpers
         /// </summary>
         public static OmbiQuartz Instance => _instance ?? (_instance = new OmbiQuartz());
 
-        protected OmbiQuartz()
+        protected OmbiQuartz() : this(true)
         {
-            Init();
+        }
+
+        /// <summary>
+        /// Allows tests to skip the async scheduler initialisation and supply their own scheduler,
+        /// since Init() runs async void and would otherwise race with (and overwrite) a test scheduler.
+        /// </summary>
+        protected OmbiQuartz(bool init)
+        {
+            if (init)
+            {
+                Init();
+            }
         }
 
         private async void Init()

--- a/src/Ombi.Schedule.Tests/EmbyContentSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyContentSyncTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Ombi.Api.External.MediaServers.Emby;
+using Ombi.Api.External.MediaServers.Emby.Models;
+using Ombi.Api.External.MediaServers.Emby.Models.Media.Tv;
+using Ombi.Api.External.MediaServers.Emby.Models.Movie;
+using Ombi.Core.Services;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Hubs;
+using Ombi.Schedule.Jobs.Emby;
+using Quartz;
+
+namespace Ombi.Schedule.Tests
+{
+    [TestFixture]
+    public class EmbyContentSyncTests
+    {
+        private AutoMocker _mocker;
+        private EmbyContentSync _subject;
+        private Mock<IEmbyApi> _api;
+        private Mock<IJobExecutionContext> _context;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mocker = new AutoMocker();
+
+            _api = new Mock<IEmbyApi>();
+            _mocker.Setup<IEmbyApiFactory, IEmbyApi>(x => x.CreateClient(It.IsAny<EmbySettings>()))
+                .Returns(_api.Object);
+
+            _mocker.Setup<ISettingsService<EmbySettings>, Task<EmbySettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new EmbySettings
+                {
+                    Enable = true,
+                    Servers = new List<EmbyServers>
+                    {
+                        new EmbyServers
+                        {
+                            Name = "Test",
+                            ApiKey = "key",
+                            AdministratorId = "admin",
+                            Ip = "localhost",
+                            Port = 8096
+                        }
+                    }
+                });
+
+            _mocker.Setup<IFeatureService, Task<bool>>(x => x.FeatureEnabled(It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            _context = new Mock<IJobExecutionContext>();
+            _context.Setup(x => x.MergedJobDataMap).Returns(new JobDataMap());
+
+            var scheduler = new Mock<IScheduler>();
+            scheduler.Setup(x => x.GetCurrentlyExecutingJobs(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<IJobExecutionContext>());
+            _ = new QuartzMock(scheduler);
+
+            _subject = _mocker.CreateInstance<EmbyContentSync>();
+        }
+
+        [Test]
+        public async Task TvSync_EmptyPageWithRemainingRecords_StopsInsteadOfRefetchingForever()
+        {
+            SetupMovies(totalRecordCount: 0);
+            SetupShows(totalRecordCount: 50);
+
+            await _subject.Execute(_context.Object);
+
+            _api.Verify(x => x.GetAllShows(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Content Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task MovieSync_EmptyPageWithRemainingRecords_StopsInsteadOfRefetchingForever()
+        {
+            SetupMovies(totalRecordCount: 50);
+            SetupShows(totalRecordCount: 0);
+
+            await _subject.Execute(_context.Object);
+
+            _api.Verify(x => x.GetAllMovies(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Content Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private void SetupMovies(int totalRecordCount)
+        {
+            _api.Setup(x => x.GetAllMovies(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyMovie>
+                {
+                    TotalRecordCount = totalRecordCount,
+                    Items = new List<EmbyMovie>()
+                });
+        }
+
+        private void SetupShows(int totalRecordCount)
+        {
+            _api.Setup(x => x.GetAllShows(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbySeries>
+                {
+                    TotalRecordCount = totalRecordCount,
+                    Items = new List<EmbySeries>()
+                });
+        }
+    }
+}

--- a/src/Ombi.Schedule.Tests/EmbyEpisodeSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyEpisodeSyncTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Ombi.Api.External.MediaServers.Emby;
+using Ombi.Api.External.MediaServers.Emby.Models;
+using Ombi.Api.External.MediaServers.Emby.Models.Media.Tv;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Hubs;
+using Ombi.Schedule.Jobs.Emby;
+using Ombi.Store.Entities;
+using Ombi.Store.Repository;
+using Quartz;
+
+namespace Ombi.Schedule.Tests
+{
+    [TestFixture]
+    public class EmbyEpisodeSyncTests
+    {
+        private AutoMocker _mocker;
+        private EmbyEpisodeSync _subject;
+        private Mock<IEmbyApi> _api;
+        private Mock<IJobExecutionContext> _context;
+        private List<EmbyEpisode> _addedEpisodes;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mocker = new AutoMocker();
+
+            _api = new Mock<IEmbyApi>();
+            _mocker.Setup<IEmbyApiFactory, IEmbyApi>(x => x.CreateClient(It.IsAny<EmbySettings>()))
+                .Returns(_api.Object);
+
+            SetupServers(Server("server1"));
+
+            // AddRange is called with a live HashSet that the sync clears afterwards,
+            // so snapshot its contents at call time rather than inspecting it at verify time
+            _addedEpisodes = new List<EmbyEpisode>();
+            _mocker.GetMock<IEmbyContentRepository>()
+                .Setup(x => x.AddRange(It.IsAny<IEnumerable<IMediaServerEpisode>>()))
+                .Callback<IEnumerable<IMediaServerEpisode>>(e => _addedEpisodes.AddRange(e.Cast<EmbyEpisode>()))
+                .Returns(Task.CompletedTask);
+
+            _mocker.Setup<IEmbyContentRepository, Task<HashSet<string>>>(x => x.GetAllSeriesEmbyIds())
+                .ReturnsAsync(new HashSet<string> { "series1" });
+            _mocker.Setup<IEmbyContentRepository, Task<Dictionary<string, (int EpisodeNumber, int SeasonNumber)>>>(x => x.GetAllEpisodeMetadata())
+                .ReturnsAsync(new Dictionary<string, (int EpisodeNumber, int SeasonNumber)>());
+
+            _context = new Mock<IJobExecutionContext>();
+            _context.Setup(x => x.MergedJobDataMap).Returns(new JobDataMap());
+
+            var scheduler = new Mock<IScheduler>();
+            scheduler.Setup(x => x.GetCurrentlyExecutingJobs(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<IJobExecutionContext>());
+            _ = new QuartzMock(scheduler);
+
+            _subject = _mocker.CreateInstance<EmbyEpisodeSync>();
+        }
+
+        [Test]
+        public async Task EpisodeWithNullProviderIds_IsStillAdded()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1")));
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedEpisodes, Has.Count.EqualTo(1));
+            Assert.That(_addedEpisodes.Single().EmbyId, Is.EqualTo("ep1"));
+            Assert.That(_addedEpisodes.Single().TvDbId, Is.Null);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Failed", It.IsAny<CancellationToken>()), Times.Never);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task EmptyPageWithRemainingRecords_StopsInsteadOfRefetchingForever()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyEpisodes> { TotalRecordCount = 100, Items = new List<EmbyEpisodes>() });
+
+            await _subject.Execute(_context.Object);
+
+            _api.Verify(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ServerThrowing_SendsFailureNotification_AndDoesNotThrow()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("Emby returned something we cannot handle"));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Failed", It.IsAny<CancellationToken>()), Times.Once);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task OneServerFailing_DoesNotStopTheOtherServers()
+        {
+            SetupServers(Server("badServer"), Server("goodServer"));
+            _api.Setup(x => x.GetAllEpisodes("badServer", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("Emby returned something we cannot handle"));
+            _api.Setup(x => x.GetAllEpisodes("goodServer", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1")));
+
+            await _subject.Execute(_context.Object);
+
+            _api.Verify(x => x.GetAllEpisodes("goodServer", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            Assert.That(_addedEpisodes.Select(x => x.EmbyId), Does.Contain("ep1"));
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Failed", It.IsAny<CancellationToken>()), Times.Once);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private void SetupServers(params EmbyServers[] servers)
+        {
+            _mocker.Setup<ISettingsService<EmbySettings>, Task<EmbySettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new EmbySettings
+                {
+                    Enable = true,
+                    Servers = servers.ToList()
+                });
+        }
+
+        private static EmbyServers Server(string apiKey) => new EmbyServers
+        {
+            Name = apiKey,
+            ApiKey = apiKey,
+            AdministratorId = "admin",
+            Ip = "localhost",
+            Port = 8096
+        };
+
+        private static EmbyItemContainer<EmbyEpisodes> Page(params EmbyEpisodes[] episodes) => new EmbyItemContainer<EmbyEpisodes>
+        {
+            TotalRecordCount = episodes.Length,
+            Items = episodes.ToList()
+        };
+
+        private static EmbyEpisodes Episode(string id, int episodeNumber = 1, int seasonNumber = 1) => new EmbyEpisodes
+        {
+            Id = id,
+            Name = $"Episode {id}",
+            SeriesId = "series1",
+            SeriesName = "Series",
+            IndexNumber = episodeNumber,
+            ParentIndexNumber = seasonNumber,
+            ProviderIds = null
+        };
+    }
+}

--- a/src/Ombi.Schedule.Tests/OmbiQuartzTests.cs
+++ b/src/Ombi.Schedule.Tests/OmbiQuartzTests.cs
@@ -1,6 +1,7 @@
-﻿using Moq;
+using Moq;
 using NUnit.Framework;
 using Quartz;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Ombi.Helpers;
@@ -10,26 +11,83 @@ namespace Ombi.Schedule.Tests
     [TestFixture]
     public class OmbiQuartzTests
     {
+        private Mock<IScheduler> _scheduler;
+
+        [SetUp]
+        public void Setup()
+        {
+            _scheduler = new Mock<IScheduler>();
+            _ = new QuartzMock(_scheduler);
+        }
 
         [Test]
-        [Ignore("Cannot get this to work")]
-        public void Test()
+        public async Task TriggerJobIfNotRunning_TriggersWhenJobIsNotRunning()
         {
-            var scheduleMock = new Mock<IScheduler>();
-            scheduleMock.Setup(x => x.TriggerJob(It.IsAny<JobKey>(),
-                It.IsAny<CancellationToken>()));
-            var sut = new QuartzMock(scheduleMock);
+            SetupRunningJobs(_scheduler);
 
-            //await QuartzMock.TriggerJob("ABC");
+            var triggered = await OmbiQuartz.TriggerJobIfNotRunning("MyJob", "Group");
 
-            scheduleMock.Verify(x => x.TriggerJob(It.Is<JobKey>(j => j.Name == "ABC"), 
-                default(CancellationToken)), Times.Once);
+            Assert.That(triggered, Is.True);
+            _scheduler.Verify(x => x.TriggerJob(It.Is<JobKey>(j => j.Name == "MyJob" && j.Group == "Group"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
 
+        [Test]
+        public async Task TriggerJobIfNotRunning_DoesNotTriggerWhenJobIsAlreadyRunning()
+        {
+            SetupRunningJobs(_scheduler, "MyJob");
+
+            var triggered = await OmbiQuartz.TriggerJobIfNotRunning("MyJob", "Group");
+
+            Assert.That(triggered, Is.False);
+            _scheduler.Verify(x => x.TriggerJob(It.IsAny<JobKey>(), It.IsAny<CancellationToken>()), Times.Never);
+            _scheduler.Verify(x => x.TriggerJob(It.IsAny<JobKey>(), It.IsAny<JobDataMap>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task TriggerJobIfNotRunning_PassesTheDataMap()
+        {
+            SetupRunningJobs(_scheduler);
+
+            var triggered = await OmbiQuartz.TriggerJobIfNotRunning("MyJob", "Group",
+                new Dictionary<string, object> { { "RecentlyAddedSearch", "false" } });
+
+            Assert.That(triggered, Is.True);
+            _scheduler.Verify(x => x.TriggerJob(It.Is<JobKey>(j => j.Name == "MyJob" && j.Group == "Group"),
+                It.Is<JobDataMap>(d => (string)d["RecentlyAddedSearch"] == "false"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TriggerJob_DoesNotTriggerWhenJobIsAlreadyRunning()
+        {
+            SetupRunningJobs(_scheduler, "MyJob");
+
+            await OmbiQuartz.TriggerJob("MyJob", "Group");
+
+            _scheduler.Verify(x => x.TriggerJob(It.IsAny<JobKey>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        private static void SetupRunningJobs(Mock<IScheduler> scheduler, params string[] runningJobNames)
+        {
+            var running = new List<IJobExecutionContext>();
+            foreach (var name in runningJobNames)
+            {
+                var jobDetail = new Mock<IJobDetail>();
+                jobDetail.Setup(x => x.Key).Returns(new JobKey(name, "Group"));
+                var context = new Mock<IJobExecutionContext>();
+                context.Setup(x => x.JobDetail).Returns(jobDetail.Object);
+                running.Add(context.Object);
+            }
+
+            scheduler.Setup(x => x.GetCurrentlyExecutingJobs(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(running);
         }
     }
+
     public class QuartzMock : OmbiQuartz
     {
-        public QuartzMock(Mock<IScheduler> mock)
+        public QuartzMock(Mock<IScheduler> mock) : base(false)
         {
             _instance = this;
             _scheduler = mock.Object;

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -79,6 +79,13 @@ namespace Ombi.Schedule.Jobs.Emby
             var processed = 0;
             while (processed < totalTv)
             {
+                if (tv.Items == null || !tv.Items.Any())
+                {
+                    _logger.LogWarning("Emby returned no TV shows at offset {0} but reported {1} total records. Stopping the sync for this library to avoid an infinite loop.",
+                        processed, totalTv);
+                    break;
+                }
+
                 foreach (var tvShow in tv.Items)
                 {
                     processed++;
@@ -161,6 +168,13 @@ namespace Ombi.Schedule.Jobs.Emby
             var mediaToUpdate = new HashSet<EmbyContent>();
             while (processed < totalCount)
             {
+                if (movies.Items == null || !movies.Items.Any())
+                {
+                    _logger.LogWarning("Emby returned no movies at offset {0} but reported {1} total records. Stopping the sync for this library to avoid an infinite loop.",
+                        processed, totalCount);
+                    break;
+                }
+
                 foreach (var movie in movies.Items)
                 {
                     if (movie.Type.Equals("boxset", StringComparison.InvariantCultureIgnoreCase))

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -84,18 +84,26 @@ namespace Ombi.Schedule.Jobs.Emby
             await _notification.SendNotificationToAdmins("Emby Episode Sync Started");
             foreach (var server in settings.Servers)
             {
-                if (server.EmbySelectedLibraries.Any() && server.EmbySelectedLibraries.Any(x => x.Enabled))
+                try
                 {
-                    var tvLibsToFilter = server.EmbySelectedLibraries.Where(x => x.Enabled && x.CollectionType is "tvshows" or "mixed");
-                    foreach (var tvParentIdFilter in tvLibsToFilter)
+                    if (server.EmbySelectedLibraries.Any() && server.EmbySelectedLibraries.Any(x => x.Enabled))
                     {
-                        _logger.LogInformation($"Scanning Lib for episodes '{tvParentIdFilter.Title}'");
-                        await CacheEpisodes(server, recentlyAddedSearch, tvParentIdFilter.Key);
+                        var tvLibsToFilter = server.EmbySelectedLibraries.Where(x => x.Enabled && x.CollectionType is "tvshows" or "mixed");
+                        foreach (var tvParentIdFilter in tvLibsToFilter)
+                        {
+                            _logger.LogInformation($"Scanning Lib for episodes '{tvParentIdFilter.Title}'");
+                            await CacheEpisodes(server, recentlyAddedSearch, tvParentIdFilter.Key);
+                        }
+                    }
+                    else
+                    {
+                        await CacheEpisodes(server, recentlyAddedSearch, string.Empty);
                     }
                 }
-                else
+                catch (Exception e)
                 {
-                    await CacheEpisodes(server, recentlyAddedSearch, string.Empty);
+                    await _notification.SendNotificationToAdmins("Emby Episode Sync Failed");
+                    _logger.LogError(e, "Exception when syncing Emby episodes for server {0}", server.Name);
                 }
             }
 
@@ -141,103 +149,26 @@ namespace Ombi.Schedule.Jobs.Emby
 
             while (processed < total)
             {
+                if (allEpisodes.Items == null || !allEpisodes.Items.Any())
+                {
+                    _logger.LogWarning("Emby returned no episodes at offset {0} but reported {1} total records. Stopping the sync for this library to avoid an infinite loop.",
+                        processed, total);
+                    break;
+                }
+
                 _logger.LogInformation($"Processing chunk {processed}/{total}");
                 // Process episodes in current chunk
                 foreach (var ep in allEpisodes.Items)
                 {
                     processed++;
 
-                    // Check if parent series exists using preloaded HashSet (O(1) lookup)
-                    if (!seriesLookup.Contains(ep.SeriesId))
+                    try
                     {
-                        _logger.LogInformation("The episode {0} does not relate to a series, so we cannot save this",
-                            ep.Name);
-                        continue;
+                        ProcessEpisode(ep, seriesLookup, episodeMetadata, epToAdd, pendingUpdates, episodesInCurrentBatch);
                     }
-
-                    // Create unique key for multi-episode files to prevent duplicates
-                    var episodeKey = $"{ep.Id}_{ep.IndexNumber}_{ep.ParentIndexNumber}";
-
-                    // Check if episode already exists using preloaded metadata (O(1) lookup)
-                    var metadataKey = $"{ep.Id}:{ep.IndexNumber}";
-                    var existingInDatabase = episodeMetadata.ContainsKey(metadataKey);
-                    var existingInCurrentBatch = episodesInCurrentBatch.Contains(episodeKey);
-
-                    if (existingInDatabase)
+                    catch (Exception e)
                     {
-                        // Check if metadata has changed (e.g. Emby re-identified the file)
-                        var existing = episodeMetadata[metadataKey];
-                        if (existing.EpisodeNumber != ep.IndexNumber || existing.SeasonNumber != ep.ParentIndexNumber)
-                        {
-                            _logger.LogInformation("Episode {0} metadata changed (S{1}E{2} -> S{3}E{4}), queuing update",
-                                ep.Name, existing.SeasonNumber, existing.EpisodeNumber, ep.ParentIndexNumber, ep.IndexNumber);
-                            pendingUpdates[metadataKey] = (ep.Id, ep.IndexNumber, ep.ParentIndexNumber);
-                            episodeMetadata[metadataKey] = (ep.IndexNumber, ep.ParentIndexNumber);
-                        }
-                    }
-                    else if (!existingInCurrentBatch)
-                    {
-                        // Sanity checks - skip only true unindexed specials (no episode AND no season number)
-                        if (ep.IndexNumber == 0 && ep.ParentIndexNumber == 0)
-                        {
-                            _logger.LogWarning($"Episode {ep.Name} has no episode or season number. Skipping.");
-                            continue;
-                        }
-
-                        _logger.LogDebug("Adding new episode {0} to parent {1}", ep.Name, ep.SeriesName);
-                        
-                        // add it
-                        epToAdd.Add(new EmbyEpisode
-                        {
-                            EmbyId = ep.Id,
-                            EpisodeNumber = ep.IndexNumber,
-                            SeasonNumber = ep.ParentIndexNumber,
-                            ParentId = ep.SeriesId,
-                            TvDbId = ep.ProviderIds.Tvdb,
-                            TheMovieDbId = ep.ProviderIds.Tmdb,
-                            ImdbId = ep.ProviderIds.Imdb,
-                            Title = ep.Name,
-                            AddedAt = DateTime.UtcNow
-                        });
-                        episodesInCurrentBatch.Add(episodeKey);
-
-                        if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value != ep.IndexNumber)
-                        {
-                            var episodeFillCount = ep.IndexNumberEnd.Value - ep.IndexNumber;
-
-                            if (episodeFillCount > 50)
-                            {
-                                _logger.LogWarning($"Episode {ep.Name} has {episodeFillCount} episodes! Skipping.");
-                                continue;
-                            }
-
-                            int episodeNumber = ep.IndexNumber;
-                            do
-                            {
-                                episodeNumber++;
-                                var multiEpisodeKey = $"{ep.Id}_{episodeNumber}_{ep.ParentIndexNumber}";
-                                
-                                // Check if this multi-episode entry already exists
-                                if (!episodesInCurrentBatch.Contains(multiEpisodeKey))
-                                {
-                                    _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
-                                    epToAdd.Add(new EmbyEpisode
-                                    {
-                                        EmbyId = ep.Id,
-                                        EpisodeNumber = episodeNumber,
-                                        SeasonNumber = ep.ParentIndexNumber,
-                                        ParentId = ep.SeriesId,
-                                        TvDbId = ep.ProviderIds.Tvdb,
-                                        TheMovieDbId = ep.ProviderIds.Tmdb,
-                                        ImdbId = ep.ProviderIds.Imdb,
-                                        Title = ep.Name,
-                                        AddedAt = DateTime.UtcNow
-                                    });
-                                    episodesInCurrentBatch.Add(multiEpisodeKey);
-                                }
-
-                            } while (episodeNumber < ep.IndexNumberEnd.Value);
-                        }
+                        _logger.LogError(e, "Exception when processing episode {0} ({1}), skipping it and continuing with the rest of the sync", ep.Name, ep.Id);
                     }
                 }
 
@@ -299,6 +230,108 @@ namespace Ombi.Schedule.Jobs.Emby
                 }
             }
         }
+        private void ProcessEpisode(
+            EmbyEpisodes ep,
+            HashSet<string> seriesLookup,
+            Dictionary<string, (int EpisodeNumber, int SeasonNumber)> episodeMetadata,
+            HashSet<EmbyEpisode> epToAdd,
+            Dictionary<string, (string EmbyId, int EpisodeNumber, int SeasonNumber)> pendingUpdates,
+            HashSet<string> episodesInCurrentBatch)
+        {
+            // Check if parent series exists using preloaded HashSet (O(1) lookup)
+            if (!seriesLookup.Contains(ep.SeriesId))
+            {
+                _logger.LogInformation("The episode {0} does not relate to a series, so we cannot save this",
+                    ep.Name);
+                return;
+            }
+
+            // Create unique key for multi-episode files to prevent duplicates
+            var episodeKey = $"{ep.Id}_{ep.IndexNumber}_{ep.ParentIndexNumber}";
+
+            // Check if episode already exists using preloaded metadata (O(1) lookup)
+            var metadataKey = $"{ep.Id}:{ep.IndexNumber}";
+            var existingInDatabase = episodeMetadata.ContainsKey(metadataKey);
+            var existingInCurrentBatch = episodesInCurrentBatch.Contains(episodeKey);
+
+            if (existingInDatabase)
+            {
+                // Check if metadata has changed (e.g. Emby re-identified the file)
+                var existing = episodeMetadata[metadataKey];
+                if (existing.EpisodeNumber != ep.IndexNumber || existing.SeasonNumber != ep.ParentIndexNumber)
+                {
+                    _logger.LogInformation("Episode {0} metadata changed (S{1}E{2} -> S{3}E{4}), queuing update",
+                        ep.Name, existing.SeasonNumber, existing.EpisodeNumber, ep.ParentIndexNumber, ep.IndexNumber);
+                    pendingUpdates[metadataKey] = (ep.Id, ep.IndexNumber, ep.ParentIndexNumber);
+                    episodeMetadata[metadataKey] = (ep.IndexNumber, ep.ParentIndexNumber);
+                }
+            }
+            else if (!existingInCurrentBatch)
+            {
+                // Sanity checks - skip only true unindexed specials (no episode AND no season number)
+                if (ep.IndexNumber == 0 && ep.ParentIndexNumber == 0)
+                {
+                    _logger.LogWarning($"Episode {ep.Name} has no episode or season number. Skipping.");
+                    return;
+                }
+
+                _logger.LogDebug("Adding new episode {0} to parent {1}", ep.Name, ep.SeriesName);
+
+                // add it
+                epToAdd.Add(new EmbyEpisode
+                {
+                    EmbyId = ep.Id,
+                    EpisodeNumber = ep.IndexNumber,
+                    SeasonNumber = ep.ParentIndexNumber,
+                    ParentId = ep.SeriesId,
+                    TvDbId = ep.ProviderIds?.Tvdb,
+                    TheMovieDbId = ep.ProviderIds?.Tmdb,
+                    ImdbId = ep.ProviderIds?.Imdb,
+                    Title = ep.Name,
+                    AddedAt = DateTime.UtcNow
+                });
+                episodesInCurrentBatch.Add(episodeKey);
+
+                if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value != ep.IndexNumber)
+                {
+                    var episodeFillCount = ep.IndexNumberEnd.Value - ep.IndexNumber;
+
+                    if (episodeFillCount > 50)
+                    {
+                        _logger.LogWarning($"Episode {ep.Name} has {episodeFillCount} episodes! Skipping.");
+                        return;
+                    }
+
+                    int episodeNumber = ep.IndexNumber;
+                    do
+                    {
+                        episodeNumber++;
+                        var multiEpisodeKey = $"{ep.Id}_{episodeNumber}_{ep.ParentIndexNumber}";
+
+                        // Check if this multi-episode entry already exists
+                        if (!episodesInCurrentBatch.Contains(multiEpisodeKey))
+                        {
+                            _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
+                            epToAdd.Add(new EmbyEpisode
+                            {
+                                EmbyId = ep.Id,
+                                EpisodeNumber = episodeNumber,
+                                SeasonNumber = ep.ParentIndexNumber,
+                                ParentId = ep.SeriesId,
+                                TvDbId = ep.ProviderIds?.Tvdb,
+                                TheMovieDbId = ep.ProviderIds?.Tmdb,
+                                ImdbId = ep.ProviderIds?.Imdb,
+                                Title = ep.Name,
+                                AddedAt = DateTime.UtcNow
+                            });
+                            episodesInCurrentBatch.Add(multiEpisodeKey);
+                        }
+
+                    } while (episodeNumber < ep.IndexNumberEnd.Value);
+                }
+            }
+        }
+
         private async Task<T> FetchEpisodesWithRetry<T>(Func<Task<T>> apiCall, int maxAttempts = 3)
         {
             for (var attempt = 1; attempt <= maxAttempts; attempt++)

--- a/src/Ombi.Schedule/Jobs/Ombi/MediaDatabaseRefresh.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/MediaDatabaseRefresh.cs
@@ -95,7 +95,13 @@ namespace Ombi.Schedule.Jobs.Ombi
                 await _embyRepo.ExecuteSql(episodeSQL);
                 await _embyRepo.ExecuteSql(mainSql);
 
-                await OmbiQuartz.TriggerJob(nameof(IEmbyContentSync), "Emby");
+                var triggered = await OmbiQuartz.TriggerJobIfNotRunning(nameof(IEmbyContentSync), "Emby",
+                    new Dictionary<string, object> { { JobDataKeys.EmbyRecentlyAddedSearch, "false" } });
+                if (!triggered)
+                {
+                    _log.LogWarning(LoggingEvents.MediaReferesh,
+                        "Emby data was cleared but the resync was not triggered because a sync is already running. Trigger the Emby content sync manually once it finishes.");
+                }
             }
             catch (Exception e)
             {
@@ -117,7 +123,12 @@ namespace Ombi.Schedule.Jobs.Ombi
                 await _jellyfinRepo.ExecuteSql(episodeSQL);
                 await _jellyfinRepo.ExecuteSql(mainSql);
 
-                await OmbiQuartz.TriggerJob(nameof(IJellyfinContentSync), "Jellyfin");
+                var triggered = await OmbiQuartz.TriggerJobIfNotRunning(nameof(IJellyfinContentSync), "Jellyfin");
+                if (!triggered)
+                {
+                    _log.LogWarning(LoggingEvents.MediaReferesh,
+                        "Jellyfin data was cleared but the resync was not triggered because a sync is already running. Trigger the Jellyfin content sync manually once it finishes.");
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- Episode sync: wrap each server in try/catch matching the content sync
  pattern, and isolate per-episode processing so a single bad item no
  longer aborts the remaining pages and libraries
- Episode sync: null-safe ProviderIds access when inserting episodes
- Content and episode sync: stop paginating when Emby returns an empty
  page while more records were expected, avoiding an infinite loop
- Clear data and resync: pass an explicit recentlyAdded=false to the
  Emby resync and log a warning when the resync trigger is dropped
  because a sync is already running (Emby and Jellyfin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience of Emby and Jellyfin content syncs to handle empty responses and prevent infinite refetching loops
  * Enhanced error handling during content library scanning with admin notifications when syncs fail
  * Prevented job conflicts by ensuring duplicate sync tasks don't run simultaneously

* **Tests**
  * Added comprehensive test coverage for content synchronisation scenarios and job scheduling behaviour

<!-- end of auto-generated comment: release notes by coderabbit.ai -->