### PR TITLE
fix: respect Sonarr availability priority for TV episodes (#5445) [skip ci]

### DIFF
--- a/src/Ombi.Core.Tests/Rule/Search/EmbyAvailabilityRuleTests.cs
+++ b/src/Ombi.Core.Tests/Rule/Search/EmbyAvailabilityRuleTests.cs
@@ -1,13 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
+using MockQueryable.Moq;
 using NUnit.Framework;
 using Ombi.Core.Models.Search;
 using Ombi.Core.Rule.Rules.Search;
 using Ombi.Core.Services;
 using Ombi.Core.Settings;
-using Ombi.Core.Settings.Models.External;
+using Ombi.Settings.Settings.Models.External;
 using Ombi.Settings.Settings.Models;
 using Ombi.Store.Entities;
 using Ombi.Store.Repository;
@@ -99,6 +101,90 @@ namespace Ombi.Core.Tests.Rule.Search
 
             Assert.True(result.Success);
             Assert.False(search.Available);
+        }
+
+        [Test]
+        public async Task TvShow_ShouldNotCheckEpisodes_WhenSonarrPriorityEnabled()
+        {
+            var sonarrSettingsMock = new Mock<ISettingsService<SonarrSettings>>();
+            sonarrSettingsMock.Setup(x => x.GetSettingsAsync())
+                .ReturnsAsync(new SonarrSettings { Enabled = true, ScanForAvailability = true, PrioritizeArrAvailability = true });
+
+            var rule = new EmbyAvailabilityRule(ContextMock.Object, LoggerMock.Object, FeatureMock.Object, null, sonarrSettingsMock.Object);
+
+            var search = new SearchTvShowViewModel
+            {
+                TheTvDbId = "123",
+                SeasonRequests = new List<SeasonRequests>
+                {
+                    new SeasonRequests
+                    {
+                        SeasonNumber = 1,
+                        Episodes = new List<EpisodeRequests>
+                        {
+                            new EpisodeRequests { EpisodeNumber = 1 }
+                        }
+                    }
+                }
+            };
+
+            ContextMock.Setup(x => x.GetByTvDbId("123"))
+                .ReturnsAsync(new EmbyContent { Title = "Test Show", Type = MediaType.Series, TvDbId = "123" });
+
+            var result = await rule.Execute(search);
+
+            Assert.True(result.Success);
+            Assert.False(search.Available);
+            Assert.False(search.SeasonRequests[0].Episodes[0].Available);
+
+            ContextMock.Verify(x => x.GetAllEpisodes(), Times.Never);
+        }
+
+        [Test]
+        public async Task TvShow_ShouldCheckEpisodes_WhenSonarrPriorityDisabled()
+        {
+            var sonarrSettingsMock = new Mock<ISettingsService<SonarrSettings>>();
+            sonarrSettingsMock.Setup(x => x.GetSettingsAsync())
+                .ReturnsAsync(new SonarrSettings { Enabled = true, ScanForAvailability = true, PrioritizeArrAvailability = false });
+
+            var rule = new EmbyAvailabilityRule(ContextMock.Object, LoggerMock.Object, FeatureMock.Object, null, sonarrSettingsMock.Object);
+
+            var search = new SearchTvShowViewModel
+            {
+                TheTvDbId = "123",
+                SeasonRequests = new List<SeasonRequests>
+                {
+                    new SeasonRequests
+                    {
+                        SeasonNumber = 1,
+                        Episodes = new List<EpisodeRequests>
+                        {
+                            new EpisodeRequests { EpisodeNumber = 1 }
+                        }
+                    }
+                }
+            };
+
+            ContextMock.Setup(x => x.GetByTvDbId("123"))
+                .ReturnsAsync(new EmbyContent { Title = "Test Show", Type = MediaType.Series, TvDbId = "123" });
+
+            ContextMock.Setup(x => x.GetAllEpisodes()).Returns(new List<EmbyEpisode>
+            {
+                new EmbyEpisode
+                {
+                    EpisodeNumber = 1,
+                    SeasonNumber = 1,
+                    Series = new EmbyContent { Title = "Test Show", TvDbId = "123" }
+                }
+            }.AsQueryable().BuildMock());
+
+            var result = await rule.Execute(search);
+
+            Assert.True(result.Success);
+            Assert.True(search.Available);
+            Assert.True(search.SeasonRequests[0].Episodes[0].Available);
+
+            ContextMock.Verify(x => x.GetAllEpisodes(), Times.Once);
         }
     }
 }

