### PR TITLE
fix(watchlist): only prune Plex watchlist history on a complete sync

### DIFF
--- a/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
+++ b/src/Ombi.Schedule.Tests/PlexWatchlistImportTests.cs
@@ -625,6 +625,81 @@ namespace Ombi.Schedule.Tests
             _mocker.Verify<Core.Authentication.OmbiUserManager>(x => x.CreateAsync(It.IsAny<OmbiUser>()), Times.Never);
         }
 
+        [Test]
+        public async Task EmptyWatchlist_DoesNotPurgeExistingHistory()
+        {
+            // A transient empty response from the community API must not wipe history,
+            // otherwise every title is treated as new next run and re-requested, re-monitoring
+            // and re-grabbing episodes the user has intentionally removed (issue #5427).
+            UseDefaultPlexSettings();
+            SetupHistory(new PlexWatchlistHistory { TmdbId = "500", UserId = AdminOmbiId });
+            // The default watchlist mock returns zero nodes.
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IExternalRepository<PlexWatchlistHistory>>(x => x.Delete(It.IsAny<PlexWatchlistHistory>()), Times.Never);
+        }
+
+        [Test]
+        public async Task PartiallyResolvedWatchlist_DoesNotPurgeStaleHistory()
+        {
+            // One title resolves, another can't be resolved to a TMDB id this run. The snapshot
+            // is incomplete, so even with a non-empty current set we must not prune history -
+            // the "missing" title may simply have failed metadata resolution this run.
+            UseDefaultPlexSettings();
+            SetupWatchlistNodes(AdminUuid, ("movie", "rk-ok"), ("movie", "rk-unresolved"));
+            SetupMetadataWithTmdb("rk-ok", "tmdb://77");
+            // rk-unresolved has no metadata mock, so it resolves to no provider ids.
+            SetupHistory(new PlexWatchlistHistory { TmdbId = "999", UserId = AdminOmbiId });
+
+            _mocker.Setup<IMovieRequestEngine, Task<RequestEngineResult>>(x => x.RequestMovie(It.IsAny<MovieRequestViewModel>()))
+                .ReturnsAsync(new RequestEngineResult { Result = true });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IExternalRepository<PlexWatchlistHistory>>(x => x.Delete(It.IsAny<PlexWatchlistHistory>()), Times.Never);
+        }
+
+        [Test]
+        public async Task CompleteWatchlist_PurgesStaleHistory()
+        {
+            // A fully-resolved snapshot is authoritative: history rows for titles no longer on
+            // the watchlist should be removed so they can be re-requested if re-added later.
+            UseDefaultPlexSettings();
+            SetupWatchlistNode(AdminUuid, "movie", "rk-ok");
+            SetupMetadataWithTmdb("rk-ok", "tmdb://77");
+            SetupHistory(new PlexWatchlistHistory { TmdbId = "999", UserId = AdminOmbiId });
+
+            _mocker.Setup<IMovieRequestEngine, Task<RequestEngineResult>>(x => x.RequestMovie(It.IsAny<MovieRequestViewModel>()))
+                .ReturnsAsync(new RequestEngineResult { Result = true });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IExternalRepository<PlexWatchlistHistory>>(x => x.Delete(It.Is<PlexWatchlistHistory>(h => h.TmdbId == "999")), Times.Once);
+        }
+
+        [Test]
+        public async Task TitleAlreadyInHistory_IsNotReRequested()
+        {
+            // The core guarantee: a title already imported and still on the watchlist is
+            // skipped, so it's never re-requested and we never re-monitor removed episodes.
+            UseDefaultPlexSettings();
+            SetupWatchlistNode(AdminUuid, "movie", "rk-ok");
+            SetupMetadataWithTmdb("rk-ok", "tmdb://77");
+            SetupHistory(new PlexWatchlistHistory { TmdbId = "77", UserId = AdminOmbiId });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IMovieRequestEngine>(x => x.RequestMovie(It.IsAny<MovieRequestViewModel>()), Times.Never);
+            _mocker.Verify<IExternalRepository<PlexWatchlistHistory>>(x => x.Delete(It.IsAny<PlexWatchlistHistory>()), Times.Never);
+        }
+
+        private void SetupHistory(params PlexWatchlistHistory[] entries)
+        {
+            _mocker.Setup<IExternalRepository<PlexWatchlistHistory>, IQueryable<PlexWatchlistHistory>>(x => x.GetAll())
+                .Returns(entries.ToList().AsQueryable().BuildMock());
+        }
+
         private static void SetupAdminRole(Mock<OmbiUserManager> mgr, string adminUserId)
         {
             mgr.Setup(x => x.IsInRoleAsync(It.Is<OmbiUser>(u => u.Id == adminUserId), OmbiRoles.Admin))
@@ -669,6 +744,25 @@ namespace Ombi.Schedule.Tests
                             watchlist = new PlexCommunityWatchlist
                             {
                                 nodes = new List<PlexCommunityWatchlistNode> { new PlexCommunityWatchlistNode { id = ratingKey, title = "Test", type = type } },
+                                pageInfo = new PlexCommunityPageInfo { hasNextPage = false },
+                            }
+                        }
+                    }
+                });
+        }
+
+        private void SetupWatchlistNodes(string ownerId, params (string type, string ratingKey)[] nodes)
+        {
+            _mocker.Setup<IPlexApi, Task<PlexCommunityWatchlistResponse>>(x => x.GetWatchlistForUser(AdminToken, ownerId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlexCommunityWatchlistResponse
+                {
+                    data = new PlexCommunityWatchlistData
+                    {
+                        userV2 = new PlexCommunityUserV2
+                        {
+                            watchlist = new PlexCommunityWatchlist
+                            {
+                                nodes = nodes.Select(n => new PlexCommunityWatchlistNode { id = n.ratingKey, title = "Test", type = n.type }).ToList(),
                                 pageInfo = new PlexCommunityPageInfo { hasNextPage = false },
                             }
                         }

--- a/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
+++ b/src/Ombi.Schedule/Jobs/Plex/PlexWatchlistImport.cs
@@ -497,6 +497,15 @@ namespace Ombi.Schedule.Jobs.Plex
             var seenCursors = new HashSet<string>();
             var pageCount = 0;
 
+            // Tracks whether we obtained a complete, trustworthy snapshot of the watchlist
+            // this run. Only an authoritative snapshot may be used to prune history: if any
+            // page bailed out, an item couldn't be resolved to a TMDB id, or the run was
+            // cancelled, the set of "current" ids is partial and pruning against it would
+            // delete history rows for titles that are still watchlisted. Those titles would
+            // then look brand-new on the next run and be re-requested, re-monitoring and
+            // re-grabbing content the user has intentionally removed (issue #5427).
+            var snapshotComplete = true;
+
             do
             {
                 pageCount++;
@@ -504,12 +513,14 @@ namespace Ombi.Schedule.Jobs.Plex
                 {
                     _logger.LogWarning("Watchlist for '{User}' exceeded {Max} pages; stopping to avoid an infinite loop",
                         plexUser.username, MaxWatchlistPages);
+                    snapshotComplete = false;
                     break;
                 }
                 if (!string.IsNullOrEmpty(cursor) && !seenCursors.Add(cursor))
                 {
                     _logger.LogWarning("Plex community API returned a repeated pagination cursor for '{User}'; stopping",
                         plexUser.username);
+                    snapshotComplete = false;
                     break;
                 }
 
@@ -533,6 +544,9 @@ namespace Ombi.Schedule.Jobs.Plex
                         if (string.IsNullOrEmpty(alt))
                         {
                             _logger.LogWarning($"No TheMovieDb Id found for {node.title} for user {user.UserName}, skipping");
+                            // We can't confirm this title's identity this run, so the snapshot
+                            // is incomplete and must not be used to prune history.
+                            snapshotComplete = false;
                             continue;
                         }
                         ids.TheMovieDb = alt;
@@ -546,17 +560,34 @@ namespace Ombi.Schedule.Jobs.Plex
             }
             while (!string.IsNullOrEmpty(cursor) && !ct.IsCancellationRequested);
 
-            // Always purge history for items no longer on the user's Plex watchlist
-            // (including when the watchlist has been fully cleared).
+            if (ct.IsCancellationRequested)
+            {
+                snapshotComplete = false;
+            }
+
             var historyEntries = await _watchlistRepo.GetAll().Where(x => x.UserId == user.Id).ToListAsync(ct);
             var existingTmdbIds = new HashSet<string>(historyEntries.Select(h => h.TmdbId));
-            foreach (var entry in historyEntries)
+
+            // Purge history for titles no longer on the user's watchlist, but only when we
+            // have a complete snapshot AND it actually resolved at least one title. An empty
+            // or partial result is far more likely to be a transient community-API hiccup
+            // than a genuinely cleared watchlist; pruning against it would re-request titles
+            // the user already has (issue #5427). A stale history row is harmless — it just
+            // stops that title being re-requested — so we err on the side of keeping it.
+            if (snapshotComplete && currentWatchlistTmdbIds.Count > 0)
             {
-                if (!currentWatchlistTmdbIds.Contains(entry.TmdbId))
+                foreach (var entry in historyEntries)
                 {
-                    _logger.LogDebug($"Removing old history entry for TMDB ID {entry.TmdbId} (no longer in Plex watchlist for {user.UserName})");
-                    await _watchlistRepo.Delete(entry);
+                    if (!currentWatchlistTmdbIds.Contains(entry.TmdbId))
+                    {
+                        _logger.LogDebug($"Removing old history entry for TMDB ID {entry.TmdbId} (no longer in Plex watchlist for {user.UserName})");
+                        await _watchlistRepo.Delete(entry);
+                    }
                 }
+            }
+            else if (historyEntries.Count > 0)
+            {
+                _logger.LogWarning("Skipping watchlist history cleanup for '{User}' because this sync did not return a complete watchlist snapshot; existing history is preserved and will be re-checked next run", user.UserName);
             }
 
             foreach (var (node, ids) in pendingItems)


### PR DESCRIPTION
## Summary

Fixes the Plex watchlist importer re-requesting shows that had already been satisfied, which caused Sonarr to re-monitor and re-grab episodes the user had watched and intentionally removed. Reported in #5427.

## Root cause

The "import once" guarantee is implemented by `PlexWatchlistHistory`: a title on the watchlist is only requested once because already-imported titles are skipped. The community-API importer prunes that history on every run by comparing it against whatever the sync happened to resolve.

The problem is the prune ran **unconditionally**. A run that returned an empty page, bailed out of pagination, or failed to resolve an item to a TMDB id would delete history rows for titles that are *still* on the watchlist. On the next run those titles look brand-new and get re-requested — and `TvSender` re-monitors and searches the requested episodes, re-grabbing content the user had deleted.

The pre-refactor importer guarded this with `if (currentWatchlistTmdbIds.Count > 0)`; that guard was dropped when the sync moved to the admin-token community API, which is flakier and does a per-item metadata lookup, making degraded-but-not-errored runs much more likely.

## Change

- Track whether the run produced a complete, authoritative snapshot (`snapshotComplete`), set to `false` on a page-limit bail-out, a repeated-cursor bail-out, an unresolved item, or cancellation.
- Only prune history when the snapshot is complete **and** at least one title resolved. Degraded/empty runs now preserve existing history and re-check next run (a stale history row is harmless — it only prevents a re-request). A genuinely cleared watchlist still drops its rows on a clean, non-empty sync.

## Tests

Adds regression coverage in `PlexWatchlistImportTests`:
- `EmptyWatchlist_DoesNotPurgeExistingHistory`
- `PartiallyResolvedWatchlist_DoesNotPurgeStaleHistory`
- `CompleteWatchlist_PurgesStaleHistory`
- `TitleAlreadyInHistory_IsNotReRequested`

All 32 tests in the file pass.

## Note

This hardens the history layer against every degraded-fetch trigger, which is the correct place for the fix. The exact trigger the reporter hit isn't provable from code alone — worth confirming against their logs (look for `Removing old history entry for TMDB ID …` correlated with the re-adds) before closing #5427.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Plex watchlist synchronisation to prevent accidental history deletion when watchlist data is incomplete
  * Improved handling of edge cases, including empty watchlists and partially resolved watchlist entries
  * History entries are now preserved when watchlist synchronisation cannot fully complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->