### PR TITLE
fix(settings): resolve mobile dropdown positioning and horizontal layout overflow

### DIFF
--- a/src/Ombi/ClientApp/src/app/settings/couchpotato/couchpotato.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/couchpotato/couchpotato.component.html
@@ -12,7 +12,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-5 col-7 col-sm-12">
+                <div class="col-md-5 col-12">
                     <label for="username" class="control-label"><h3>Server Configuration</h3></label>
                     <div class="md-form-field">
                         <mat-form-field appearance="outline" >
@@ -46,7 +46,7 @@
                         </mat-form-field>
                     </div>
                 </div>
-                <div class="col-md-5 col-4 col-sm-12">
+                <div class="col-md-5 col-12">
                     <label for="username" class="control-label"><h3>Interface</h3></label>
                     <div class="form-group col-md-12">
                         <div id="profiles">

--- a/src/Ombi/ClientApp/src/app/settings/dognzb/dognzb.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/dognzb/dognzb.component.html
@@ -1,4 +1,4 @@
-﻿<settings-menu>
+<settings-menu>
 </settings-menu>
 <div>
 <div *ngIf="form" class="small-middle-container">
@@ -13,7 +13,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-7 col-8 col-sm-12">
+                <div class="col-md-7 col-12">
                     <div class="md-form-field">
                         <mat-form-field appearance="outline" floatLabel=always>
                             <mat-label>DogNzb API Key</mat-label>
@@ -31,7 +31,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-7 col-8 col-sm-12">
+                <div class="col-md-7 col-12">
                     <div class="md-form-field">
                         <div>
                             <br />

--- a/src/Ombi/ClientApp/src/app/settings/issues/issues.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/issues/issues.component.scss
@@ -13,16 +13,18 @@
     display: contents;
 }
 
