### PR TITLE
fix: resolve user data leakage in BCC mass email templates (#5444) [skip ci]

### DIFF
--- a/src/Ombi.Core.Tests/Senders/MassEmailSenderTests.cs
+++ b/src/Ombi.Core.Tests/Senders/MassEmailSenderTests.cs
@@ -149,7 +149,7 @@ namespace Ombi.Core.Tests.Senders
         {
             var model = new MassEmailModel
             {
-                Body = "Test",
+                Body = "Test {Alias} {UserName}",
                 Subject = "Subject",
                 Bcc = true,
                 Users = new List<OmbiUser>
@@ -182,7 +182,7 @@ namespace Ombi.Core.Tests.Senders
             var result = await _subject.SendMassEmail(model);
 
             _mocker.Verify<IEmailProvider>(x => x.SendAdHoc(It.Is<NotificationMessage>(m => m.Subject == model.Subject
-            && m.Message == model.Body
+            && m.Message == "Test User User"
             && m.Other["bcc"] == "Test@test.com,b@test.com"), It.IsAny<EmailNotificationSettings>()), Times.Once);
         }
 

--- a/src/Ombi.Core/Senders/MassEmailSender.cs
+++ b/src/Ombi.Core/Senders/MassEmailSender.cs
@@ -103,10 +103,8 @@ namespace Ombi.Core.Senders
                 return;
             }
 
-            var firstUser = validUsers.FirstOrDefault();
-
             var bccAddress = string.Join(',', validUsers.Select(x => x.Email));
-            curlys.Setup(firstUser, customization);
+            curlys.Setup(new OmbiUser { UserName = "User", Alias = "User" }, customization);
             var template = new NotificationTemplates() { Message = model.Body, Subject = model.Subject };
             var content = resolver.ParseMessage(template, curlys);
             var msg = new NotificationMessage


### PR DESCRIPTION
## 📝 Description

When sending mass emails via BCC with templates containing personalized placeholders (like `{Alias}`, `{UserName}`), the template was previously resolved once using the first user in the recipient list (`validUsers.FirstOrDefault()`). Because BCC sends a single copy of the email body to all recipients, everyone received a message addressed to that first user, exposing their real username/alias.

This PR fixes the data leakage by instantiating a generic dummy `OmbiUser` (`UserName = "User", Alias = "User"`) to resolve placeholders to a generic `"User"` value when in BCC mode.

## 🔗 Related Issues

Fixes #5239

## 🧪 Testing

Updated the unit test in `MassEmailSenderTests.cs` (`SendMassEmail_Bcc`) to include `{Alias}` and `{UserName}` in the test message body and verified that they correctly resolve to `"User"`.

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [x] No breaking changes

## 📸 Screenshots (if applicable)

N/A (Backend change)

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR (Yes, this was fully vibe coded!)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

This PR was vibe coded with love by Antigravity AI assistant pair-programming with the repository owner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mass email sending so template placeholders are resolved consistently when sending BCC messages.
  * Ensured the generated email content uses the expected recipient name values for bulk emails, leading to more accurate personalised output.
* **Tests**
  * Updated mass email sender tests to reflect the corrected placeholder-based message content and expected provider payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->