### PR TITLE
fix(emby): make episode sync pagination deterministic and harden multi-episode fill

### DIFF
--- a/src/Ombi.Api.External/MediaServers/Emby/EmbyApi.cs
+++ b/src/Ombi.Api.External/MediaServers/Emby/EmbyApi.cs
@@ -187,11 +187,13 @@ namespace Ombi.Api.External.MediaServers.Emby
             request.AddQueryString("Fields", includeOverview ? "ProviderIds,MediaStreams,Overview" : "ProviderIds,MediaStreams ");
             request.AddQueryString("startIndex", startIndex.ToString());
             request.AddQueryString("limit", count.ToString());
-            // Include Id as a secondary sort key so the ordering is a unique, stable
-            // total order. Without a tiebreaker, rows that share the primary sort value
-            // can shift position between paginated requests and silently fall into the
-            // gaps between startIndex pages, never getting synced.
-            request.AddQueryString("sortBy", "DateCreated,Id");
+            // Append the season (ParentIndexNumber) and episode (IndexNumber) numbers as
+            // secondary sort keys so the ordering is deterministic across paginated
+            // requests. Without a tiebreaker, rows that share the primary sort value have
+            // an undefined relative order that can shift between requests, letting items
+            // fall into the gaps between startIndex pages and never get synced. (Emby has
+            // no unique-id sort field, so this is best-effort rather than a total order.)
+            request.AddQueryString("sortBy", "DateCreated,ParentIndexNumber,IndexNumber");
             request.AddQueryString("SortOrder", "Descending");
             if (!string.IsNullOrEmpty(parentIdFilder))
             {
@@ -247,12 +249,14 @@ namespace Ombi.Api.External.MediaServers.Emby
                 request.AddQueryString("ParentId", parentIdFilder);
             }
 
-            // Include Id as a secondary sort key so the ordering is a unique, stable
-            // total order. SortName alone produces large tie groups (e.g. "Pilot",
+            // Append the season (ParentIndexNumber) and episode (IndexNumber) numbers as
+            // secondary sort keys so the ordering is deterministic across paginated
+            // requests. SortName alone produces large tie groups (e.g. "Pilot",
             // "Episode 1") whose relative order is undefined and can shift between
-            // paginated requests, causing episodes to silently fall into the gaps
-            // between startIndex pages and never get synced.
-            request.AddQueryString("SortBy", "SortName,Id");
+            // requests, causing episodes to silently fall into the gaps between
+            // startIndex pages and never get synced. (Emby has no unique-id sort field,
+            // so this is best-effort rather than a total order.)
+            request.AddQueryString("SortBy", "SortName,ParentIndexNumber,IndexNumber");
             request.AddQueryString("SortOrder", "Ascending");
 
             request.AddQueryString("isMissing", "False");
@@ -302,10 +306,11 @@ namespace Ombi.Api.External.MediaServers.Emby
             request.AddQueryString("UserId", userId);
             request.AddQueryString("isPlayed", true.ToString());
 
-            // paginate and display recently played items first. Include Id as a
-            // secondary sort key so the ordering is a unique, stable total order and
-            // paginated requests cannot drop items that share the same DatePlayed.
-            request.AddQueryString("sortBy", "DatePlayed,Id");
+            // paginate and display recently played items first. Append the season
+            // (ParentIndexNumber) and episode (IndexNumber) numbers as secondary sort
+            // keys so paginated requests cannot drop items that share the same
+            // DatePlayed. (Emby has no unique-id sort field, so this is best-effort.)
+            request.AddQueryString("sortBy", "DatePlayed,ParentIndexNumber,IndexNumber");
             request.AddQueryString("SortOrder", "Descending");
             request.AddQueryString("startIndex", startIndex.ToString());
             request.AddQueryString("limit", count.ToString());

--- a/src/Ombi.Api.External/MediaServers/Emby/EmbyApi.cs
+++ b/src/Ombi.Api.External/MediaServers/Emby/EmbyApi.cs
@@ -187,7 +187,11 @@ namespace Ombi.Api.External.MediaServers.Emby
             request.AddQueryString("Fields", includeOverview ? "ProviderIds,MediaStreams,Overview" : "ProviderIds,MediaStreams ");
             request.AddQueryString("startIndex", startIndex.ToString());
             request.AddQueryString("limit", count.ToString());
-            request.AddQueryString("sortBy", "DateCreated");
+            // Include Id as a secondary sort key so the ordering is a unique, stable
+            // total order. Without a tiebreaker, rows that share the primary sort value
+            // can shift position between paginated requests and silently fall into the
+            // gaps between startIndex pages, never getting synced.
+            request.AddQueryString("sortBy", "DateCreated,Id");
             request.AddQueryString("SortOrder", "Descending");
             if (!string.IsNullOrEmpty(parentIdFilder))
             {
@@ -243,7 +247,12 @@ namespace Ombi.Api.External.MediaServers.Emby
                 request.AddQueryString("ParentId", parentIdFilder);
             }
 
