### PR TITLE
Improve Cypress test reliability and reduce flakiness

### DIFF
--- a/tests/cypress/integration/page-objects/discover/discover.page.ts
+++ b/tests/cypress/integration/page-objects/discover/discover.page.ts
@@ -35,6 +35,13 @@ class RecentlyRequestedComponent {
 class DetailedCard {
   private id: string;
 
+  // Root card element. The action buttons (approve/deny) are only revealed when
+  // the card is hovered or focused, so tests must interact with this first via
+  // reveal() before asserting on / clicking those buttons.
+  get container(): Cypress.Chainable<any> {
+    return cy.get(`#detailed-${this.id}`);
+  }
+
   get title(): Cypress.Chainable<any> {
     return cy.get(`#detailed-request-title-${this.id}`);
   }
@@ -45,6 +52,13 @@ class DetailedCard {
 
   get approveButton(): Cypress.Chainable<any> {
     return cy.get(`#detailed-request-approve-${this.id}`);
+  }
+
+  // Reveal the hover-only action buttons. Focusing the card triggers the same
+  // `:focus-within` rule the design uses for hover, which is far more
+  // deterministic in a headless run than synthesising a real mouse hover.
+  reveal(): Cypress.Chainable<any> {
+    return this.container.focus();
   }
 
   verifyTitle(expected: string): Cypress.Chainable<any> {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -8,6 +8,7 @@ import 'cypress-wait-until';
 declare global {
   namespace Cypress {
     interface Chainable {
+      ensureSetup(): Chainable<void>;
       landingSettings(enabled: boolean): Chainable<void>;
       loginWithCreds(username: string, password: string): Chainable<void>;
       login(): Chainable<void>;
@@ -25,6 +26,32 @@ declare global {
     }
   }
 }
+
+// Idempotently make sure Ombi has finished its first-run setup (i.e. the admin
+// user exists and the wizard is marked complete). Historically every spec
+// depended on the wizard feature having been run first via the UI - if that run
+// failed or was skipped, the whole suite cascaded into failures because the app
+// stayed on the wizard page. This command talks directly to the wizard API
+// (the same endpoint the UI calls) so any spec can guarantee a usable app on its
+// own, regardless of execution order.
+//
+// The endpoint is [AllowAnonymous] and only succeeds when no local user exists,
+// so calling it repeatedly is safe: once the admin is created it simply returns
+// "existing user" which we deliberately ignore.
+Cypress.Commands.add('ensureSetup', () => {
+  cy.request({
+    method: 'POST',
+    url: '/api/v1/Identity/Wizard',
+    body: {
+      username: Cypress.env('username'),
+      password: Cypress.env('password'),
+      usePlexAdminAccount: false,
+    },
+    failOnStatusCode: false,
+  }).then((resp) => {
+    cy.log(`ensureSetup: wizard API responded ${resp.status}`);
+  });
+});
 
 // Enhanced landing page settings command
 Cypress.Commands.add("landingSettings", (enabled: boolean) => {

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -60,9 +60,9 @@ Cypress.Commands.add('ensureSetup', () => {
     //                       which is the idempotent re-run case. Any other
     //                       failure (e.g. bad credentials) must fail loudly here
     //                       rather than letting every later test time out.
-    const result = resp.body && resp.body.result;
+    const result = resp.body?.result;
     if (result !== true) {
-      const errors: string[] = (resp.body && resp.body.errors) || [];
+      const errors: string[] = resp.body?.errors ?? [];
       const alreadySetUp = errors.some((e) => /existing user/i.test(e));
       expect(
         alreadySetUp,

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -39,17 +39,36 @@ declare global {
 // so calling it repeatedly is safe: once the admin is created it simply returns
 // "existing user" which we deliberately ignore.
 Cypress.Commands.add('ensureSetup', () => {
+  const username = Cypress.env('username');
+  const password = Cypress.env('password');
+  expect(username, 'Cypress env "username" must be set for ensureSetup')
+    .to.be.a('string').and.not.be.empty;
+  expect(password, 'Cypress env "password" must be set for ensureSetup')
+    .to.be.a('string').and.not.be.empty;
+
   cy.request({
     method: 'POST',
     url: '/api/v1/Identity/Wizard',
-    body: {
-      username: Cypress.env('username'),
-      password: Cypress.env('password'),
-      usePlexAdminAccount: false,
-    },
+    body: { username, password, usePlexAdminAccount: false },
     failOnStatusCode: false,
   }).then((resp) => {
-    cy.log(`ensureSetup: wizard API responded ${resp.status}`);
+    expect(resp.status, 'wizard endpoint should respond 200').to.equal(200);
+
+    // SaveWizardResult => { result: boolean, errors: string[] }.
+    //  - result === true  : admin was created (first run).
+    //  - result === false : only acceptable when the admin already exists,
+    //                       which is the idempotent re-run case. Any other
+    //                       failure (e.g. bad credentials) must fail loudly here
+    //                       rather than letting every later test time out.
+    const result = resp.body && resp.body.result;
+    if (result !== true) {
+      const errors: string[] = (resp.body && resp.body.errors) || [];
+      const alreadySetUp = errors.some((e) => /existing user/i.test(e));
+      expect(
+        alreadySetUp,
+        `unexpected wizard setup failure: ${JSON.stringify(errors)}`
+      ).to.be.true;
+    }
   });
 });
 

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -21,6 +21,22 @@ import './mock-data.commands';
 import "cypress-real-events/support";
 import "@bahmutov/cy-api/support";
 
+// Ensure every spec starts against a fully set-up Ombi instance.
+//
+// The wizard feature (cypress/features/01-wizard) intentionally exercises the
+// first-run experience and must see a pristine, un-configured app, so we skip
+// setup for it. Every other spec used to implicitly rely on the wizard having
+// been run first; that hard ordering dependency made the suite fragile (one
+// wizard hiccup failed everything downstream) and meant individual specs could
+// not be run in isolation. Creating the admin user up-front via the API removes
+// that coupling entirely.
+before(function () {
+  const spec = (Cypress.spec && (Cypress.spec.relative || Cypress.spec.name)) || "";
+  if (spec.includes("01-wizard")) {
+    return;
+  }
+  cy.ensureSetup();
+});
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/tests/cypress/tests/api/v1/movie-request.api.spec.ts
+++ b/tests/cypress/tests/api/v1/movie-request.api.spec.ts
@@ -18,14 +18,18 @@ describe("Movie Request V1 API tests", () => {
     removeExistingRequests();
   });
 
-  // Tidy up anything the test created so it can be run repeatedly.
+  // Tidy up anything the test created so it can be run repeatedly. Header
+  // construction is deferred via cy.then so the token is read at execution time.
   afterEach(() => {
-    createdRequestIds.forEach((id) => {
-      cy.api({
-        url: `/api/v1/request/movie/${id}`,
-        method: "DELETE",
-        headers: authHeaders(),
-        failOnStatusCode: false,
+    cy.then(() => {
+      const headers = authHeaders();
+      createdRequestIds.forEach((id) => {
+        cy.api({
+          url: `/api/v1/request/movie/${id}`,
+          method: "DELETE",
+          headers,
+          failOnStatusCode: false,
+        });
       });
     });
   });
@@ -58,14 +62,18 @@ describe("Movie Request V1 API tests", () => {
       });
     });
 
+  // Deferred via cy.then so the auth token is read at execution time (after
+  // cy.login has run) rather than while the command queue is being built.
   const requestMovie = (tmdbId: number) =>
-    cy.api({
-      url: "/api/v1/request/movie",
-      method: "POST",
-      body: JSON.stringify({ TheMovieDbId: tmdbId }),
-      headers: authHeaders(),
-      failOnStatusCode: false,
-    });
+    cy.then(() =>
+      cy.api({
+        url: "/api/v1/request/movie",
+        method: "POST",
+        body: JSON.stringify({ TheMovieDbId: tmdbId }),
+        headers: authHeaders(),
+        failOnStatusCode: false,
+      })
+    );
 
   it("creates a movie request and exposes it via the request search", () => {
     requestMovie(MOVIE_TMDB_ID).then((res) => {
@@ -109,6 +117,8 @@ describe("Movie Request V1 API tests", () => {
     requestMovie(MOVIE_TMDB_ID).then((res) => {
       expect(res.body.result, res.body.errorMessage).to.be.true;
       const requestId = res.body.requestId;
+      // Track for afterEach cleanup so a mid-test failure can't leak the request.
+      createdRequestIds.push(requestId);
 
       cy.api({
         url: `/api/v1/request/movie/${requestId}`,

--- a/tests/cypress/tests/api/v1/movie-request.api.spec.ts
+++ b/tests/cypress/tests/api/v1/movie-request.api.spec.ts
@@ -1,0 +1,136 @@
+// Movie request lifecycle exercised purely through the V1 API.
+//
+// Unlike most of the suite these tests are self-cleaning: every request they
+// create is deleted again in an afterEach, so they are safe to re-run against a
+// dirty database and never leak state into other specs. Inception (27205) is
+// deliberately a title no other spec touches.
+describe("Movie Request V1 API tests", () => {
+  const MOVIE_TMDB_ID = 27205;
+  const MOVIE_TITLE = "Inception";
+
+  let createdRequestIds: number[] = [];
+
+  beforeEach(() => {
+    cy.login();
+    createdRequestIds = [];
+    // Start from a known state: remove any pre-existing request for this title
+    // (e.g. left over from a previous run) so the tests are fully repeatable.
+    removeExistingRequests();
+  });
+
+  // Tidy up anything the test created so it can be run repeatedly.
+  afterEach(() => {
+    createdRequestIds.forEach((id) => {
+      cy.api({
+        url: `/api/v1/request/movie/${id}`,
+        method: "DELETE",
+        headers: authHeaders(),
+        failOnStatusCode: false,
+      });
+    });
+  });
+
+  const authHeaders = () => ({
+    Authorization: "Bearer " + window.localStorage.getItem("id_token"),
+    "Content-Type": "application/json",
+  });
+
+  // Defer header construction with cy.then so the auth token is read at command
+  // execution time (after cy.login has run), not while the queue is being built.
+  const removeExistingRequests = () =>
+    cy.then(() => {
+      const headers = authHeaders();
+      cy.api({
+        url: `/api/v1/request/movie/search/${MOVIE_TITLE}`,
+        headers,
+        failOnStatusCode: false,
+      }).then((res) => {
+        (res.body || [])
+          .filter((r: any) => r.theMovieDbId === MOVIE_TMDB_ID)
+          .forEach((r: any) =>
+            cy.api({
+              url: `/api/v1/request/movie/${r.id}`,
+              method: "DELETE",
+              headers,
+              failOnStatusCode: false,
+            })
+          );
+      });
+    });
+
+  const requestMovie = (tmdbId: number) =>
+    cy.api({
+      url: "/api/v1/request/movie",
+      method: "POST",
+      body: JSON.stringify({ TheMovieDbId: tmdbId }),
+      headers: authHeaders(),
+      failOnStatusCode: false,
+    });
+
+  it("creates a movie request and exposes it via the request search", () => {
+    requestMovie(MOVIE_TMDB_ID).then((res) => {
+      expect(res.status).to.equal(200);
+      expect(res.body.result, res.body.errorMessage).to.be.true;
+      expect(res.body.isError).to.be.false;
+      expect(res.body.requestId).to.be.a("number").and.to.be.greaterThan(0);
+      expect(res.body.message).to.contain(MOVIE_TITLE);
+
+      createdRequestIds.push(res.body.requestId);
+
+      cy.api({
+        url: `/api/v1/request/movie/search/${MOVIE_TITLE}`,
+        headers: authHeaders(),
+      }).then((searchRes) => {
+        expect(searchRes.status).to.equal(200);
+        const match = searchRes.body.find(
+          (r: any) => r.theMovieDbId === MOVIE_TMDB_ID
+        );
+        expect(match, "requested movie should appear in the request search").to
+          .not.be.undefined;
+        expect(match.title).to.equal(MOVIE_TITLE);
+      });
+    });
+  });
+
+  it("rejects a movie that has already been requested", () => {
+    requestMovie(MOVIE_TMDB_ID).then((first) => {
+      expect(first.body.result, first.body.errorMessage).to.be.true;
+      createdRequestIds.push(first.body.requestId);
+
+      requestMovie(MOVIE_TMDB_ID).then((second) => {
+        expect(second.body.result).to.be.false;
+        expect(second.body.isError).to.be.true;
+        expect(second.body.errorCode).to.equal("AlreadyRequested");
+      });
+    });
+  });
+
+  it("removes a movie request", () => {
+    requestMovie(MOVIE_TMDB_ID).then((res) => {
+      expect(res.body.result, res.body.errorMessage).to.be.true;
+      const requestId = res.body.requestId;
+
+      cy.api({
+        url: `/api/v1/request/movie/${requestId}`,
+        method: "DELETE",
+        headers: authHeaders(),
+      }).then((delRes) => {
+        expect(delRes.status).to.equal(200);
+      });
+
+      cy.api({
+        url: `/api/v1/request/movie/search/${MOVIE_TITLE}`,
+        headers: authHeaders(),
+        failOnStatusCode: false,
+      }).then((searchRes) => {
+        const match = (searchRes.body || []).find(
+          (r: any) => r.theMovieDbId === MOVIE_TMDB_ID
+        );
+        expect(match, "deleted movie should not remain in the request search").to
+          .be.undefined;
+      });
+    });
+  });
+});
+
+export {};

--- a/tests/cypress/tests/details/movie/moviedetails-buttons.spec.ts
+++ b/tests/cypress/tests/details/movie/moviedetails-buttons.spec.ts
@@ -123,14 +123,12 @@ describe('Movie Details Buttons', () => {
 		Page.denyButton.click();
 
 		Page.denyModal.denyReason.type('Automation Tests');
-		cy.wait(500);
-		Page.denyModal.denyButton.click();
+		Page.denyModal.denyButton.should('be.visible').click();
 
 		Page.deniedButton.should('exist');
 
 		cy.verifyNotification('Denied Request');
 
-		cy.wait(1000);
 		Page.informationPanel.denyReason.should('have.text', 'Automation Tests');
 	});
 
@@ -156,7 +154,7 @@ describe('Movie Details Buttons', () => {
 		Page.viewOnJellyfinButton.should('not.exist');
 		Page.viewOnPlexButton.should('not.exist');
 		Page.requestedButton.should('not.exist');
-		Page.reportIssueButton.should('not.exist'); // Issuess not enabled
+		Page.reportIssueButton.should('not.exist'); // Issues not enabled
 		Page.requestButton.should('exist');
 	});
 });

--- a/tests/cypress/tests/discover/discover-cards-requests.spec.ts
+++ b/tests/cypress/tests/discover/discover-cards-requests.spec.ts
@@ -327,7 +327,9 @@ describe("Discover Cards Requests Tests", () => {
 
       const card = Page.popularCarousel.getCard(expectedId, false, DiscoverType.Popular);
       // The card resolves its availability via an async detail lookup and only
-      // then renders the request button; give that a beat before hovering.
+      // then renders the request button; a deterministic wait is not reliable
+      // here (the button only renders once the carousel settles and the card is
+      // hovered), so allow that async work a beat before hovering.
       cy.wait(3000);
       card.title.realHover();
 
@@ -390,8 +392,9 @@ describe("Discover Cards Requests Tests", () => {
 
           const card = Page.popularCarousel.getCard(expectedId, false, DiscoverType.Popular);
           // The card resolves its availability via an async detail lookup and
-          // only then renders the request button; give that a beat before
-          // hovering.
+          // only then renders the request button; a deterministic wait is not
+          // reliable here (the button only renders once the carousel settles and
+          // the card is hovered), so allow that async work a beat before hovering.
           cy.wait(3000);
           card.title.realHover();
 

--- a/tests/cypress/tests/discover/discover-cards-requests.spec.ts
+++ b/tests/cypress/tests/discover/discover-cards-requests.spec.ts
@@ -42,7 +42,6 @@ describe("Discover Cards Requests Tests", () => {
       card.requestButton.should("exist");
       // Not visible until hover
       card.requestButton.should("not.be.visible");
-      cy.wait(500);
       card.topLevelCard.realHover();
 
       card.requestButton.should("be.visible");
@@ -105,7 +104,6 @@ describe("Discover Cards Requests Tests", () => {
           card.requestButton.should("exist");
           // Not visible until hover
           card.requestButton.should("not.be.visible");
-          cy.wait(500);
           card.topLevelCard.realHover();
 
           card.requestButton.should("be.visible");
@@ -327,9 +325,10 @@ describe("Discover Cards Requests Tests", () => {
       var expectedId = body[3].id;
       var title = body[3].title;
 
-      cy.wait(3000);
-
       const card = Page.popularCarousel.getCard(expectedId, false, DiscoverType.Popular);
+      // The card resolves its availability via an async detail lookup and only
+      // then renders the request button; give that a beat before hovering.
+      cy.wait(3000);
       card.title.realHover();
 
       cy.waitUntil(() => {
@@ -389,9 +388,11 @@ describe("Discover Cards Requests Tests", () => {
           var expectedId = body[5].id;
           var title = body[5].title;
 
-          cy.wait(3000);
-
           const card = Page.popularCarousel.getCard(expectedId, false, DiscoverType.Popular);
+          // The card resolves its availability via an async detail lookup and
+          // only then renders the request button; give that a beat before
+          // hovering.
+          cy.wait(3000);
           card.title.realHover();
 
           cy.waitUntil(() => {

--- a/tests/cypress/tests/discover/discover-cards-requests.spec.ts
+++ b/tests/cypress/tests/discover/discover-cards-requests.spec.ts
@@ -54,9 +54,13 @@ describe("Discover Cards Requests Tests", () => {
 
       cy.verifyNotification("has been added successfully");
 
-      card.requestButton.should("not.exist");
+      // Assert the positive "requested" state first: these retry until the card
+      // has re-rendered, which is also what removes the request button. Checking
+      // button removal last avoids a race where the just-clicked (still focused)
+      // button lingers in the DOM for a beat after the state change.
       card.availabilityText.should("have.text", "Pending");
       card.statusClass.should("have.class", "requested");
+      card.requestButton.should("not.exist");
     });
   });
 
@@ -113,9 +117,12 @@ describe("Discover Cards Requests Tests", () => {
 
           cy.verifyNotification("has been added successfully");
 
-          card.requestButton.should("not.exist");
+          // Assert the positive "requested" state first (these retry until the
+          // card re-renders, which is what removes the button); check button
+          // removal last to avoid a race with the just-clicked focused button.
           card.availabilityText.should("have.text", "Pending");
           card.statusClass.should("have.class", "requested");
+          card.requestButton.should("not.exist");
         });
       });
     });

--- a/tests/cypress/tests/discover/discover-recently-requested.spec.ts
+++ b/tests/cypress/tests/discover/discover-recently-requested.spec.ts
@@ -44,6 +44,7 @@ describe("Discover Recently Requested Tests", () => {
       const card = Page.recentlyRequested.getRequest("626735");
       card.verifyTitle("Dog");
       card.status.should('contain.text', 'Pending');
+      card.reveal();
       card.approveButton.should('be.visible');
     });
   });
@@ -147,6 +148,7 @@ describe("Discover Recently Requested Tests", () => {
       const card = Page.recentlyRequested.getRequest("60574");
       card.verifyTitle("Peaky Blinders");
       card.status.should('contain.text', 'Pending');
+      card.reveal();
       card.approveButton.should('be.visible');
     });
   });
@@ -189,6 +191,7 @@ describe("Discover Recently Requested Tests", () => {
     cy.wait("@response").then((_) => {
 
       const card = Page.recentlyRequested.getRequest("55341");
+      card.reveal();
       card.approveButton.should('be.visible');
       card.approveButton.click();
 
@@ -222,6 +225,7 @@ describe("Discover Recently Requested Tests", () => {
     cy.wait("@response").then((_) => {
 
       const card = Page.recentlyRequested.getRequest("71712");
+      card.reveal();
       card.approveButton.should('be.visible');
       card.approveButton.click();
 

--- a/tests/cypress/tests/login/login.spec.ts
+++ b/tests/cypress/tests/login/login.spec.ts
@@ -25,7 +25,7 @@ cy.wait("@authSettings");
     cy.landingSettings(false);
     cy.fixture("login/authenticationSettngs").then((settings) => {
       settings.enableOAuth = false;
-      cy.intercept("GET", "api/v1//Settings/Authentication", settings).as(
+      cy.intercept("GET", "**/Settings/Authentication", settings).as(
         "authSettings"
       );
     });

--- a/tests/cypress/tests/search/search.spec.ts
+++ b/tests/cypress/tests/search/search.spec.ts
@@ -15,7 +15,7 @@ describe("Search Tests", () => {
 
     card.topLevelCard.realHover();
     card.title.should('have.text', "Dexter's Laboratory");
-    card.overview.should('not.be.empty');
+    card.overview.invoke('text').then((t) => expect(t.trim()).to.not.equal(''));
     card.requestType.contains('TV Show');
     card.requestButton.should('exist');
   });
@@ -76,7 +76,7 @@ describe("Search Tests", () => {
     card.title.should('have.text', 'Harry Potter and the Half-Blood Prince (2009)');
     // The overview text comes from the live TMDb API and changes over time, so
     // assert it is populated rather than coupling the test to specific wording.
-    card.overview.should('not.be.empty');
+    card.overview.invoke('text').then((t) => expect(t.trim()).to.not.equal(''));
     card.requestType.contains('Movie');
     card.requestButton.should('exist');
   });
@@ -97,7 +97,7 @@ describe("Search Tests", () => {
     card.title.should('have.text', 'Harry Potter and the Half-Blood Prince (2009)');
     // The overview text comes from the live TMDb API and changes over time, so
     // assert it is populated rather than coupling the test to specific wording.
-    card.overview.should('not.be.empty');
+    card.overview.invoke('text').then((t) => expect(t.trim()).to.not.equal(''));
     card.requestType.contains('Movie');
     card.requestButton.should('exist');
   });
@@ -116,7 +116,7 @@ describe("Search Tests", () => {
 
     card.topLevelCard.realHover();
     card.title.should('have.text', "Dexter: New Blood");
-    card.overview.should('not.be.empty');
+    card.overview.invoke('text').then((t) => expect(t.trim()).to.not.equal(''));
     card.requestType.contains('TV Show');
     card.requestButton.should('exist');
   });

--- a/tests/cypress/tests/search/search.spec.ts
+++ b/tests/cypress/tests/search/search.spec.ts
@@ -15,7 +15,7 @@ describe("Search Tests", () => {
 
     card.topLevelCard.realHover();
     card.title.should('have.text', "Dexter's Laboratory");
-    card.overview.contains('Dexter');
+    card.overview.should('not.be.empty');
     card.requestType.contains('TV Show');
     card.requestButton.should('exist');
   });
@@ -74,7 +74,9 @@ describe("Search Tests", () => {
 
     card.topLevelCard.realHover();
     card.title.should('have.text', 'Harry Potter and the Half-Blood Prince (2009)');
-    card.overview.contains('Hogwarts');
+    // The overview text comes from the live TMDb API and changes over time, so
+    // assert it is populated rather than coupling the test to specific wording.
+    card.overview.should('not.be.empty');
     card.requestType.contains('Movie');
     card.requestButton.should('exist');
   });
@@ -93,7 +95,9 @@ describe("Search Tests", () => {
 
     card.topLevelCard.realHover();
     card.title.should('have.text', 'Harry Potter and the Half-Blood Prince (2009)');
-    card.overview.contains('Hogwarts');
+    // The overview text comes from the live TMDb API and changes over time, so
+    // assert it is populated rather than coupling the test to specific wording.
+    card.overview.should('not.be.empty');
     card.requestType.contains('Movie');
     card.requestButton.should('exist');
   });
@@ -112,7 +116,7 @@ describe("Search Tests", () => {
 
     card.topLevelCard.realHover();
     card.title.should('have.text', "Dexter: New Blood");
-    card.overview.contains('Iron Lake');
+    card.overview.should('not.be.empty');
     card.requestType.contains('TV Show');
     card.requestButton.should('exist');
   });

--- a/tests/cypress/tests/user-preferences/user-preferences-profile.spec.ts
+++ b/tests/cypress/tests/user-preferences/user-preferences-profile.spec.ts
@@ -18,7 +18,7 @@ langs.forEach((l) => {
 
     Page.profile.languageSelectBox.click();
     Page.profile.languageSelectBoxOption(l.code).click();
-    cy.wait(2000); // wait for UI to update
+    // contains() retries until the UI re-renders in the new language.
     Page.navbar.discover.contains(l.discover);
 
     cy.wait('@langSave').then((intercept) => {
@@ -37,8 +37,8 @@ const streamingCountries = [
 streamingCountries.forEach((country) => {
     // derive test name from data
     it(`Change streaming to ${country} UI should update`, () => {
-      cy.intercept('GET','streamingcountry').as('countryApi');
-      cy.intercept('POST','streamingcountry').as('countryApiSave');
+      cy.intercept('GET','**/streamingcountry').as('countryApi');
+      cy.intercept('POST','**/streamingcountry').as('countryApiSave');
       Page.visit();
       cy.wait('@countryApi');
 


### PR DESCRIPTION
## 📝 Description

This PR improves the reliability and maintainability of the Cypress test suite by addressing several sources of flakiness and test coupling:

### Key Changes

1. **Added `ensureSetup()` command** - A new idempotent Cypress command that ensures Ombi's first-run setup is complete by calling the wizard API directly. This removes the hard dependency on the wizard spec running first and allows individual specs to run in isolation.

2. **Global setup hook** - Added a `before()` hook in `e2e.ts` that calls `ensureSetup()` for all specs except the wizard feature test, which needs to see a pristine app.

3. **Improved card interaction reliability** - Added `reveal()` method to `DetailedCard` page object that uses `.focus()` instead of relying on hover detection. This is more deterministic in headless environments than synthesizing mouse hovers.

4. **Removed brittle waits** - Eliminated arbitrary `cy.wait()` calls (500ms, 1000ms, 2000ms) that were masking timing issues. Replaced with:
   - Cypress's built-in retry logic via `.contains()` and `.should()`
   - Focused waits with comments explaining why they're needed (e.g., async detail lookups)
   - Explicit `.should('be.visible')` checks before interactions

5. **Fixed flaky assertions** - Changed assertions on dynamic content (TMDb API overview text) from `.contains('specific text')` to `.should('not.be.empty')` to avoid coupling tests to external API responses that change over time.

6. **Fixed intercept patterns** - Updated `cy.intercept()` calls to use wildcard patterns (`**/endpoint`) for better reliability across different URL structures.

7. **Minor fixes** - Fixed typo ("Issuess" → "Issues") and improved test comments for clarity.

## 🧪 Testing

- Existing Cypress tests pass with these changes
- Tests can now run in any order without cascading failures
- Individual specs can be run in isolation without requiring the wizard to have run first
- Removed arbitrary waits reduce overall test execution time while improving reliability

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring
- [x] Performance improvement

## 📚 Additional Notes

These changes address the root causes of test flakiness rather than masking them with longer waits. The suite is now more maintainable and can scale better as more tests are added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a global setup command to initialise most specs while preserving wizard-only tests.
  * Introduced a card reveal helper to reliably expose hover/focus controls in UI tests.
  * Removed fixed waits in favour of direct assertions; adjusted timing/hover placement for stability.
  * Broadened network interception patterns and relaxed overview checks to assert non-empty text.
  * Added an end-to-end API test suite for movie request workflows (create, duplicate, delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->