### PR TITLE
fix(emby): remove stale records, harden played sync, keep provider-id-less series

### DIFF
--- a/src/Ombi.Schedule.Tests/EmbyContentSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyContentSyncTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -11,9 +13,13 @@ using Ombi.Api.External.MediaServers.Emby.Models.Movie;
 using Ombi.Core.Services;
 using Ombi.Core.Settings;
 using Ombi.Core.Settings.Models.External;
+using Ombi.Helpers;
 using Ombi.Hubs;
 using Ombi.Schedule.Jobs.Emby;
+using Ombi.Store.Entities;
+using Ombi.Store.Repository;
 using Quartz;
+using MediaType = Ombi.Store.Entities.MediaType;
 
 namespace Ombi.Schedule.Tests
 {
@@ -24,6 +30,9 @@ namespace Ombi.Schedule.Tests
         private EmbyContentSync _subject;
         private Mock<IEmbyApi> _api;
         private Mock<IJobExecutionContext> _context;
+        private List<EmbyContent> _addedContent;
+        private List<EmbyContent> _deletedContent;
+        private List<EmbyEpisode> _deletedEpisodes;
 
         [SetUp]
         public void Setup()
@@ -33,6 +42,33 @@ namespace Ombi.Schedule.Tests
             _api = new Mock<IEmbyApi>();
             _mocker.Setup<IEmbyApiFactory, IEmbyApi>(x => x.CreateClient(It.IsAny<EmbySettings>()))
                 .Returns(_api.Object);
+
+            // The sync passes live collections that it clears afterwards, so snapshot
+            // their contents at call time rather than inspecting them at verify time
+            _addedContent = new List<EmbyContent>();
+            _mocker.GetMock<IEmbyContentRepository>()
+                .Setup(x => x.AddRange(It.IsAny<IEnumerable<EmbyContent>>(), It.IsAny<bool>()))
+                .Callback<IEnumerable<EmbyContent>, bool>((c, _) => _addedContent.AddRange(c))
+                .Returns(Task.CompletedTask);
+
+            _deletedContent = new List<EmbyContent>();
+            _mocker.GetMock<IEmbyContentRepository>()
+                .Setup(x => x.DeleteRange(It.IsAny<IEnumerable<EmbyContent>>()))
+                .Callback<IEnumerable<EmbyContent>>(c => _deletedContent.AddRange(c))
+                .Returns(Task.CompletedTask);
+
+            _deletedEpisodes = new List<EmbyEpisode>();
+            _mocker.GetMock<IEmbyContentRepository>()
+                .Setup(x => x.DeleteEpisodes(It.IsAny<IEnumerable<EmbyEpisode>>()))
+                .Callback<IEnumerable<EmbyEpisode>>(e => _deletedEpisodes.AddRange(e))
+                .Returns(Task.CompletedTask);
+
+            _mocker.Setup<IEmbyContentRepository, Task<EmbyContent>>(x => x.GetByEmbyId(It.IsAny<string>()))
+                .ReturnsAsync((EmbyContent)null);
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyContent>>>(x => x.GetAllContentIdentifiers())
+                .ReturnsAsync(new List<EmbyContent>());
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>());
 
             _mocker.Setup<ISettingsService<EmbySettings>, Task<EmbySettings>>(x => x.GetSettingsAsync())
                 .ReturnsAsync(new EmbySettings
@@ -88,6 +124,117 @@ namespace Ombi.Schedule.Tests
             _api.Verify(x => x.GetAllMovies(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Content Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [Test]
+        public async Task SeriesWithoutProviderIds_IsAddedWithEmbyIdOnly()
+        {
+            SetupMovies(totalRecordCount: 0);
+            SetupShows(Show("series1", "No Metadata Show", providerIds: null));
+
+            await _subject.Execute(_context.Object);
+
+            var added = _addedContent.SingleOrDefault(x => x.EmbyId == "series1");
+            Assert.That(added, Is.Not.Null);
+            Assert.That(added.Title, Is.EqualTo("No Metadata Show"));
+            Assert.That(added.TvDbId, Is.Null);
+            Assert.That(added.TheMovieDbId, Is.Null);
+            Assert.That(added.ImdbId, Is.Null);
+        }
+
+        [Test]
+        public async Task SeriesThatLostItsProviderIds_DoesNotWipeTheExistingIds()
+        {
+            SetupMovies(totalRecordCount: 0);
+            SetupShows(Show("series1", "Backfilled Show", providerIds: null));
+            _mocker.Setup<IEmbyContentRepository, Task<EmbyContent>>(x => x.GetByEmbyId("series1"))
+                .ReturnsAsync(new EmbyContent { Id = 1, EmbyId = "series1", TvDbId = "123", Type = MediaType.Series });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IEmbyContentRepository>(x => x.UpdateWithoutSave(It.IsAny<IMediaServerContent>()), Times.Never);
+            Assert.That(_addedContent, Is.Empty);
+        }
+
+        [Test]
+        public async Task FullSync_RemovesContentThatNoLongerExistsOnTheServer()
+        {
+            SetupMovies(totalRecordCount: 0);
+            SetupShows(Show("series1", "Still Here", providerIds: new EmbyProviderids { Tvdb = "1" }));
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyContent>>>(x => x.GetAllContentIdentifiers())
+                .ReturnsAsync(new List<EmbyContent>
+                {
+                    new EmbyContent { Id = 1, EmbyId = "series1", Type = MediaType.Series },
+                    new EmbyContent { Id = 2, EmbyId = "goneSeries", Type = MediaType.Series },
+                    new EmbyContent { Id = 3, EmbyId = "goneMovie", Type = MediaType.Movie }
+                });
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>
+                {
+                    new EmbyEpisode { Id = 10, EmbyId = "ep1", EpisodeNumber = 1, ParentId = "goneSeries" },
+                    new EmbyEpisode { Id = 11, EmbyId = "ep2", EpisodeNumber = 1, ParentId = "series1" }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_deletedContent.Select(x => x.EmbyId), Is.EquivalentTo(new[] { "goneSeries", "goneMovie" }));
+            Assert.That(_deletedEpisodes.Select(x => x.Id), Is.EquivalentTo(new[] { 10 }));
+        }
+
+        [Test]
+        public async Task RecentlyAddedSync_DoesNotRemoveContent()
+        {
+            _context.Setup(x => x.MergedJobDataMap).Returns(new JobDataMap(new Dictionary<string, string>
+            {
+                { JobDataKeys.EmbyRecentlyAddedSearch, "true" }
+            }));
+            _api.Setup(x => x.RecentlyAddedMovies(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyMovie> { TotalRecordCount = 0, Items = new List<EmbyMovie>() });
+            _api.Setup(x => x.RecentlyAddedShows(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbySeries>
+                {
+                    TotalRecordCount = 1,
+                    Items = new List<EmbySeries> { Show("series1", "Still Here", providerIds: new EmbyProviderids { Tvdb = "1" }) }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IEmbyContentRepository>(x => x.GetAllContentIdentifiers(), Times.Never);
+            _mocker.Verify<IEmbyContentRepository>(x => x.DeleteRange(It.IsAny<IEnumerable<EmbyContent>>()), Times.Never);
+        }
+
+        [Test]
+        public async Task FailedServer_SkipsStaleContentCleanup()
+        {
+            SetupMovies(totalRecordCount: 0);
+            _api.Setup(x => x.GetAllShows(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("Emby died"));
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyContent>>>(x => x.GetAllContentIdentifiers())
+                .ReturnsAsync(new List<EmbyContent>
+                {
+                    new EmbyContent { Id = 1, EmbyId = "wouldOtherwiseBeRemoved", Type = MediaType.Series }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IEmbyContentRepository>(x => x.DeleteRange(It.IsAny<IEnumerable<EmbyContent>>()), Times.Never);
+        }
+
+        private void SetupShows(params EmbySeries[] shows)
+        {
+            _api.Setup(x => x.GetAllShows(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbySeries>
+                {
+                    TotalRecordCount = shows.Length,
+                    Items = shows.ToList()
+                });
+        }
+
+        private static EmbySeries Show(string id, string name, EmbyProviderids providerIds) => new EmbySeries
+        {
+            Id = id,
+            Name = name,
+            ProviderIds = providerIds
+        };
 
         private void SetupMovies(int totalRecordCount)
         {

--- a/src/Ombi.Schedule.Tests/EmbyEpisodeSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyEpisodeSyncTests.cs
@@ -11,6 +11,7 @@ using Ombi.Api.External.MediaServers.Emby.Models;
 using Ombi.Api.External.MediaServers.Emby.Models.Media.Tv;
 using Ombi.Core.Settings;
 using Ombi.Core.Settings.Models.External;
+using Ombi.Helpers;
 using Ombi.Hubs;
 using Ombi.Schedule.Jobs.Emby;
 using Ombi.Store.Entities;
@@ -27,6 +28,7 @@ namespace Ombi.Schedule.Tests
         private Mock<IEmbyApi> _api;
         private Mock<IJobExecutionContext> _context;
         private List<EmbyEpisode> _addedEpisodes;
+        private List<EmbyEpisode> _deletedEpisodes;
 
         [SetUp]
         public void Setup()
@@ -47,10 +49,18 @@ namespace Ombi.Schedule.Tests
                 .Callback<IEnumerable<IMediaServerEpisode>>(e => _addedEpisodes.AddRange(e.Cast<EmbyEpisode>()))
                 .Returns(Task.CompletedTask);
 
+            _deletedEpisodes = new List<EmbyEpisode>();
+            _mocker.GetMock<IEmbyContentRepository>()
+                .Setup(x => x.DeleteEpisodes(It.IsAny<IEnumerable<EmbyEpisode>>()))
+                .Callback<IEnumerable<EmbyEpisode>>(e => _deletedEpisodes.AddRange(e))
+                .Returns(Task.CompletedTask);
+
             _mocker.Setup<IEmbyContentRepository, Task<HashSet<string>>>(x => x.GetAllSeriesEmbyIds())
                 .ReturnsAsync(new HashSet<string> { "series1" });
             _mocker.Setup<IEmbyContentRepository, Task<Dictionary<string, (int EpisodeNumber, int SeasonNumber)>>>(x => x.GetAllEpisodeMetadata())
                 .ReturnsAsync(new Dictionary<string, (int EpisodeNumber, int SeasonNumber)>());
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>());
 
             _context = new Mock<IJobExecutionContext>();
             _context.Setup(x => x.MergedJobDataMap).Returns(new JobDataMap());
@@ -119,6 +129,96 @@ namespace Ombi.Schedule.Tests
             _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Episode Sync Finished", It.IsAny<CancellationToken>()), Times.Once);
         }
 
+        [Test]
+        public async Task FullSync_RemovesEpisodesThatNoLongerExistOnTheServer()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1")));
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>
+                {
+                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1 },
+                    new EmbyEpisode { Id = 2, EmbyId = "goneEpisode", EpisodeNumber = 1 }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_deletedEpisodes.Select(x => x.EmbyId), Is.EquivalentTo(new[] { "goneEpisode" }));
+        }
+
+        [Test]
+        public async Task FullSync_KeepsRowsForMultiEpisodeFiles()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1", episodeNumber: 1, seasonNumber: 1, indexNumberEnd: 3)));
+            _mocker.Setup<IEmbyContentRepository, Task<Dictionary<string, (int EpisodeNumber, int SeasonNumber)>>>(x => x.GetAllEpisodeMetadata())
+                .ReturnsAsync(new Dictionary<string, (int EpisodeNumber, int SeasonNumber)>
+                {
+                    ["ep1:1"] = (1, 1),
+                    ["ep1:2"] = (2, 1),
+                    ["ep1:3"] = (3, 1)
+                });
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>
+                {
+                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1 },
+                    new EmbyEpisode { Id = 2, EmbyId = "ep1", EpisodeNumber = 2 },
+                    new EmbyEpisode { Id = 3, EmbyId = "ep1", EpisodeNumber = 3 }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_deletedEpisodes, Is.Empty);
+        }
+
+        [Test]
+        public async Task RecentlyAddedSync_DoesNotRemoveEpisodes()
+        {
+            _context.Setup(x => x.MergedJobDataMap).Returns(new JobDataMap(new Dictionary<string, string>
+            {
+                { JobDataKeys.EmbyRecentlyAddedSearch, "true" }
+            }));
+            _api.Setup(x => x.RecentlyAddedEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1")));
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IEmbyContentRepository>(x => x.GetAllEpisodeIdentifiers(), Times.Never);
+            _mocker.Verify<IEmbyContentRepository>(x => x.DeleteEpisodes(It.IsAny<IEnumerable<EmbyEpisode>>()), Times.Never);
+        }
+
+        [Test]
+        public async Task FailedServer_SkipsStaleEpisodeCleanup()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("Emby died"));
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>
+                {
+                    new EmbyEpisode { Id = 1, EmbyId = "wouldOtherwiseBeRemoved", EpisodeNumber = 1 }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IEmbyContentRepository>(x => x.DeleteEpisodes(It.IsAny<IEnumerable<EmbyEpisode>>()), Times.Never);
+        }
+
+        [Test]
+        public async Task EmptyPageWithRemainingRecords_SkipsStaleEpisodeCleanup()
+        {
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyEpisodes> { TotalRecordCount = 100, Items = new List<EmbyEpisodes>() });
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>
+                {
+                    new EmbyEpisode { Id = 1, EmbyId = "wouldOtherwiseBeRemoved", EpisodeNumber = 1 }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            _mocker.Verify<IEmbyContentRepository>(x => x.DeleteEpisodes(It.IsAny<IEnumerable<EmbyEpisode>>()), Times.Never);
+        }
+
         private void SetupServers(params EmbyServers[] servers)
         {
             _mocker.Setup<ISettingsService<EmbySettings>, Task<EmbySettings>>(x => x.GetSettingsAsync())
@@ -144,7 +244,7 @@ namespace Ombi.Schedule.Tests
             Items = episodes.ToList()
         };
 
-        private static EmbyEpisodes Episode(string id, int episodeNumber = 1, int seasonNumber = 1) => new EmbyEpisodes
+        private static EmbyEpisodes Episode(string id, int episodeNumber = 1, int seasonNumber = 1, int? indexNumberEnd = null) => new EmbyEpisodes
         {
             Id = id,
             Name = $"Episode {id}",
@@ -152,6 +252,7 @@ namespace Ombi.Schedule.Tests
             SeriesName = "Series",
             IndexNumber = episodeNumber,
             ParentIndexNumber = seasonNumber,
+            IndexNumberEnd = indexNumberEnd,
             ProviderIds = null
         };
     }

--- a/src/Ombi.Schedule.Tests/EmbyEpisodeSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyEpisodeSyncTests.cs
@@ -137,13 +137,31 @@ namespace Ombi.Schedule.Tests
             _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
                 .ReturnsAsync(new List<EmbyEpisode>
                 {
-                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1 },
-                    new EmbyEpisode { Id = 2, EmbyId = "goneEpisode", EpisodeNumber = 1 }
+                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1, ParentId = "series1" },
+                    new EmbyEpisode { Id = 2, EmbyId = "goneEpisode", EpisodeNumber = 1, ParentId = "series1" }
                 });
 
             await _subject.Execute(_context.Object);
 
             Assert.That(_deletedEpisodes.Select(x => x.EmbyId), Is.EquivalentTo(new[] { "goneEpisode" }));
+        }
+
+        [Test]
+        public async Task FullSync_RemovesEpisodeRowsThatMovedToAnotherSeries()
+        {
+            // The API reports ep1 under series1, but the database row still points at
+            // a previous series - the stale row must be cleaned up
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1")));
+            _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
+                .ReturnsAsync(new List<EmbyEpisode>
+                {
+                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1, ParentId = "previousSeries" }
+                });
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_deletedEpisodes.Select(x => x.Id), Is.EquivalentTo(new[] { 1 }));
         }
 
         [Test]