-            request.AddQueryString("SortBy", "SortName");
+            // Include Id as a secondary sort key so the ordering is a unique, stable
+            // total order. SortName alone produces large tie groups (e.g. "Pilot",
+            // "Episode 1") whose relative order is undefined and can shift between
+            // paginated requests, causing episodes to silently fall into the gaps
+            // between startIndex pages and never get synced.
+            request.AddQueryString("SortBy", "SortName,Id");
             request.AddQueryString("SortOrder", "Ascending");
 
             request.AddQueryString("isMissing", "False");
@@ -293,8 +302,10 @@ namespace Ombi.Api.External.MediaServers.Emby
             request.AddQueryString("UserId", userId);
             request.AddQueryString("isPlayed", true.ToString());
 
-            // paginate and display recently played items first
-            request.AddQueryString("sortBy", "DatePlayed");
+            // paginate and display recently played items first. Include Id as a
+            // secondary sort key so the ordering is a unique, stable total order and
+            // paginated requests cannot drop items that share the same DatePlayed.
+            request.AddQueryString("sortBy", "DatePlayed,Id");
             request.AddQueryString("SortOrder", "Descending");
             request.AddQueryString("startIndex", startIndex.ToString());
             request.AddQueryString("limit", count.ToString());

--- a/src/Ombi.Api.External/MediaServers/Emby/EmbyApi.cs
+++ b/src/Ombi.Api.External/MediaServers/Emby/EmbyApi.cs
@@ -187,13 +187,15 @@ namespace Ombi.Api.External.MediaServers.Emby
             request.AddQueryString("Fields", includeOverview ? "ProviderIds,MediaStreams,Overview" : "ProviderIds,MediaStreams ");
             request.AddQueryString("startIndex", startIndex.ToString());
             request.AddQueryString("limit", count.ToString());
-            // Append the season (ParentIndexNumber) and episode (IndexNumber) numbers as
-            // secondary sort keys so the ordering is deterministic across paginated
-            // requests. Without a tiebreaker, rows that share the primary sort value have
-            // an undefined relative order that can shift between requests, letting items
-            // fall into the gaps between startIndex pages and never get synced. (Emby has
-            // no unique-id sort field, so this is best-effort rather than a total order.)
-            request.AddQueryString("sortBy", "DateCreated,ParentIndexNumber,IndexNumber");
+            // For episodes, append the season (ParentIndexNumber) and episode
+            // (IndexNumber) numbers as secondary sort keys so the ordering is
+            // deterministic across paginated requests. Without a tiebreaker, rows that
+            // share the primary sort value have an undefined relative order that can
+            // shift between requests, letting episodes fall into the gaps between
+            // startIndex pages and never get synced. These fields are episode-only, so
+            // other media types keep their primary sort. (Emby has no unique-id sort
+            // field, so this is best-effort rather than a total order.)
+            request.AddQueryString("sortBy", type == "Episode" ? "DateCreated,ParentIndexNumber,IndexNumber" : "DateCreated");
             request.AddQueryString("SortOrder", "Descending");
             if (!string.IsNullOrEmpty(parentIdFilder))
             {
@@ -249,14 +251,15 @@ namespace Ombi.Api.External.MediaServers.Emby
                 request.AddQueryString("ParentId", parentIdFilder);
             }
 
-            // Append the season (ParentIndexNumber) and episode (IndexNumber) numbers as
-            // secondary sort keys so the ordering is deterministic across paginated
-            // requests. SortName alone produces large tie groups (e.g. "Pilot",
-            // "Episode 1") whose relative order is undefined and can shift between
-            // requests, causing episodes to silently fall into the gaps between
-            // startIndex pages and never get synced. (Emby has no unique-id sort field,
-            // so this is best-effort rather than a total order.)
-            request.AddQueryString("SortBy", "SortName,ParentIndexNumber,IndexNumber");
+            // For episodes, append the season (ParentIndexNumber) and episode
+            // (IndexNumber) numbers as secondary sort keys so the ordering is
+            // deterministic across paginated requests. SortName alone produces large tie
+            // groups (e.g. "Pilot", "Episode 1") whose relative order is undefined and
+            // can shift between requests, causing episodes to silently fall into the gaps
+            // between startIndex pages and never get synced. These fields are
+            // episode-only, so other media types keep their primary sort. (Emby has no
+            // unique-id sort field, so this is best-effort rather than a total order.)
+            request.AddQueryString("SortBy", type == "Episode" ? "SortName,ParentIndexNumber,IndexNumber" : "SortName");
             request.AddQueryString("SortOrder", "Ascending");
 
             request.AddQueryString("isMissing", "False");