-.col-md-9 {
-    display: inline-table;
-}
-
-.col-md-3 {
-    display: inline-table;
-}
-
-.row {
-    display: block;
+@media (min-width: 768px) {
+    .col-md-9 {
+        display: inline-table;
+    }
+    
+    .col-md-3 {
+        display: inline-table;
+    }
+    
+    .row {
+        display: block;
+    }
 }
 
 .btn-danger-outline {

--- a/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.html
@@ -1,4 +1,4 @@
-﻿<div *ngIf="form" class="small-middle-container">
+<div *ngIf="form" class="small-middle-container">
     <fieldset>
       <legend>Lidarr Settings</legend>
       <div class="md-form-field" style="margin-top:1em;"></div>
@@ -16,7 +16,7 @@
         </div>
         </div>
         <div class="row">
-          <div class="col-md-7 col-8 col-sm-12">
+          <div class="col-md-7 col-12">
             <label for="username" class="control-label">
               <h3>Server Configuration</h3>
             </label>
@@ -47,7 +47,7 @@
               </mat-form-field>
             </div>
           </div>
-          <div class="col-md-5 col-4 col-sm-12">
+          <div class="col-md-5 col-12">
 
             <label for="username" class="control-label">
               <h3>Interface</h3>

--- a/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/lidarr/lidarr.component.scss
@@ -5,13 +5,14 @@
     margin-top: 10px;
 }
 
-.col-8 {
-    display: inline-table;
-}
-.col-md-5 {
-    display: inline-table;
-}
-
-.row {
-    display: block;
+@media (min-width: 768px) {
+    .col-md-7 {
+        display: inline-table;
+    }
+    .col-md-5 {
+        display: inline-table;
+    }
+    .row {
+        display: block;
+    }
 }

--- a/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/plex/plex.component.scss
@@ -5,14 +5,6 @@
     margin-top: 10px;
 }
 
-.col-8 {
-    display: inline-table;
-}
-.col-md-5 {
-    display: inline-table;
-}
-
-
 .align-right {
     float: right;
     width:100%;

--- a/src/Ombi/ClientApp/src/app/settings/radarr/components/radarr-form.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/radarr/components/radarr-form.component.html
@@ -1,4 +1,4 @@
-﻿<div [formGroup]="form">
+<div [formGroup]="form">
             <div class="row top-spacing">
                 <div class="col-md-12 col-12 col-sm-12">
                     <div >
@@ -26,7 +26,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-7 col-8 col-sm-12">
+                <div class="col-md-7 col-12">
                     <label for="username" class="control-label"><h3>Radarr Server Configuration</h3></label>
                     <div class="md-form-field">
                         <mat-form-field appearance="outline" >
@@ -58,7 +58,7 @@
                         </mat-form-field>
                     </div>
                 </div>
-                <div class="col-md-5 col-4 col-sm-12">
+                <div class="col-md-5 col-12">
                     <label for="username" class="control-label"><h3>Radarr Interface</h3></label>
                     <div class="md-form-field">
                     <div class="md-form-field" style="display:inline;">

--- a/src/Ombi/ClientApp/src/app/settings/radarr/components/radarr-form.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/radarr/components/radarr-form.component.scss
@@ -5,15 +5,16 @@
     margin-top: 10px;
 }
 
-.col-8 {
-    display: inline-table;
-}
-.col-md-5 {
-    display: inline-table;
-}
-
-.row {
-    display: block;
+@media (min-width: 768px) {
+    .col-md-7 {
+        display: inline-table;
+    }
+    .col-md-5 {
+        display: inline-table;
+    }
+    .row {
+        display: block;
+    }
 }
 
 .top-spacing {

--- a/src/Ombi/ClientApp/src/app/settings/radarr/radarr.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/radarr/radarr.component.scss
@@ -4,14 +4,3 @@
     width: 95%;
     margin-top: 10px;
 }
-
-.col-8 {
-    display: inline-table;
-}
-.col-md-5 {
-    display: inline-table;
-}
-
-.row {
-    display: block;
-}

--- a/src/Ombi/ClientApp/src/app/settings/sickrage/sickrage.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/sickrage/sickrage.component.html
@@ -1,4 +1,4 @@
-﻿
+
 <div *ngIf="form" class="small-middle-container">
     <fieldset>
         <legend>SickRage Settings</legend>
@@ -16,7 +16,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-7 col-8 col-sm-12">
+                <div class="col-md-7 col-12">
                     <label for="select" class="control-label"><h3>SickRage Server Configuration</h3></label>
                     <div class="md-form-field">
                         <mat-form-field appearance="outline" floatLabel=always>
@@ -49,7 +49,7 @@
                         </mat-form-field>
                     </div>
                 </div>
-                <div class="col-md-5 col-4 col-sm-12">
+                <div class="col-md-5 col-12">
                     <div class="form-group">
                         <label for="select" class="control-label"><h3>SickRage Quality Profiles</h3></label>
                         <div id="profiles">

--- a/src/Ombi/ClientApp/src/app/settings/sonarr/sonarr.component.html
+++ b/src/Ombi/ClientApp/src/app/settings/sonarr/sonarr.component.html
@@ -1,4 +1,4 @@
-﻿﻿<div *ngIf="form" class="small-middle-container">
+<div *ngIf="form" class="small-middle-container">
     <fieldset>
         <legend>Sonarr Settings</legend>
         <div class="md-form-field" style="margin-top:1em;"></div>
@@ -28,7 +28,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-7 col-8 col-sm-12">
+                <div class="col-md-7 col-12">
                     <label for="username" class="control-label"><h3>Sonarr Server Configuration</h3></label>
                     <div class="md-form-field">
                         <mat-form-field appearance="outline" floatLabel=always>
@@ -59,7 +59,7 @@
                         </mat-form-field>
                     </div>
                 </div>
-                <div class="col-md-5 col-4 col-sm-12">
+                <div class="col-md-5 col-12">
 
                     <div class="form-group col-md-12">
                         <div class="row">

--- a/src/Ombi/ClientApp/src/app/settings/sonarr/sonarr.component.scss
+++ b/src/Ombi/ClientApp/src/app/settings/sonarr/sonarr.component.scss
@@ -5,11 +5,13 @@
     margin-top: 10px;
 }
 
-.col-8 {
-    display: inline-table;
-}
-.col-md-5 {
-    display: inline-table;
+@media (min-width: 768px) {
+    .col-md-7 {
+        display: inline-table;
+    }
+    .col-md-5 {
+        display: inline-table;
+    }
 }
 
 ::ng-deep .load {

--- a/src/Ombi/ClientApp/src/styles/material-overrides.scss
+++ b/src/Ombi/ClientApp/src/styles/material-overrides.scss
@@ -2,10 +2,12 @@
 
 .lg-form-field .mat-form-field-infix {
     width: 480px;
+    max-width: 100%;
 }
 
 .md-form-field .mat-form-field-infix {
     width: 380px;
+    max-width: 100%;
 }
 
 td.mat-cell {


### PR DESCRIPTION
## 📝 Description

This PR resolves horizontal layout overflow and select dropdown misalignment on mobile/tablet viewports for the settings pages.

On mobile viewports, the Sonarr, Radarr, Lidarr, CouchPotato, SickRage, and DogNZB settings forms were forced to display side-by-side using narrow column widths (e.g., `col-8` and `col-4`). Due to the form elements inside having fixed widths (like `width: 380px`), they overflowed significantly to the right of the viewport, pushing the select inputs and their overlay panels off-screen. On Radarr (which uses `<mat-tab-group>`), the container has `overflow: hidden;` which clipped this overflow and made the dropdowns completely inaccessible on phones.

## 🔗 Related Issues

Fixes #5414

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [x] No breaking changes

### Test Run Details:
- **Backend Tests (.NET)**: 524/524 tests passed (0 failures).
- **Frontend Tests (Vitest)**: 993/1015 tests passed. The 22 failures are pre-existing issues unrelated to these changes (failures in `auth.service.spec.ts` and `storage-service.spec.ts` due to `TypeError: localStorage.clear is not a function`, and one timezone test failure in `OmbiDatePipe.spec.ts`).

Tested manually on a local development server using mobile device emulation in Chrome Compatibility Tools and verified live on a phone via WSL port proxy. 

## 📸 Screenshots (if applicable)

*N/A*

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

**Vibe Coding Notice**: Yes, this PR is a vibe coded PR, but it has been thoroughly and manually validated to ensure correctness and that no regressions are introduced to the desktop views.

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

The layout overrides like `display: inline-table;` were wrapped in a `@media (min-width: 768px)` query to preserve the original desktop alignment while letting mobile fall back to the standard Bootstrap vertical flex grid structure. Large/medium input form fields are also limited to `max-width: 100%` in the global `material-overrides.scss` to prevent viewport stretching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layout across multiple settings pages so the two-column form sections stack cleanly on smaller screens.
  * Scoped column/row display styling to apply only on larger breakpoints to prevent mobile/tablet misalignment.
  * Removed stray leading characters that could affect template rendering.
  * Tightened Material form field widths to prevent controls overflowing their containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->