--- a/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
@@ -20,6 +20,8 @@ namespace Ombi.Core.Rule.Rules.Search
         private readonly ISettingsService<SonarrSettings> _sonarrSettings;
 
         protected ILogger Log { get; }
+        private bool? _deferToRadarr;
+        private bool? _deferToSonarr;
 
         protected MediaServerAvailabilityRule(
             ILogger log,
@@ -109,6 +111,11 @@ namespace Ombi.Core.Rule.Rules.Search
 
         private async Task CheckEpisodeAvailability(SearchTvShowViewModel search, ContentLookupResult lookup, IMediaServerContent item)
         {
+            if (await ShouldDeferToSonarr())
+            {
+                return;
+            }
+
             if (!search.SeasonRequests.Any())
             {
                 return;
@@ -130,26 +137,40 @@ namespace Ombi.Core.Rule.Rules.Search
 
         private async Task<bool> ShouldDeferToRadarr()
         {
+            if (_deferToRadarr.HasValue)
+            {
+                return _deferToRadarr.Value;
+            }
+
             if (_radarrSettings == null)
             {
+                _deferToRadarr = false;
                 return false;
             }
 
             var settings = await _radarrSettings.GetSettingsAsync();
-            return settings != null && settings.Enabled &&
+            _deferToRadarr = settings != null && settings.Enabled &&
                    settings.ScanForAvailability && settings.PrioritizeArrAvailability;
+            return _deferToRadarr.Value;
         }
 
         private async Task<bool> ShouldDeferToSonarr()
         {
+            if (_deferToSonarr.HasValue)
+            {
+                return _deferToSonarr.Value;
+            }
+
             if (_sonarrSettings == null)
             {
+                _deferToSonarr = false;
                 return false;
             }
 
             var settings = await _sonarrSettings.GetSettingsAsync();
-            return settings != null && settings.Enabled &&
+            _deferToSonarr = settings != null && settings.Enabled &&
                    settings.ScanForAvailability && settings.PrioritizeArrAvailability;
+            return _deferToSonarr.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
## 📝 Description

When "Prioritize Sonarr Availability" is enabled in Sonarr settings, the background checker correctly skips Plex TV availability checks, but the search rules executing when a user searches or views TV show details still queried media server episodes, marking them as available (and disabling requests) in the UI.

This PR fixes this by ensuring `CheckEpisodeAvailability` in `MediaServerAvailabilityRule.cs` respects `ShouldDeferToSonarr()` and returns early without checking media server episodes.

## 🔗 Related Issues

Fixes #5286

## 🧪 Testing

Verified code matches the pattern in `SetMovieAvailability` (which already implements `ShouldDeferToRadarr()` check and works properly).

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [x] No breaking changes

## 📸 Screenshots (if applicable)

N/A (Backend change)

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR (Yes, this was fully vibe coded!)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

This PR was vibe coded with love by Antigravity AI assistant pair-programming with the repository owner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media server availability evaluation by caching deferral decisions for Radarr and Sonarr, with safe behaviour when related settings are unavailable.
  * When Sonarr prioritisation is enabled, episode-level checks now short-circuit immediately, avoiding unnecessary season/episode iteration.

* **Tests**
  * Added unit tests for TV-show availability with Sonarr prioritisation toggled, including assertions on whether episode lookups are performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->