@@ -306,11 +309,12 @@ namespace Ombi.Api.External.MediaServers.Emby
             request.AddQueryString("UserId", userId);
             request.AddQueryString("isPlayed", true.ToString());
 
-            // paginate and display recently played items first. Append the season
-            // (ParentIndexNumber) and episode (IndexNumber) numbers as secondary sort
-            // keys so paginated requests cannot drop items that share the same
-            // DatePlayed. (Emby has no unique-id sort field, so this is best-effort.)
-            request.AddQueryString("sortBy", "DatePlayed,ParentIndexNumber,IndexNumber");
+            // paginate and display recently played items first. For episodes, append the
+            // season (ParentIndexNumber) and episode (IndexNumber) numbers as secondary
+            // sort keys so paginated requests cannot drop items that share the same
+            // DatePlayed. These fields are episode-only, so other media types keep their
+            // primary sort. (Emby has no unique-id sort field, so this is best-effort.)
+            request.AddQueryString("sortBy", type == "Episode" ? "DatePlayed,ParentIndexNumber,IndexNumber" : "DatePlayed");
             request.AddQueryString("SortOrder", "Descending");
             request.AddQueryString("startIndex", startIndex.ToString());
             request.AddQueryString("limit", count.ToString());

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -278,18 +278,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 _logger.LogDebug("Adding new episode {0} to parent {1}", ep.Name, ep.SeriesName);
 
                 // add it
-                epToAdd.Add(new EmbyEpisode
-                {
-                    EmbyId = ep.Id,
-                    EpisodeNumber = ep.IndexNumber,
-                    SeasonNumber = ep.ParentIndexNumber,
-                    ParentId = ep.SeriesId,
-                    TvDbId = ep.ProviderIds?.Tvdb,
-                    TheMovieDbId = ep.ProviderIds?.Tmdb,
-                    ImdbId = ep.ProviderIds?.Imdb,
-                    Title = ep.Name,
-                    AddedAt = DateTime.UtcNow
-                });
+                epToAdd.Add(BuildEpisode(ep, ep.IndexNumber));
                 episodesInCurrentBatch.Add(episodeKey);
 
                 // A multi-episode file spans IndexNumber..IndexNumberEnd. Only fill the
@@ -314,29 +303,39 @@ namespace Ombi.Schedule.Jobs.Emby
                         for (var episodeNumber = ep.IndexNumber + 1; episodeNumber <= ep.IndexNumberEnd.Value; episodeNumber++)
                         {
                             var multiEpisodeKey = $"{ep.Id}_{episodeNumber}_{ep.ParentIndexNumber}";
+                            var multiEpisodeMetadataKey = $"{ep.Id}:{episodeNumber}";
 
-                            // Check if this multi-episode entry already exists
-                            if (!episodesInCurrentBatch.Contains(multiEpisodeKey))
+                            // Skip if this filled episode already exists in the current
+                            // batch or is already persisted in the database. EmbyEpisode
+                            // has no uniqueness constraint, so an unguarded insert here
+                            // would create a duplicate row.
+                            if (!episodesInCurrentBatch.Contains(multiEpisodeKey)
+                                && !episodeMetadata.ContainsKey(multiEpisodeMetadataKey))
                             {
                                 _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
-                                epToAdd.Add(new EmbyEpisode
-                                {
-                                    EmbyId = ep.Id,
-                                    EpisodeNumber = episodeNumber,
-                                    SeasonNumber = ep.ParentIndexNumber,
-                                    ParentId = ep.SeriesId,
-                                    TvDbId = ep.ProviderIds?.Tvdb,
-                                    TheMovieDbId = ep.ProviderIds?.Tmdb,
-                                    ImdbId = ep.ProviderIds?.Imdb,
-                                    Title = ep.Name,
-                                    AddedAt = DateTime.UtcNow
-                                });
+                                epToAdd.Add(BuildEpisode(ep, episodeNumber));
                                 episodesInCurrentBatch.Add(multiEpisodeKey);
                             }
                         }
                     }
                 }
             }
+        }
+
+        private static EmbyEpisode BuildEpisode(EmbyEpisodes ep, int episodeNumber)
+        {
+            return new EmbyEpisode
+            {
+                EmbyId = ep.Id,
+                EpisodeNumber = episodeNumber,
+                SeasonNumber = ep.ParentIndexNumber,
+                ParentId = ep.SeriesId,
+                TvDbId = ep.ProviderIds?.Tvdb,
+                TheMovieDbId = ep.ProviderIds?.Tmdb,
+                ImdbId = ep.ProviderIds?.Imdb,
+                Title = ep.Name,
+                AddedAt = DateTime.UtcNow
+            };
         }
 
         private async Task<T> FetchEpisodesWithRetry<T>(Func<Task<T>> apiCall, int maxAttempts = 3)

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -292,42 +292,49 @@ namespace Ombi.Schedule.Jobs.Emby
                 });
                 episodesInCurrentBatch.Add(episodeKey);
 
