### PR TITLE
Fix movie wrongly shown as available when a series shares its TMDB ID

### DIFF
--- a/src/Ombi.Core.Tests/Rule/Search/JellyfinAvailabilityRuleTests.cs
+++ b/src/Ombi.Core.Tests/Rule/Search/JellyfinAvailabilityRuleTests.cs
@@ -117,5 +117,25 @@ namespace Ombi.Core.Tests.Rule.Search
             Assert.True(result.Success);
             Assert.False(search.Available);
         }
+
+        [Test]
+        public async Task Movie_ShouldNotBe_Available_WhenOnlyASeriesSharesTheMovieDbId()
+        {
+            // TheMovieDb has separate ID namespaces for movies and TV, so a series can share the same id.
+            ContextMock.Setup(x => x.GetByTheMovieDbId(It.IsAny<string>())).ReturnsAsync(new JellyfinContent
+            {
+                TheMovieDbId = "87428",
+                Quality = "1080",
+                Type = MediaType.Series
+            });
+            var search = new SearchMovieViewModel()
+            {
+                TheMovieDbId = "87428",
+            };
+            var result = await Rule.Execute(search);
+
+            Assert.True(result.Success);
+            Assert.False(search.Available);
+        }
     }
 }

--- a/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
@@ -166,11 +166,19 @@ namespace Ombi.Core.Rule.Rules.Search
             var result = new ContentLookupResult();
             IMediaServerContent item = null;
 
+            // TheMovieDb (and potentially other providers) use separate ID namespaces for
+            // movies and TV shows, so the same ID can refer to both a movie and a series.
+            // Only accept content whose type matches the thing we are searching for, otherwise
+            // a movie can be wrongly marked as available because a series shares its ID (and vice versa).
+            var expectedType = obj is SearchMovieViewModel ? MediaType.Movie : MediaType.Series;
+            bool Matches(IMediaServerContent content) => content != null && content.Type == expectedType;
+
             if (obj.ImdbId.HasValue())
             {
-                item = await getByImdbId(obj.ImdbId);
-                if (item != null)
+                var match = await getByImdbId(obj.ImdbId);
+                if (Matches(match))
                 {
+                    item = match;
                     result.UseImdb = true;
                 }
             }
@@ -179,9 +187,10 @@ namespace Ombi.Core.Rule.Rules.Search
             {
                 if (lookupById && obj.Id > 0)
                 {
-                    item = await getByTheMovieDbId(obj.Id.ToString());
-                    if (item != null)
+                    var match = await getByTheMovieDbId(obj.Id.ToString());
+                    if (Matches(match))
                     {
+                        item = match;
                         obj.TheMovieDbId = obj.Id.ToString();
                         result.UseTheMovieDb = true;
                     }
@@ -189,18 +198,20 @@ namespace Ombi.Core.Rule.Rules.Search
 
                 if (item == null && obj.TheMovieDbId.HasValue())
                 {
-                    item = await getByTheMovieDbId(obj.TheMovieDbId);
-                    if (item != null)
+                    var match = await getByTheMovieDbId(obj.TheMovieDbId);
+                    if (Matches(match))
                     {
+                        item = match;
                         result.UseTheMovieDb = true;
                     }
                 }
 
                 if (item == null && obj.TheTvDbId.HasValue())
                 {
-                    item = await getByTvDbId(obj.TheTvDbId);
-                    if (item != null)
+                    var match = await getByTvDbId(obj.TheTvDbId);
+                    if (Matches(match))
                     {
+                        item = match;
                         result.UseTvDb = true;
                     }
                 }

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyAvaliabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyAvaliabilityChecker.cs
@@ -70,9 +70,9 @@ namespace Ombi.Schedule.Jobs.Emby
                     embyContent = await _repo.GetByImdbId(movie.ImdbId);
                 }
                 
-                if (embyContent == null)
+                if (embyContent == null || embyContent.Type != MediaType.Movie)
                 {
-                    // We don't have this yet
+                    // We don't have this yet (a series may share the same TheMovieDbId, so ensure it's a movie)
                     continue;
                 }
 

--- a/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinAvaliabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/Jellyfin/JellyfinAvaliabilityChecker.cs
@@ -97,9 +97,9 @@ namespace Ombi.Schedule.Jobs.Jellyfin
                     jellyfinContent = await _repo.GetByImdbId(movie.ImdbId);
                 }
                 
-                if (jellyfinContent == null)
+                if (jellyfinContent == null || jellyfinContent.Type != MediaType.Movie)
                 {
-                    // We don't have this yet
+                    // We don't have this yet (a series may share the same TheMovieDbId, so ensure it's a movie)
                     continue;
                 }
 


### PR DESCRIPTION
TheMovieDb uses separate ID namespaces for movies and TV shows, so the
same id can refer to both a movie and a series. The Emby/Jellyfin
availability lookups matched content purely by provider id without
checking the media type, so a movie was marked as available (and linked
to "Watch on ...") whenever a series with the same TMDB id existed on the
server. Plex already disambiguated by media type, which is why it was
unaffected.

Only accept media server content whose type matches the item being
searched for, both in the shared search availability rule and in the
background Emby/Jellyfin availability checkers.

Fixes #5430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed availability verification checks to properly distinguish between movies and television series when they share identical external IDs, preventing incorrect availability marking across Emby and Jellyfin media server libraries. Media type is now validated during all provider ID lookups.

* **Tests**
  * Added test case to validate Jellyfin television series handling in availability rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->