### PR TITLE
fix(tv): don't mark unaired shows as available

### DIFF
--- a/src/Ombi.Core.Tests/Rule/Search/AvailabilityRuleHelperTests.cs
+++ b/src/Ombi.Core.Tests/Rule/Search/AvailabilityRuleHelperTests.cs
@@ -169,6 +169,32 @@ namespace Ombi.Core.Tests.Rule.Search
             Assert.That(model.PartlyAvailable, Is.False);
         }
         [Test]
+        public void Is_NotAvailable_When_No_Episodes_Have_Aired_Yet()
+        {
+            var episodes = new List<EpisodeRequests>
+            {
+                new EpisodeRequests
+                {
+                    AirDate = DateTime.Now.AddDays(1), // Tomorrow
+                    Available = false
+                },
+                new EpisodeRequests
+                {
+                    AirDate = DateTime.Now.AddDays(7), // Next week
+                    Available = false
+                }
+            };
+
+            var model = new SearchTvShowViewModel
+            {
+                SeasonRequests = new List<SeasonRequests> { new SeasonRequests { Episodes = episodes } }
+            };
+            AvailabilityRuleHelper.CheckForUnairedEpisodes(model);
+            Assert.That(model.FullyAvailable, Is.False);
+            Assert.That(model.PartlyAvailable, Is.False);
+        }
+
+        [Test]
         public void Is_NotAvailable_When_All_Episodes_Are_Unknown()
         {
             var episodes = new List<EpisodeRequests>

--- a/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
@@ -40,9 +40,10 @@ namespace Ombi.Core.Rule.Rules.Search
                         x.Episodes.Any(c => !c.Available && c.AirDate == DateTime.MinValue));
                     if (!unknownAirDateUnavailable)
                     {
-                        var hasUnairedEpisodes = search.SeasonRequests.Any(x =>
-                            x.Episodes.Any(c => !c.Available && c.AirDate > DateTime.Now.Date && c.AirDate != DateTime.MinValue));
-                        if (hasUnairedEpisodes || search.PartlyAvailable)
+                        // Only treat the remaining (unaired) episodes as non-blocking when we
+                        // actually have something available already. A show where nothing has
+                        // aired yet has no available episodes and must not be marked available.
+                        if (search.PartlyAvailable)
                         {
                             search.FullyAvailable = true;
                         }


### PR DESCRIPTION
## Summary

Fixes #5433 — new/upcoming TV shows that have not aired yet were showing as **"Available"** on the discover page and **"partially available"** on the details page, even though they had never been requested and none of their episodes had a status.

## Root cause

The issue is in `AvailabilityRuleHelper.CheckForUnairedEpisodes` (`src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs`), not the frontend — the discover card simply reflects the `fullyAvailable`/`partlyAvailable` flags returned by the server.

For a brand-new show where **every episode has a future air date and none are available**:

- Nothing is available, so neither `FullyAvailable` nor `PartlyAvailable` are set initially.
- `airedButNotAvailable` is `false` (no episodes have aired).
- `unknownAirDateUnavailable` is `false` (air dates are known, just in the future).
- `hasUnairedEpisodes` is `true`, so `if (hasUnairedEpisodes || PartlyAvailable)` incorrectly set `FullyAvailable = true`.
- A later block then also set `PartlyAvailable = true`.

This produced exactly the reported behavior.

## Fix

Only treat the remaining unaired episodes as non-blocking when the show is already partly available (i.e. it has at least one available episode). A show where nothing has aired has zero available episodes and must not be marked available, so the request button reappears and the availability badge clears.

## Tests

Added `Is_NotAvailable_When_No_Episodes_Have_Aired_Yet` and verified the full `AvailabilityRuleHelperTests` suite passes (7/7). The existing "ongoing show with available episodes + upcoming episodes" behavior is preserved.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved availability detection logic for shows with episodes that have not yet aired, ensuring more accurate status reporting.

* **Tests**
  * Added test coverage for availability status when no episodes have aired yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->