-                if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value != ep.IndexNumber)
+                // A multi-episode file spans IndexNumber..IndexNumberEnd. Only fill the
+                // additional episodes when the range is sane: IndexNumberEnd must be
+                // greater than IndexNumber. Some Emby servers report a bogus
+                // IndexNumberEnd (absolute numbering or corrupt metadata) that is far
+                // larger than - or even smaller than - IndexNumber, which previously
+                // either skipped the file entirely or fabricated phantom episode rows.
+                if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value > ep.IndexNumber)
                 {
                     var episodeFillCount = ep.IndexNumberEnd.Value - ep.IndexNumber;
 
                     if (episodeFillCount > 50)
                     {
-                        _logger.LogWarning($"Episode {ep.Name} has {episodeFillCount} episodes! Skipping.");
-                        return;
+                        // The primary episode has already been added above; we just skip
+                        // the implausible fill rather than discarding the whole file.
+                        _logger.LogWarning(
+                            $"Episode {ep.Name} from series {ep.SeriesName} reports {episodeFillCount} episodes in a single file, which is almost certainly incorrect metadata. Only the primary episode was added.");
                     }
-
-                    int episodeNumber = ep.IndexNumber;
-                    do
+                    else
                     {
-                        episodeNumber++;
-                        var multiEpisodeKey = $"{ep.Id}_{episodeNumber}_{ep.ParentIndexNumber}";
-
-                        // Check if this multi-episode entry already exists
-                        if (!episodesInCurrentBatch.Contains(multiEpisodeKey))
+                        for (var episodeNumber = ep.IndexNumber + 1; episodeNumber <= ep.IndexNumberEnd.Value; episodeNumber++)
                         {
-                            _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
-                            epToAdd.Add(new EmbyEpisode
-                            {
-                                EmbyId = ep.Id,
-                                EpisodeNumber = episodeNumber,
-                                SeasonNumber = ep.ParentIndexNumber,
-                                ParentId = ep.SeriesId,
-                                TvDbId = ep.ProviderIds?.Tvdb,
-                                TheMovieDbId = ep.ProviderIds?.Tmdb,
-                                ImdbId = ep.ProviderIds?.Imdb,
-                                Title = ep.Name,
-                                AddedAt = DateTime.UtcNow
-                            });
-                            episodesInCurrentBatch.Add(multiEpisodeKey);
-                        }
+                            var multiEpisodeKey = $"{ep.Id}_{episodeNumber}_{ep.ParentIndexNumber}";
 
-                    } while (episodeNumber < ep.IndexNumberEnd.Value);
+                            // Check if this multi-episode entry already exists
+                            if (!episodesInCurrentBatch.Contains(multiEpisodeKey))
+                            {
+                                _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
+                                epToAdd.Add(new EmbyEpisode
+                                {
+                                    EmbyId = ep.Id,
+                                    EpisodeNumber = episodeNumber,
+                                    SeasonNumber = ep.ParentIndexNumber,
+                                    ParentId = ep.SeriesId,
+                                    TvDbId = ep.ProviderIds?.Tvdb,
+                                    TheMovieDbId = ep.ProviderIds?.Tmdb,
+                                    ImdbId = ep.ProviderIds?.Imdb,
+                                    Title = ep.Name,
+                                    AddedAt = DateTime.UtcNow
+                                });
+                                episodesInCurrentBatch.Add(multiEpisodeKey);
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add Id as a secondary sort key to the paginated Emby item queries
(GetAll, RecentlyAdded and GetPlayed). SortName/DateCreated/DatePlayed
alone produce large tie groups whose relative order is undefined, so
rows could shift between startIndex pages and silently fall into the
gaps between pages, leaving episodes permanently missing with no log
output. Id gives a unique, stable total order so every item lands on
exactly one page.

Also harden the multi-episode file fill in EmbyEpisodeSync: only fill
when IndexNumberEnd is genuinely greater than IndexNumber and replace
the do/while with a for loop so a corrupt IndexNumberEnd can no longer
fabricate phantom episode rows. An implausibly large span now keeps the
primary episode instead of being discarded, and logs the series name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paging stability for recently added, full library, and recently played lists by adding deterministic secondary sort keys (applied to episode items where needed).
  * Reduced cases where items could shift, duplicate, or disappear while paging.
  * Made multi-episode “filled” expansion safer by only generating additional episodes when the end index is present and greater than the start.
  * Added warnings and safeguards to avoid generating episodes from implausible filled ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->