@@ -161,14 +179,26 @@ namespace Ombi.Schedule.Tests
             _mocker.Setup<IEmbyContentRepository, Task<List<EmbyEpisode>>>(x => x.GetAllEpisodeIdentifiers())
                 .ReturnsAsync(new List<EmbyEpisode>
                 {
-                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1 },
-                    new EmbyEpisode { Id = 2, EmbyId = "ep1", EpisodeNumber = 2 },
-                    new EmbyEpisode { Id = 3, EmbyId = "ep1", EpisodeNumber = 3 }
+                    new EmbyEpisode { Id = 1, EmbyId = "ep1", EpisodeNumber = 1, ParentId = "series1" },
+                    new EmbyEpisode { Id = 2, EmbyId = "ep1", EpisodeNumber = 2, ParentId = "series1" },
+                    new EmbyEpisode { Id = 3, EmbyId = "ep1", EpisodeNumber = 3, ParentId = "series1" }
                 });
 
             await _subject.Execute(_context.Object);
 
             Assert.That(_deletedEpisodes, Is.Empty);
+        }
+
+        [Test]
+        public async Task NegativeIndexNumberWithHugeIndexNumberEnd_DoesNotOverflowTheFillCap()
+        {
+            // int subtraction would wrap negative here and bypass the 50-episode cap
+            _api.Setup(x => x.GetAllEpisodes(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(Page(Episode("ep1", episodeNumber: -2100000000, seasonNumber: 1, indexNumberEnd: 2100000000)));
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedEpisodes, Has.Count.EqualTo(1));
         }
 
         [Test]

--- a/src/Ombi.Schedule.Tests/EmbyPlayedSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyPlayedSyncTests.cs
@@ -137,6 +137,17 @@ namespace Ombi.Schedule.Tests
         }
 
         [Test]
+        public async Task NegativeIndexNumberWithHugeIndexNumberEnd_DoesNotOverflowTheFillCap()
+        {
+            // int subtraction would wrap negative here and bypass the 50-episode cap
+            SetupPlayedEpisodes(Episode("ep1", episodeNumber: -2100000000, indexNumberEnd: 2100000000));
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedEpisodes, Has.Count.EqualTo(1));
+        }
+
+        [Test]
         public async Task EmptyPlayedPageWithRemainingRecords_StopsInsteadOfRefetchingForever()
         {
             _api.Setup(x => x.GetTvPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
@@ -145,6 +156,17 @@ namespace Ombi.Schedule.Tests
             await _subject.Execute(_context.Object);
 
             _api.Verify(x => x.GetTvPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public async Task EmptyPlayedMoviePageWithRemainingRecords_StopsInsteadOfRefetchingForever()
+        {
+            _api.Setup(x => x.GetMoviesPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyMovie> { TotalRecordCount = 50, Items = new List<EmbyMovie>() });
+
+            await _subject.Execute(_context.Object);
+
+            _api.Verify(x => x.GetMoviesPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
         private void SetupPlayedMovies(params EmbyMovie[] movies)

--- a/src/Ombi.Schedule.Tests/EmbyPlayedSyncTests.cs
+++ b/src/Ombi.Schedule.Tests/EmbyPlayedSyncTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Ombi.Api.External.MediaServers.Emby;
+using Ombi.Api.External.MediaServers.Emby.Models;
+using Ombi.Api.External.MediaServers.Emby.Models.Media.Tv;
+using Ombi.Api.External.MediaServers.Emby.Models.Movie;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Hubs;
+using Ombi.Schedule.Jobs.Emby;
+using Ombi.Store.Entities;
+using Ombi.Store.Repository;
+using Ombi.Test.Common;
+using Quartz;
+
+namespace Ombi.Schedule.Tests
+{
+    [TestFixture]
+    public class EmbyPlayedSyncTests
+    {
+        private AutoMocker _mocker;
+        private EmbyPlayedSync _subject;
+        private Mock<IEmbyApi> _api;
+        private Mock<IJobExecutionContext> _context;
+        private List<UserPlayedEpisode> _addedEpisodes;
+        private List<UserPlayedMovie> _addedMovies;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mocker = new AutoMocker();
+
+            _api = new Mock<IEmbyApi>();
+            _mocker.Setup<IEmbyApiFactory, IEmbyApi>(x => x.CreateClient(It.IsAny<EmbySettings>()))
+                .Returns(_api.Object);
+
+            _mocker.Setup<ISettingsService<EmbySettings>, Task<EmbySettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new EmbySettings
+                {
+                    Enable = true,
+                    Servers = new List<EmbyServers>
+                    {
+                        new EmbyServers
+                        {
+                            Name = "Test",
+                            ApiKey = "key",
+                            AdministratorId = "admin",
+                            Ip = "localhost",
+                            Port = 8096
+                        }
+                    }
+                });
+
+            var users = new List<OmbiUser>
+            {
+                new OmbiUser { Id = "user1", UserName = "embyUser", UserType = UserType.EmbyUser, ProviderUserId = "embyUser1" }
+            };
+            _mocker.Use(MockHelper.MockUserManager(users));
+
+            // The sync passes live collections that it clears afterwards, so snapshot
+            // their contents at call time rather than inspecting them at verify time
+            _addedEpisodes = new List<UserPlayedEpisode>();
+            _mocker.GetMock<IUserPlayedEpisodeRepository>()
+                .Setup(x => x.AddRange(It.IsAny<IEnumerable<UserPlayedEpisode>>(), It.IsAny<bool>()))
+                .Callback<IEnumerable<UserPlayedEpisode>, bool>((e, _) => _addedEpisodes.AddRange(e))
+                .Returns(Task.CompletedTask);
+            _mocker.Setup<IUserPlayedEpisodeRepository, Task<UserPlayedEpisode>>(x => x.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync((UserPlayedEpisode)null);
+
+            _addedMovies = new List<UserPlayedMovie>();
+            _mocker.GetMock<IUserPlayedMovieRepository>()
+                .Setup(x => x.AddRange(It.IsAny<IEnumerable<UserPlayedMovie>>(), It.IsAny<bool>()))
+                .Callback<IEnumerable<UserPlayedMovie>, bool>((m, _) => _addedMovies.AddRange(m))
+                .Returns(Task.CompletedTask);
+            _mocker.Setup<IUserPlayedMovieRepository, Task<UserPlayedMovie>>(x => x.Get(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync((UserPlayedMovie)null);
+
+            _mocker.Setup<IEmbyContentRepository, Task<EmbyContent>>(x => x.GetByEmbyId(It.IsAny<string>()))
+                .ReturnsAsync(new EmbyContent { EmbyId = "series1", TheMovieDbId = "550", Type = MediaType.Series, Title = "Series" });
+
+            SetupPlayedMovies();
+            SetupPlayedEpisodes();
+
+            _context = new Mock<IJobExecutionContext>();
+            _context.Setup(x => x.MergedJobDataMap).Returns(new JobDataMap());
+
+            _subject = _mocker.CreateInstance<EmbyPlayedSync>();
+        }
+
+        [Test]
+        public async Task GarbageIndexNumberEnd_OnlyRecordsThePrimaryEpisode()
+        {
+            SetupPlayedEpisodes(Episode("ep1", episodeNumber: 1, indexNumberEnd: 406176));
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedEpisodes, Has.Count.EqualTo(1));
+            Assert.That(_addedEpisodes.Single().EpisodeNumber, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task IndexNumberEndBeforeIndexNumber_DoesNotFabricateEpisodes()
+        {
+            SetupPlayedEpisodes(Episode("ep1", episodeNumber: 5, indexNumberEnd: 3));
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedEpisodes, Has.Count.EqualTo(1));
+            Assert.That(_addedEpisodes.Single().EpisodeNumber, Is.EqualTo(5));
+        }
+
+        [Test]
+        public async Task SaneMultiEpisodeRange_RecordsEveryEpisodeInTheFile()
+        {
+            SetupPlayedEpisodes(Episode("ep1", episodeNumber: 1, indexNumberEnd: 3));
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedEpisodes.Select(x => x.EpisodeNumber), Is.EquivalentTo(new[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public async Task MovieWithNullProviderIds_IsSkippedWithoutCrashing()
+        {
+            SetupPlayedMovies(new EmbyMovie { Id = "movie1", Name = "No Metadata Movie", ProviderIds = null });
+
+            await _subject.Execute(_context.Object);
+
+            Assert.That(_addedMovies, Is.Empty);
+            _mocker.Verify<INotificationHubService>(x => x.SendNotificationToAdmins("Emby Content Sync Failed", It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task EmptyPlayedPageWithRemainingRecords_StopsInsteadOfRefetchingForever()
+        {
+            _api.Setup(x => x.GetTvPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyEpisodes> { TotalRecordCount = 50, Items = new List<EmbyEpisodes>() });
+
+            await _subject.Execute(_context.Object);
+
+            _api.Verify(x => x.GetTvPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        private void SetupPlayedMovies(params EmbyMovie[] movies)
+        {
+            _api.Setup(x => x.GetMoviesPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyMovie>
+                {
+                    TotalRecordCount = movies.Length,
+                    Items = movies.ToList()
+                });
+        }
+
+        private void SetupPlayedEpisodes(params EmbyEpisodes[] episodes)
+        {
+            _api.Setup(x => x.GetTvPlayed(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new EmbyItemContainer<EmbyEpisodes>
+                {
+                    TotalRecordCount = episodes.Length,
+                    Items = episodes.ToList()
+                });
+        }
+
+        private static EmbyEpisodes Episode(string id, int episodeNumber, int? indexNumberEnd = null) => new EmbyEpisodes
+        {
+            Id = id,
+            Name = $"Episode {id}",
+            SeriesId = "series1",
+            SeriesName = "Series",
+            IndexNumber = episodeNumber,
+            ParentIndexNumber = 1,
+            IndexNumberEnd = indexNumberEnd,
+            ProviderIds = null
+        };
+    }
+}

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -48,6 +48,8 @@ namespace Ombi.Schedule.Jobs.Emby
 
         public async override Task Execute(IJobExecutionContext context)
         {
+            // The set is run-scoped; clear it in case the same job instance is reused
+            _seenEmbyIds.Clear();
 
             await base.Execute(context);
 

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyContentSync.cs
@@ -39,11 +39,25 @@ namespace Ombi.Schedule.Jobs.Emby
         private readonly IEmbyContentRepository _repo;
         private readonly IFeatureService _feature;
 
+        private const int DeleteBatchSize = 1000;
+
+        // Every EmbyId the server reported during this run, used to work out which
+        // database records no longer exist on the server.
+        private readonly HashSet<string> _seenEmbyIds = new HashSet<string>();
+
 
         public async override Task Execute(IJobExecutionContext context)
         {
 
             await base.Execute(context);
+
+            // A full sync has seen everything on the server, so anything in our database
+            // that was not reported no longer exists in Emby (or lives in a library that
+            // is not enabled) and would otherwise produce incorrect availability results.
+            if (!recentlyAdded)
+            {
+                await RemoveStaleContent();
+            }
 
             // Episodes
             await OmbiQuartz.Scheduler.TriggerJob(new JobKey(nameof(IEmbyEpisodeSync), "Emby"), new JobDataMap(new Dictionary<string, string> { { JobDataKeys.EmbyRecentlyAddedSearch, recentlyAdded.ToString() } }));
@@ -81,6 +95,7 @@ namespace Ombi.Schedule.Jobs.Emby
             {
                 if (tv.Items == null || !tv.Items.Any())
                 {
+                    syncIncomplete = true;
                     _logger.LogWarning("Emby returned no TV shows at offset {0} but reported {1} total records. Stopping the sync for this library to avoid an infinite loop.",
                         processed, totalTv);
                     break;
@@ -89,15 +104,25 @@ namespace Ombi.Schedule.Jobs.Emby
                 foreach (var tvShow in tv.Items)
                 {
                     processed++;
-                    if (!tvShow.ProviderIds.Any())
+                    _seenEmbyIds.Add(tvShow.Id);
+
+                    // ProviderIds can be missing entirely from the API response, so guard
+                    // against null as well as empty. A series without provider ids is still
+                    // added (with its EmbyId only) so that its episodes can be linked and
+                    // the metadata refresh job can backfill the ids from the title later.
+                    var hasProviderIds = tvShow.ProviderIds?.Any() == true;
+                    if (!hasProviderIds)
                     {
-                        _logger.LogInformation("Provider Id on tv {0} is null", tvShow.Name);
-                        continue;
+                        _logger.LogInformation("Provider Id on tv {0} is null, adding it with its Emby Id only. The metadata refresh will attempt to backfill the provider ids.", tvShow.Name);
                     }
 
                     var existingTv = await _repo.GetByEmbyId(tvShow.Id);
 
-                    if (existingTv != null &&
+                    // Only treat differing ids as a reidentification when the incoming item
+                    // actually has provider ids, otherwise a series that lost its metadata
+                    // would wipe the ids we already have (including ones backfilled by the
+                    // metadata refresh job).
+                    if (existingTv != null && hasProviderIds &&
                         ( existingTv.ImdbId != tvShow.ProviderIds?.Imdb
                         || existingTv.TheMovieDbId != tvShow.ProviderIds?.Tmdb
                         || existingTv.TvDbId != tvShow.ProviderIds?.Tvdb))
@@ -170,6 +195,7 @@ namespace Ombi.Schedule.Jobs.Emby
             {
                 if (movies.Items == null || !movies.Items.Any())
                 {
+                    syncIncomplete = true;
                     _logger.LogWarning("Emby returned no movies at offset {0} but reported {1} total records. Stopping the sync for this library to avoid an infinite loop.",
                         processed, totalCount);
                     break;
@@ -209,12 +235,17 @@ namespace Ombi.Schedule.Jobs.Emby
 
         private async Task ProcessMovies(EmbyMovie movieInfo, ICollection<EmbyContent> content, ICollection<EmbyContent> toUpdate, EmbyServers server)
         {
+            _seenEmbyIds.Add(movieInfo.Id);
+
             var quality = movieInfo.MediaStreams?.FirstOrDefault()?.DisplayTitle ?? string.Empty;
             var has4K = false;
             if (quality.Contains("4K", CompareOptions.IgnoreCase))
             {
                 has4K = true;
             }
+
+            // ProviderIds can be missing entirely from the API response
+            var hasProviderIds = movieInfo.ProviderIds?.Any() == true;
 
             // Check if it exists
             var existingMovie = await _repo.GetByEmbyId(movieInfo.Id);
@@ -226,7 +257,7 @@ namespace Ombi.Schedule.Jobs.Emby
             }
             if (existingMovie == null)
             {
-                if (!movieInfo.ProviderIds.Any())
+                if (!hasProviderIds)
                 {
                     _logger.LogWarning($"Movie {movieInfo.Name} has no relevant metadata. Skipping.");
                     return;
@@ -240,7 +271,7 @@ namespace Ombi.Schedule.Jobs.Emby
             else
             {
                 var movieHasChanged = false;
-                if (existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb)
+                if (hasProviderIds && (existingMovie.ImdbId != movieInfo.ProviderIds.Imdb || existingMovie.TheMovieDbId != movieInfo.ProviderIds.Tmdb))
                 {
                     _logger.LogDebug($"Updating existing movie '{movieInfo.Name}'");
                     MapEmbyContent(existingMovie, movieInfo, server, has4K, quality);
@@ -271,7 +302,7 @@ namespace Ombi.Schedule.Jobs.Emby
         }
 
         private void MapEmbyContent(EmbyContent content, EmbyMovie movieInfo, EmbyServers server, bool has4K, string quality){
-            content.ImdbId = movieInfo.ProviderIds.Imdb;
+            content.ImdbId = movieInfo.ProviderIds?.Imdb;
             content.TheMovieDbId = movieInfo.ProviderIds?.Tmdb;
             content.Title = movieInfo.Name;
             content.Type = MediaType.Movie;
@@ -279,6 +310,59 @@ namespace Ombi.Schedule.Jobs.Emby
             content.Url = EmbyHelper.GetEmbyMediaUrl(movieInfo.Id, server?.ServerId, server.ServerHostname);
             content.Quality = has4K ? null : quality;
             content.Has4K = has4K;
+        }
+
+        /// <summary>
+        /// Removes content records (and their episodes) that were not reported by the
+        /// server during this run. This clears out ghosts left behind by removed or
+        /// reidentified items, which otherwise keep matching availability lookups forever.
+        /// Only runs after a complete full sync so we never delete based on partial data.
+        /// </summary>
+        private async Task RemoveStaleContent()
+        {
+            if (syncIncomplete)
+            {
+                _logger.LogWarning("Skipping the stale Emby content cleanup because the sync did not fully complete. Removing records based on a partial sync could delete content that still exists on the server.");
+                return;
+            }
+
+            if (!_seenEmbyIds.Any())
+            {
+                _logger.LogInformation("Skipping the stale Emby content cleanup because the server reported no content.");
+                return;
+            }
+
+            var dbContent = await _repo.GetAllContentIdentifiers();
+            var staleContent = dbContent.Where(x => string.IsNullOrEmpty(x.EmbyId) || !_seenEmbyIds.Contains(x.EmbyId)).ToList();
+            if (!staleContent.Any())
+            {
+                return;
+            }
+
+            _logger.LogInformation("Removing {0} Emby content records that no longer exist on the server", staleContent.Count);
+
+            var staleSeriesIds = staleContent
+                .Where(x => x.Type == MediaType.Series && !string.IsNullOrEmpty(x.EmbyId))
+                .Select(x => x.EmbyId)
+                .ToHashSet();
+            if (staleSeriesIds.Any())
+            {
+                var allEpisodes = await _repo.GetAllEpisodeIdentifiers();
+                var orphanedEpisodes = allEpisodes.Where(x => staleSeriesIds.Contains(x.ParentId)).ToList();
+                if (orphanedEpisodes.Any())
+                {
+                    _logger.LogInformation("Removing {0} episodes belonging to the removed series", orphanedEpisodes.Count);
+                    foreach (var chunk in orphanedEpisodes.Chunk(DeleteBatchSize))
+                    {
+                        await _repo.DeleteEpisodes(chunk);
+                    }
+                }
+            }
+
+            foreach (var chunk in staleContent.Chunk(DeleteBatchSize))
+            {
+                await _repo.DeleteRange(chunk);
+            }
         }
     }
 

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -150,22 +150,7 @@ namespace Ombi.Schedule.Jobs.Emby
             _logger.LogInformation($"Starting episode sync for server {server.Name}");
 
             // Get initial episode count
-            EmbyItemContainer<EmbyEpisodes> allEpisodes;
-            if (recentlyAdded)
-            {
-                var recentlyAddedAmountToTake = AmountToTake;
-                allEpisodes = await FetchEpisodesWithRetry(() => Api.RecentlyAddedEpisodes(server.ApiKey, parentIdFilter, 0, recentlyAddedAmountToTake, server.AdministratorId, server.FullUri));
-                total = allEpisodes.TotalRecordCount;
-                if (total > recentlyAddedAmountToTake)
-                {
-                    total = recentlyAddedAmountToTake;
-                }
-            }
-            else
-            {
-                allEpisodes = await FetchEpisodesWithRetry(() => Api.GetAllEpisodes(server.ApiKey, parentIdFilter, 0, AmountToTake, server.AdministratorId, server.FullUri));
-                total = allEpisodes.TotalRecordCount;
-            }
+            (var allEpisodes, total) = await FetchInitialEpisodes(server, recentlyAdded, parentIdFilter);
 
             _logger.LogInformation($"Processing {total} episodes in chunks of {AmountToTake}");
 
@@ -201,55 +186,14 @@ namespace Ombi.Schedule.Jobs.Emby
                     }
                 }
 
-                // Only commit to database when we reach the batch size or finish processing
                 // Apply batched metadata updates
-                if (pendingUpdates.Any())
-                {
-                    // Group updates by EmbyId so we update all rows for multi-episode files
-                    var updatesByEmbyId = pendingUpdates.GroupBy(u => u.Value.EmbyId);
-                    foreach (var group in updatesByEmbyId)
-                    {
-                        var entities = await _repo.GetEpisodesByEmbyId(group.Key);
-                        foreach (var entity in entities)
-                        {
-                            var matchingUpdate = group.FirstOrDefault(u => u.Value.EpisodeNumber == entity.EpisodeNumber);
-                            if (matchingUpdate.Key != null)
-                            {
-                                entity.SeasonNumber = matchingUpdate.Value.SeasonNumber;
-                                hasUpserts = true;
-                            }
-                            else
-                            {
-                                _logger.LogDebug("No matching update found for episode {EpisodeNumber} in EmbyId {EmbyId}",
-                                    entity.EpisodeNumber, group.Key);
-                            }
-                        }
-                    }
-                    pendingUpdates.Clear();
-                }
+                hasUpserts |= await ApplyPendingUpdates(pendingUpdates);
 
+                // Only commit to database when we reach the batch size or finish processing
                 if (epToAdd.Count >= DatabaseBatchSize || processed >= total)
                 {
-                    if (epToAdd.Any())
-                    {
-                        await _repo.AddRange(epToAdd);
-                        _logger.LogInformation($"Committed {epToAdd.Count} episodes to database. Progress: {processed}/{total}");
-
-                        // Update the episode metadata with newly added episodes to prevent duplicates in subsequent batches
-                        foreach (var episode in epToAdd)
-                        {
-                            episodeMetadata[$"{episode.EmbyId}:{episode.EpisodeNumber}"] = (episode.EpisodeNumber, episode.SeasonNumber);
-                        }
-                    }
-                    else if (hasUpserts)
-                    {
-                        // Save upserted episode metadata changes even if no new episodes were added
-                        await _repo.SaveChangesAsync();
-                        _logger.LogInformation($"Saved episode metadata updates. Progress: {processed}/{total}");
-                    }
-                    epToAdd.Clear();
+                    await CommitBatch(epToAdd, hasUpserts, episodeMetadata, episodesInCurrentBatch, processed, total);
                     hasUpserts = false;
-                    episodesInCurrentBatch.Clear();
                 }
 
                 // Get next chunk of episodes for processing
@@ -260,6 +204,81 @@ namespace Ombi.Schedule.Jobs.Emby
             }
 
             return completedWithoutGaps;
+        }
+
+        private async Task<(EmbyItemContainer<EmbyEpisodes> Episodes, int Total)> FetchInitialEpisodes(EmbyServers server, bool recentlyAdded, string parentIdFilter)
+        {
+            if (recentlyAdded)
+            {
+                var container = await FetchEpisodesWithRetry(() => Api.RecentlyAddedEpisodes(server.ApiKey, parentIdFilter, 0, AmountToTake, server.AdministratorId, server.FullUri));
+                return (container, Math.Min(container.TotalRecordCount, AmountToTake));
+            }
+
+            var allEpisodes = await FetchEpisodesWithRetry(() => Api.GetAllEpisodes(server.ApiKey, parentIdFilter, 0, AmountToTake, server.AdministratorId, server.FullUri));
+            return (allEpisodes, allEpisodes.TotalRecordCount);
+        }
+
+        private async Task<bool> ApplyPendingUpdates(Dictionary<string, (string EmbyId, int EpisodeNumber, int SeasonNumber)> pendingUpdates)
+        {
+            if (!pendingUpdates.Any())
+            {
+                return false;
+            }
+
+            var hasUpserts = false;
+
+            // Group updates by EmbyId so we update all rows for multi-episode files
+            var updatesByEmbyId = pendingUpdates.GroupBy(u => u.Value.EmbyId);
+            foreach (var group in updatesByEmbyId)
+            {
+                var entities = await _repo.GetEpisodesByEmbyId(group.Key);
+                foreach (var entity in entities)
+                {
+                    var matchingUpdate = group.FirstOrDefault(u => u.Value.EpisodeNumber == entity.EpisodeNumber);
+                    if (matchingUpdate.Key != null)
+                    {
+                        entity.SeasonNumber = matchingUpdate.Value.SeasonNumber;
+                        hasUpserts = true;
+                    }
+                    else
+                    {
+                        _logger.LogDebug("No matching update found for episode {EpisodeNumber} in EmbyId {EmbyId}",
+                            entity.EpisodeNumber, group.Key);
+                    }
+                }
+            }
+            pendingUpdates.Clear();
+
+            return hasUpserts;
+        }
+
+        private async Task CommitBatch(
+            HashSet<EmbyEpisode> epToAdd,
+            bool hasUpserts,
+            Dictionary<string, (int EpisodeNumber, int SeasonNumber)> episodeMetadata,
+            HashSet<string> episodesInCurrentBatch,
+            int processed,
+            int total)
+        {
+            if (epToAdd.Any())
+            {
+                await _repo.AddRange(epToAdd);
+                _logger.LogInformation("Committed {Count} episodes to database. Progress: {Processed}/{Total}", epToAdd.Count, processed, total);
+
+                // Update the episode metadata with newly added episodes to prevent duplicates in subsequent batches
+                foreach (var episode in epToAdd)
+                {
+                    episodeMetadata[$"{episode.EmbyId}:{episode.EpisodeNumber}"] = (episode.EpisodeNumber, episode.SeasonNumber);
+                }
+            }
+            else if (hasUpserts)
+            {
+                // Save upserted episode metadata changes even if no new episodes were added
+                await _repo.SaveChangesAsync();
+                _logger.LogInformation("Saved episode metadata updates. Progress: {Processed}/{Total}", processed, total);
+            }
+            epToAdd.Clear();
+            episodesInCurrentBatch.Clear();
         }
 
         private static void RecordSeenEpisode(EmbyEpisodes ep, HashSet<string> seenEpisodeKeys)

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -66,6 +66,10 @@ namespace Ombi.Schedule.Jobs.Emby
         private const int AmountToTake = 500;
         private const int DatabaseBatchSize = 1000;
 
+        // A single video file spanning more episodes than this is treated as corrupt
+        // metadata (e.g. absolute numbering leaking into IndexNumberEnd).
+        private const int MaxEpisodeFillCount = 50;
+
         private IEmbyApi Api { get; set; }
 
 
@@ -82,6 +86,13 @@ namespace Ombi.Schedule.Jobs.Emby
 
             Api = _apiFactory.CreateClient(settings);
             await _notification.SendNotificationToAdmins("Emby Episode Sync Started");
+
+            // Every EmbyId:EpisodeNumber the server reported during this run, used to work
+            // out which episode records no longer exist on the server. Only trustworthy
+            // when every server and library completed, tracked via syncIncomplete.
+            var seenEpisodeKeys = new HashSet<string>();
+            var syncIncomplete = false;
+
             foreach (var server in settings.Servers)
             {
                 try
@@ -92,19 +103,30 @@ namespace Ombi.Schedule.Jobs.Emby
                         foreach (var tvParentIdFilter in tvLibsToFilter)
                         {
                             _logger.LogInformation($"Scanning Lib for episodes '{tvParentIdFilter.Title}'");
-                            await CacheEpisodes(server, recentlyAddedSearch, tvParentIdFilter.Key);
+                            syncIncomplete |= !await CacheEpisodes(server, recentlyAddedSearch, tvParentIdFilter.Key, seenEpisodeKeys);
                         }
                     }
                     else
                     {
-                        await CacheEpisodes(server, recentlyAddedSearch, string.Empty);
+                        syncIncomplete |= !await CacheEpisodes(server, recentlyAddedSearch, string.Empty, seenEpisodeKeys);
                     }
                 }
                 catch (Exception e)
                 {
+                    syncIncomplete = true;
                     await _notification.SendNotificationToAdmins("Emby Episode Sync Failed");
                     _logger.LogError(e, "Exception when syncing Emby episodes for server {0}", server.Name);
                 }
+            }
+
+            // A full sync has seen every episode on the server, so anything in our
+            // database that was not reported no longer exists in Emby. This purges ghost
+            // records left behind by reidentifications (changed episode numbers create a
+            // new row and orphan the old one) which otherwise report availability for
+            // episodes that no longer exist.
+            if (!recentlyAddedSearch)
+            {
+                await RemoveStaleEpisodes(seenEpisodeKeys, syncIncomplete);
             }
 
             await _notification.SendNotificationToAdmins("Emby Episode Sync Finished");
@@ -112,7 +134,7 @@ namespace Ombi.Schedule.Jobs.Emby
             await OmbiQuartz.TriggerJob(nameof(IRefreshMetadata), "System");
         }
 
-        private async Task CacheEpisodes(EmbyServers server, bool recentlyAdded, string parentIdFilter)
+        private async Task<bool> CacheEpisodes(EmbyServers server, bool recentlyAdded, string parentIdFilter, HashSet<string> seenEpisodeKeys)
         {
             // Preload existing data to eliminate N+1 queries
             var seriesLookup = await _repo.GetAllSeriesEmbyIds();
@@ -147,10 +169,12 @@ namespace Ombi.Schedule.Jobs.Emby
 
             _logger.LogInformation($"Processing {total} episodes in chunks of {AmountToTake}");
 
+            var completedWithoutGaps = true;
             while (processed < total)
             {
                 if (allEpisodes.Items == null || !allEpisodes.Items.Any())
                 {
+                    completedWithoutGaps = false;
                     _logger.LogWarning("Emby returned no episodes at offset {0} but reported {1} total records. Stopping the sync for this library to avoid an infinite loop.",
                         processed, total);
                     break;
@@ -161,6 +185,11 @@ namespace Ombi.Schedule.Jobs.Emby
                 foreach (var ep in allEpisodes.Items)
                 {
                     processed++;
+
+                    // Record everything the server reports, even episodes we go on to
+                    // skip - "seen" means "exists in Emby", which is what the stale
+                    // record cleanup needs to know.
+                    RecordSeenEpisode(ep, seenEpisodeKeys);
 
                     try
                     {
@@ -229,7 +258,60 @@ namespace Ombi.Schedule.Jobs.Emby
                     allEpisodes = await FetchEpisodesWithRetry(() => Api.GetAllEpisodes(server.ApiKey, parentIdFilter, processed, AmountToTake, server.AdministratorId, server.FullUri));
                 }
             }
+
+            return completedWithoutGaps;
         }
+
+        private static void RecordSeenEpisode(EmbyEpisodes ep, HashSet<string> seenEpisodeKeys)
+        {
+            seenEpisodeKeys.Add($"{ep.Id}:{ep.IndexNumber}");
+
+            // Multi-episode files produce one database row per episode in the span, all
+            // sharing the same EmbyId. Mirror the sane-range rules used when inserting.
+            if (ep.IndexNumberEnd.HasValue
+                && ep.IndexNumberEnd.Value > ep.IndexNumber
+                && ep.IndexNumberEnd.Value - ep.IndexNumber <= MaxEpisodeFillCount)
+            {
+                for (var episodeNumber = ep.IndexNumber + 1; episodeNumber <= ep.IndexNumberEnd.Value; episodeNumber++)
+                {
+                    seenEpisodeKeys.Add($"{ep.Id}:{episodeNumber}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes episode records that were not reported by the server during a full
+        /// sync. Skipped when the sync was incomplete or reported nothing, so records are
+        /// never removed based on partial data.
+        /// </summary>
+        private async Task RemoveStaleEpisodes(HashSet<string> seenEpisodeKeys, bool syncIncomplete)
+        {
+            if (syncIncomplete)
+            {
+                _logger.LogWarning("Skipping the stale Emby episode cleanup because the sync did not fully complete. Removing records based on a partial sync could delete episodes that still exist on the server.");
+                return;
+            }
+
+            if (!seenEpisodeKeys.Any())
+            {
+                _logger.LogInformation("Skipping the stale Emby episode cleanup because the server reported no episodes.");
+                return;
+            }
+
+            var dbEpisodes = await _repo.GetAllEpisodeIdentifiers();
+            var staleEpisodes = dbEpisodes.Where(x => !seenEpisodeKeys.Contains($"{x.EmbyId}:{x.EpisodeNumber}")).ToList();
+            if (!staleEpisodes.Any())
+            {
+                return;
+            }
+
+            _logger.LogInformation("Removing {0} episode records that no longer exist on the Emby server", staleEpisodes.Count);
+            foreach (var chunk in staleEpisodes.Chunk(DatabaseBatchSize))
+            {
+                await _repo.DeleteEpisodes(chunk);
+            }
+        }
+
         private void ProcessEpisode(
             EmbyEpisodes ep,
             HashSet<string> seriesLookup,
@@ -291,7 +373,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 {
                     var episodeFillCount = ep.IndexNumberEnd.Value - ep.IndexNumber;
 
-                    if (episodeFillCount > 50)
+                    if (episodeFillCount > MaxEpisodeFillCount)
                     {
                         // The primary episode has already been added above; we just skip
                         // the implausible fill rather than discarding the whole file.

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyEpisodeSync.cs
@@ -264,17 +264,22 @@ namespace Ombi.Schedule.Jobs.Emby
 
         private static void RecordSeenEpisode(EmbyEpisodes ep, HashSet<string> seenEpisodeKeys)
         {
-            seenEpisodeKeys.Add($"{ep.Id}:{ep.IndexNumber}");
+            // The series id is part of the identity: if Emby re-links the same item id
+            // and episode number to a different series, the old row (pointing at the
+            // previous series) must be treated as stale, not seen.
+            seenEpisodeKeys.Add($"{ep.Id}:{ep.IndexNumber}:{ep.SeriesId}");
 
             // Multi-episode files produce one database row per episode in the span, all
             // sharing the same EmbyId. Mirror the sane-range rules used when inserting.
+            // The subtraction is done as long so a bogus negative IndexNumber cannot
+            // overflow the span and bypass the cap.
             if (ep.IndexNumberEnd.HasValue
                 && ep.IndexNumberEnd.Value > ep.IndexNumber
-                && ep.IndexNumberEnd.Value - ep.IndexNumber <= MaxEpisodeFillCount)
+                && (long)ep.IndexNumberEnd.Value - ep.IndexNumber <= MaxEpisodeFillCount)
             {
                 for (var episodeNumber = ep.IndexNumber + 1; episodeNumber <= ep.IndexNumberEnd.Value; episodeNumber++)
                 {
-                    seenEpisodeKeys.Add($"{ep.Id}:{episodeNumber}");
+                    seenEpisodeKeys.Add($"{ep.Id}:{episodeNumber}:{ep.SeriesId}");
                 }
             }
         }
@@ -299,7 +304,7 @@ namespace Ombi.Schedule.Jobs.Emby
             }
 
             var dbEpisodes = await _repo.GetAllEpisodeIdentifiers();
-            var staleEpisodes = dbEpisodes.Where(x => !seenEpisodeKeys.Contains($"{x.EmbyId}:{x.EpisodeNumber}")).ToList();
+            var staleEpisodes = dbEpisodes.Where(x => !seenEpisodeKeys.Contains($"{x.EmbyId}:{x.EpisodeNumber}:{x.ParentId}")).ToList();
             if (!staleEpisodes.Any())
             {
                 return;
@@ -371,7 +376,9 @@ namespace Ombi.Schedule.Jobs.Emby
                 // either skipped the file entirely or fabricated phantom episode rows.
                 if (ep.IndexNumberEnd.HasValue && ep.IndexNumberEnd.Value > ep.IndexNumber)
                 {
-                    var episodeFillCount = ep.IndexNumberEnd.Value - ep.IndexNumber;
+                    // Subtract as long so a bogus negative IndexNumber cannot overflow the
+                    // span, bypass the cap below and drive a huge fill loop
+                    var episodeFillCount = (long)ep.IndexNumberEnd.Value - ep.IndexNumber;
 
                     if (episodeFillCount > MaxEpisodeFillCount)
                     {

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyLibrarySync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyLibrarySync.cs
@@ -26,6 +26,13 @@ namespace Ombi.Schedule.Jobs.Emby
         protected readonly ISettingsService<EmbySettings> _settings;
         protected readonly IEmbyApiFactory _apiFactory;
         protected bool recentlyAdded;
+
+        /// <summary>
+        /// Set when any server was skipped or failed part-way through, meaning the sync
+        /// did not see the full picture of what exists on the media server. Derived jobs
+        /// must not remove records they consider stale while this is set.
+        /// </summary>
+        protected bool syncIncomplete;
         protected readonly INotificationHubService _notification;
 
         protected const int AmountToTake = 300;
@@ -58,6 +65,7 @@ namespace Ombi.Schedule.Jobs.Emby
                 }
                 catch (Exception e)
                 {
+                    syncIncomplete = true;
                     await _notification.SendNotificationToAdmins("Emby Content Sync Failed");
                     _logger.LogError(e, "Exception when caching Emby for server {0}", server.Name);
                 }
@@ -71,6 +79,7 @@ namespace Ombi.Schedule.Jobs.Emby
         {
             if (!ValidateSettings(server))
             {
+                syncIncomplete = true;
                 return;
             }
 

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
@@ -40,6 +40,12 @@ namespace Ombi.Schedule.Jobs.Emby
         private readonly IUserPlayedEpisodeRepository _episodeRepo;
         private readonly IEmbyContentRepository _contentRepo;
 
+        // A single video file spanning more episodes than this is treated as corrupt
+        // metadata (e.g. absolute numbering leaking into IndexNumberEnd). Without this
+        // guard a single bad item can loop for hundreds of thousands of iterations,
+        // each one hitting the database.
+        private const int MaxEpisodeFillCount = 50;
+
         protected async override Task ProcessTv(EmbyServers server, string parentId = default)
         {
             var allUsers = await _userManager.Users.Where(x => x.UserType == UserType.EmbyUser || x.UserType == UserType.EmbyConnectUser).ToListAsync();
@@ -83,6 +89,13 @@ namespace Ombi.Schedule.Jobs.Emby
 
             while (processed < totalCount)
             {
+                if (movies.Items == null || !movies.Items.Any())
+                {
+                    _logger.LogWarning("Emby returned no played movies at offset {0} but reported {1} total records. Stopping the sync for this user to avoid an infinite loop.",
+                        processed, totalCount);
+                    break;
+                }
+
                 foreach (var movie in movies.Items)
                 {
                     await ProcessMovie(movie, user, mediaToAdd, server);
@@ -102,14 +115,17 @@ namespace Ombi.Schedule.Jobs.Emby
 
         private async Task ProcessMovie(EmbyMovie movieInfo, OmbiUser user, ICollection<UserPlayedMovie> content, EmbyServers server)
         {
-            if (movieInfo.ProviderIds.Tmdb.IsNullOrEmpty())
+            // ProviderIds can be missing entirely from the API response, so guard against
+            // null as well as an empty Tmdb id
+            var tmdbId = movieInfo.ProviderIds?.Tmdb;
+            if (tmdbId.IsNullOrEmpty() || !int.TryParse(tmdbId, out var theMovieDbId))
             {
                 _logger.LogWarning($"Movie {movieInfo.Name} has no relevant metadata. Skipping.");
                 return;
             }
             var userPlayedMovie = new UserPlayedMovie()
             {
-                TheMovieDbId = int.Parse(movieInfo.ProviderIds.Tmdb),
+                TheMovieDbId = theMovieDbId,
                 UserId = user.Id
             };
             // Check if it exists
@@ -144,6 +160,13 @@ namespace Ombi.Schedule.Jobs.Emby
 
             while (processed < totalCount)
             {
+                if (episodes.Items == null || !episodes.Items.Any())
+                {
+                    _logger.LogWarning("Emby returned no played episodes at offset {0} but reported {1} total records. Stopping the sync for this user to avoid an infinite loop.",
+                        processed, totalCount);
+                    break;
+                }
+
                 foreach (var episode in episodes.Items)
                 {
                     await ProcessTv(episode, user, mediaToAdd, server);
@@ -191,25 +214,36 @@ namespace Ombi.Schedule.Jobs.Emby
                 UserId = user.Id
             });
 
-            if (episode.IndexNumberEnd.HasValue && episode.IndexNumberEnd.Value != episode.IndexNumber)
+            // A multi-episode file spans IndexNumber..IndexNumberEnd. Only fill the
+            // additional episodes when the range is sane: IndexNumberEnd must be greater
+            // than IndexNumber and the span plausible. Some Emby servers report a bogus
+            // IndexNumberEnd (absolute numbering or corrupt metadata) that previously
+            // caused this loop to fabricate played records for episodes that do not
+            // exist, or to run for hundreds of thousands of iterations.
+            if (episode.IndexNumberEnd.HasValue && episode.IndexNumberEnd.Value > episode.IndexNumber)
             {
-                int episodeNumber = episode.IndexNumber;
-                do
+                var episodeFillCount = episode.IndexNumberEnd.Value - episode.IndexNumber;
+
+                if (episodeFillCount > MaxEpisodeFillCount)
                 {
-                    _logger.LogDebug($"Multiple-episode file detected. Adding episode ${episodeNumber}");
-                    episodeNumber++;
-
-                    await AddToContent(content, new UserPlayedEpisode()
+                    _logger.LogWarning(
+                        $"Episode {episode.Name} from series {episode.SeriesName} reports {episodeFillCount} episodes in a single file, which is almost certainly incorrect metadata. Only the primary episode was recorded as played.");
+                }
+                else
+                {
+                    for (var episodeNumber = episode.IndexNumber + 1; episodeNumber <= episode.IndexNumberEnd.Value; episodeNumber++)
                     {
-                        TheMovieDbId = parentMovieDb,
-                        SeasonNumber = episode.ParentIndexNumber,
-                        EpisodeNumber = episodeNumber,
-                        UserId = user.Id
-                    });
+                        _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
 
-
-                } while (episodeNumber < episode.IndexNumberEnd.Value);
-
+                        await AddToContent(content, new UserPlayedEpisode()
+                        {
+                            TheMovieDbId = parentMovieDb,
+                            SeasonNumber = episode.ParentIndexNumber,
+                            EpisodeNumber = episodeNumber,
+                            UserId = user.Id
+                        });
+                    }
+                }
             }
         }
 

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
@@ -222,7 +222,9 @@ namespace Ombi.Schedule.Jobs.Emby
             // exist, or to run for hundreds of thousands of iterations.
             if (episode.IndexNumberEnd.HasValue && episode.IndexNumberEnd.Value > episode.IndexNumber)
             {
-                var episodeFillCount = episode.IndexNumberEnd.Value - episode.IndexNumber;
+                // Subtract as long so a bogus negative IndexNumber cannot overflow the
+                // span, bypass the cap below and drive a huge fill loop
+                var episodeFillCount = (long)episode.IndexNumberEnd.Value - episode.IndexNumber;
 
                 if (episodeFillCount > MaxEpisodeFillCount)
                 {

--- a/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
+++ b/src/Ombi.Schedule/Jobs/Emby/EmbyPlayedSync.cs
@@ -229,13 +229,14 @@ namespace Ombi.Schedule.Jobs.Emby
                 if (episodeFillCount > MaxEpisodeFillCount)
                 {
                     _logger.LogWarning(
-                        $"Episode {episode.Name} from series {episode.SeriesName} reports {episodeFillCount} episodes in a single file, which is almost certainly incorrect metadata. Only the primary episode was recorded as played.");
+                        "Episode {EpisodeName} from series {SeriesName} reports {EpisodeFillCount} episodes in a single file, which is almost certainly incorrect metadata. Only the primary episode was recorded as played.",
+                        episode.Name, episode.SeriesName, episodeFillCount);
                 }
                 else
                 {
                     for (var episodeNumber = episode.IndexNumber + 1; episodeNumber <= episode.IndexNumberEnd.Value; episodeNumber++)
                     {
-                        _logger.LogDebug($"Multiple-episode file detected. Adding episode {episodeNumber}");
+                        _logger.LogDebug("Multiple-episode file detected. Adding episode {EpisodeNumber}", episodeNumber);
 
                         await AddToContent(content, new UserPlayedEpisode()
                         {

--- a/src/Ombi.Store/Repository/EmbyContentRepository.cs
+++ b/src/Ombi.Store/Repository/EmbyContentRepository.cs
@@ -145,5 +145,30 @@ namespace Ombi.Store.Repository
                 .GroupBy(x => $"{x.EmbyId}:{x.EpisodeNumber}")
                 .ToDictionary(g => g.Key, g => (g.First().EpisodeNumber, g.First().SeasonNumber));
         }
+
+        // Stale record cleanup. These return detached stub entities carrying only the
+        // columns needed to identify a record, so the sync jobs can diff the database
+        // against what the Emby API reports without materialising full entities.
+        public async Task<List<EmbyContent>> GetAllContentIdentifiers()
+        {
+            var rows = await Db.EmbyContent.AsNoTracking()
+                .Select(x => new { x.Id, x.EmbyId, x.Type, x.Title })
+                .ToListAsync();
+            return rows.Select(x => new EmbyContent { Id = x.Id, EmbyId = x.EmbyId, Type = x.Type, Title = x.Title }).ToList();
+        }
+
+        public async Task<List<EmbyEpisode>> GetAllEpisodeIdentifiers()
+        {
+            var rows = await Db.EmbyEpisode.AsNoTracking()
+                .Select(x => new { x.Id, x.EmbyId, x.EpisodeNumber, x.ParentId })
+                .ToListAsync();
+            return rows.Select(x => new EmbyEpisode { Id = x.Id, EmbyId = x.EmbyId, EpisodeNumber = x.EpisodeNumber, ParentId = x.ParentId }).ToList();
+        }
+
+        public async Task DeleteEpisodes(IEnumerable<EmbyEpisode> episodes)
+        {
+            Db.EmbyEpisode.RemoveRange(episodes);
+            await InternalSaveChanges();
+        }
     }
 }

--- a/src/Ombi.Store/Repository/IEmbyContentRepository.cs
+++ b/src/Ombi.Store/Repository/IEmbyContentRepository.cs
@@ -23,5 +23,9 @@ namespace Ombi.Store.Repository
         Task<HashSet<string>> GetAllEpisodeEmbyIds();
         Task<Dictionary<string, (int EpisodeNumber, int SeasonNumber)>> GetAllEpisodeMetadata();
 
+        // Stale record cleanup
+        Task<List<EmbyContent>> GetAllContentIdentifiers();
+        Task<List<EmbyEpisode>> GetAllEpisodeIdentifiers();
+        Task DeleteEpisodes(IEnumerable<EmbyEpisode> episodes);
     }
 }


### PR DESCRIPTION
## 📝 Description

Hardens the Emby sync pipeline against the remaining failure modes reported in #5356:

- **Stale record cleanup**: full content and episode syncs now remove records the server no longer reports, purging ghost rows left behind by reidentifications and removed items which otherwise keep matching availability lookups forever. Cleanup is skipped for recently-added syncs, failed or partial syncs, and empty server responses, so records are never removed based on incomplete data. The stale-episode identity includes the parent series, so an episode Emby re-linked to a different series is also cleaned up.
- **Played sync hardening**: only fill multi-episode files with a sane range (previously a single item with corrupt `IndexNumberEnd` metadata could fabricate played records and loop hundreds of thousands of times, hitting the database on every iteration), guard against null `ProviderIds`, and stop paginating when the server returns an empty page while reporting more records. Fill-span subtraction is done as `long` so a bogus negative `IndexNumber` cannot overflow past the cap.
- **Provider-id-less series**: series with no provider ids are now added with their Emby id instead of being skipped entirely, so their episodes can be linked and the title fallback can match them; the metadata refresh job backfills the provider ids later. A series that loses its provider ids no longer wipes ids we already have, and null `ProviderIds` no longer crash the TV or movie content sync.

## 🔗 Related Issues

Addresses the remaining items from #5356.

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [x] No breaking changes

New tests cover stale content/episode cleanup (including the re-linked series and skipped-when-incomplete cases), provider-id-less series handling, the multi-episode fill guards and overflow case, and the pagination termination guards. Full `Ombi.Schedule.Tests` suite passes (129 tests).

## 📸 Screenshots (if applicable)

N/A - backend only.

## 📋 Checklist

- [x] My code follows the project's coding standards
- [ ] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

The cleanup pass also means that content in libraries which are disabled in Ombi's settings is removed from Ombi's cache during a full sync, which makes the library-selection setting actually take effect - previously those rows lingered forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Emby sync resilience for missing/invalid provider and TMDB data, preventing crashes and unintended removals.
  * Prevented infinite paging when Emby reports remaining records but returns empty items.
  * Hardened multi-episode handling with safer range logic and capped filling.
* **New Features**
  * Added more reliable full-sync stale cleanup for content and episodes that no longer exist on the server, while keeping “recently added” behaviour intact.
* **Tests**
  * Expanded coverage for content/episode cleanup, multi-episode scenarios, and played syncing pagination and range edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->