### PR TITLE
fix: auto-import and link Plex Admin during Plex OAuth login

### DIFF
--- a/src/Ombi.Core.Tests/Engine/MovieRequestLimitsTests.cs
+++ b/src/Ombi.Core.Tests/Engine/MovieRequestLimitsTests.cs
@@ -260,7 +260,7 @@ namespace Ombi.Core.Tests.Engine
                 Id = "id1"
             };
 
-            var today = DateTime.UtcNow;
+            var today = new DateTime(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
             var log = new List<RequestLog>
             {
                 new RequestLog
@@ -273,7 +273,7 @@ namespace Ombi.Core.Tests.Engine
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
             repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
-            var result = await _subject.GetRemainingMovieRequests(user);
+            var result = await _subject.GetRemainingMovieRequests(user, today);
 
             Assert.That(result, Is.InstanceOf<RequestQuotaCountModel>()
                 .With.Property(nameof(RequestQuotaCountModel.HasLimit)).EqualTo(true)

--- a/src/Ombi.Core.Tests/Engine/MusicRequestLimitTests.cs
+++ b/src/Ombi.Core.Tests/Engine/MusicRequestLimitTests.cs
@@ -258,7 +258,7 @@ namespace Ombi.Core.Tests.Engine
                 Id = "id1"
             };
 
-            var today = DateTime.UtcNow;
+            var today = new DateTime(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
             var log = new List<RequestLog>
             {
                 new RequestLog
@@ -271,7 +271,7 @@ namespace Ombi.Core.Tests.Engine
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
             repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
-            var result = await _subject.GetRemainingMusicRequests(user);
+            var result = await _subject.GetRemainingMusicRequests(user, today);
 
             Assert.That(result, Is.InstanceOf<RequestQuotaCountModel>()
                 .With.Property(nameof(RequestQuotaCountModel.HasLimit)).EqualTo(true)

--- a/src/Ombi.Core.Tests/Engine/TvRequestLimitsTests.cs
+++ b/src/Ombi.Core.Tests/Engine/TvRequestLimitsTests.cs
@@ -263,7 +263,7 @@ namespace Ombi.Core.Tests.Engine
                 EpisodeRequestLimitType = RequestLimitType.Day,
                 Id = "id1"
             };
-            var today = DateTime.UtcNow;
+            var today = new DateTime(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
             var log = new List<RequestLog>
             {
                 new RequestLog
@@ -277,7 +277,7 @@ namespace Ombi.Core.Tests.Engine
             var repoMock = _mocker.GetMock<IRepository<RequestLog>>();
             repoMock.Setup(x => x.GetAll()).Returns(log.AsQueryable().BuildMock());
 
-            var result = await _subject.GetRemainingTvRequests(user);
+            var result = await _subject.GetRemainingTvRequests(user, today);
 
             Assert.That(result, Is.InstanceOf<RequestQuotaCountModel>()
                 .With.Property(nameof(RequestQuotaCountModel.HasLimit)).EqualTo(true)

--- a/src/Ombi.Core/Services/RequestLimitService.cs
+++ b/src/Ombi.Core/Services/RequestLimitService.cs
@@ -66,9 +66,9 @@ namespace Ombi.Core.Services
 
             if (!user.MovieRequestLimitType.HasValue)
             {
-                var count = limit - await log.CountAsync(x => x.RequestDate >= DateTime.UtcNow.AddDays(-7));
+                var count = limit - await log.CountAsync(x => x.RequestDate >= now.AddDays(-7));
 
-                var oldestRequestedAt = await log.Where(x => x.RequestDate >= DateTime.UtcNow.AddDays(-7))
+                var oldestRequestedAt = await log.Where(x => x.RequestDate >= now.AddDays(-7))
                                                 .OrderBy(x => x.RequestDate)
                                                 .Select(x => x.RequestDate)
                                                 .FirstOrDefaultAsync();
@@ -78,7 +78,7 @@ namespace Ombi.Core.Services
                     HasLimit = true,
                     Limit = limit,
                     Remaining = count < 0 ? 0 : count,
-                    NextRequest = DateTime.SpecifyKind(oldestRequestedAt.AddDays(7), DateTimeKind.Utc),
+                    NextRequest = DateTime.SpecifyKind(oldestRequestedAt == default ? now : oldestRequestedAt.AddDays(7), DateTimeKind.Utc),
                 };
             }
 
@@ -121,9 +121,9 @@ namespace Ombi.Core.Services
             // Hisoric Limits
             if (!user.MusicRequestLimitType.HasValue)
             {
-                var oldcount = limit - await log.CountAsync(x => x.RequestDate >= DateTime.UtcNow.AddDays(-7));
+                var oldcount = limit - await log.CountAsync(x => x.RequestDate >= now.AddDays(-7));
 
-                var oldestRequestedAtOld = await log.Where(x => x.RequestDate >= DateTime.UtcNow.AddDays(-7))
+                var oldestRequestedAtOld = await log.Where(x => x.RequestDate >= now.AddDays(-7))
                     .OrderBy(x => x.RequestDate)
                     .Select(x => x.RequestDate)
                     .FirstOrDefaultAsync();
@@ -133,7 +133,7 @@ namespace Ombi.Core.Services
                     HasLimit = true,
                     Limit = limit,
                     Remaining = oldcount < 0 ? 0 : oldcount,
-                    NextRequest = DateTime.SpecifyKind(oldestRequestedAtOld.AddDays(7), DateTimeKind.Utc),
+                    NextRequest = DateTime.SpecifyKind(oldestRequestedAtOld == default ? now : oldestRequestedAtOld.AddDays(7), DateTimeKind.Utc),
                 };
             }
 
@@ -234,34 +234,34 @@ namespace Ombi.Core.Services
 
             if (!user.EpisodeRequestLimitType.HasValue)
             {
-                filteredLog = log.Where(x => x.RequestDate >= DateTime.UtcNow.AddDays(-7));
+                filteredLog = log.Where(x => x.RequestDate >= now.AddDays(-7));
                 // Needed, due to a bug which would cause all episode counts to be 0
                 zeroEpisodeCount = await filteredLog.Where(x => x.EpisodeCount == 0).Select(x => x.EpisodeCount).CountAsync();
-
+ 
                 episodeCount = await filteredLog.Where(x => x.EpisodeCount != 0).Select(x => x.EpisodeCount).SumAsync();
-
+ 
                 count = limit - (zeroEpisodeCount + episodeCount);
-
+ 
                 oldestRequestedAt = await log
                                                 .Where(x => x.RequestDate >= now.AddDays(-7))
                                                 .OrderBy(x => x.RequestDate)
                                                 .Select(x => x.RequestDate)
                                                 .FirstOrDefaultAsync();
-
+ 
                 return new RequestQuotaCountModel()
                 {
                     HasLimit = true,
                     Limit = limit,
                     Remaining = count < 0 ? 0 : count,
-                    NextRequest = DateTime.SpecifyKind(oldestRequestedAt.AddDays(7), DateTimeKind.Utc).Date,
+                    NextRequest = DateTime.SpecifyKind(oldestRequestedAt == default ? now : oldestRequestedAt.AddDays(7), DateTimeKind.Utc).Date,
                 };
             }
-
+ 
             switch (user.EpisodeRequestLimitType)
             {
                 case RequestLimitType.Day:
-
-                    filteredLog = log.Where(x => x.RequestDate >= DateTime.UtcNow.Date);
+ 
+                    filteredLog = log.Where(x => x.RequestDate >= now.Date);
                     // Needed, due to a bug which would cause all episode counts to be 0
                     zeroEpisodeCount = await filteredLog.Where(x => x.EpisodeCount == 0).Select(x => x.EpisodeCount).CountAsync();
                     episodeCount = await filteredLog.Where(x => x.EpisodeCount != 0).Select(x => x.EpisodeCount).SumAsync();

--- a/src/Ombi/Controllers/V1/TokenController.cs
+++ b/src/Ombi/Controllers/V1/TokenController.cs
@@ -206,22 +206,44 @@ namespace Ombi.Controllers.V1
             var account = await _plexOAuthManager.GetAccount(accessToken);
             if (account?.user == null)
             {
-                return new UnauthorizedResult();
+                return new JsonResult(new
+                {
+                    errorMessage = "Plex account details are invalid or missing"
+                });
             }
 
-            // Get the ombi user
-            OmbiUser user = null;
-            if (!string.IsNullOrEmpty(account.user.username))
+            if (string.IsNullOrEmpty(account.user.authentication_token))
             {
-                user = await _userManager.FindByNameAsync(account.user.username);
+                return new JsonResult(new
+                {
+                    errorMessage = "Plex authentication token is missing"
+                });
             }
+
+            // Get the ombi user using Plex stable ID, username or fallback to ID
+            OmbiUser user = null;
+            if (!string.IsNullOrEmpty(account.user.id))
+            {
+                user = await _userManager.Users.FirstOrDefaultAsync(x => x.ProviderUserId == account.user.id && x.UserType == UserType.PlexUser);
+            }
+
+            var plexUserName = !string.IsNullOrEmpty(account.user.username) ? account.user.username : account.user.id;
 
             if (user == null)
             {
-                // Could this be an email login?
-                if (!string.IsNullOrEmpty(account.user.email))
+                // Could this be a username login?
+                if (!string.IsNullOrEmpty(plexUserName))
                 {
-                    user = await _userManager.FindByEmailAsync(account.user.email);
+                    user = await _userManager.FindByNameAsync(plexUserName);
+                }
+
+                if (user == null)
+                {
+                    // Could this be an email login?
+                    if (!string.IsNullOrEmpty(account.user.email))
+                    {
+                        user = await _userManager.FindByEmailAsync(account.user.email);
+                    }
                 }
 
                 if (user == null)
@@ -229,7 +251,7 @@ namespace Ombi.Controllers.V1
                     // Check if this user is the Plex Admin / Server Owner
                     var isPlexAdmin = false;
                     var plexSettings = await _plexSettings.GetSettingsAsync();
-                    if (plexSettings?.Servers != null)
+                    if (!string.IsNullOrEmpty(account.user.id) && plexSettings?.Servers != null)
                     {
                         foreach (var server in plexSettings.Servers)
                         {
@@ -245,27 +267,43 @@ namespace Ombi.Controllers.V1
                                 isPlexAdmin = true;
                                 break;
                             }
+                        }
 
-                            try
+                        if (!isPlexAdmin)
+                        {
+                            // Deduplicate active tokens that are not the same as the user's authentication token (which was already checked)
+                            var uniqueTokens = plexSettings.Servers
+                                .Select(s => s.PlexAuthToken)
+                                .Where(token => !string.IsNullOrEmpty(token) && 
+                                                (string.IsNullOrEmpty(account.user.authentication_token) || 
+                                                 !string.Equals(token, account.user.authentication_token, StringComparison.Ordinal)))
+                                .Distinct()
+                                .ToList();
+
+                            if (uniqueTokens.Any())
                             {
-                                // Otherwise, fetch the account for the server token and compare the stable unique ID
-                                var serverAdminAccount = await _plexOAuthManager.GetAccount(server.PlexAuthToken);
-                                if (serverAdminAccount?.user != null)
+                                foreach (var token in uniqueTokens)
                                 {
-                                    var idMatch = !string.IsNullOrEmpty(serverAdminAccount.user.id) &&
-                                                  !string.IsNullOrEmpty(account.user.id) &&
-                                                  string.Equals(serverAdminAccount.user.id, account.user.id, StringComparison.OrdinalIgnoreCase);
-
-                                    if (idMatch)
+                                    try
                                     {
-                                        isPlexAdmin = true;
-                                        break;
+                                        // Fetch the account for the server token and compare the stable unique ID
+                                        var serverAdminAccount = await _plexOAuthManager.GetAccount(token);
+                                        if (serverAdminAccount?.user != null)
+                                        {
+                                            var idMatch = !string.IsNullOrEmpty(serverAdminAccount.user.id) &&
+                                                          string.Equals(serverAdminAccount.user.id, account.user.id, StringComparison.OrdinalIgnoreCase);
+                                            if (idMatch)
+                                            {
+                                                isPlexAdmin = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        _log.LogWarning(ex, "Failed to retrieve Plex account for token verification during Plex Admin OAuth import.");
                                     }
                                 }
-                            }
-                            catch (Exception ex)
-                            {
-                                _log.LogWarning(ex, $"Failed to retrieve Plex account for server token on server '{server.Name}'. Continuing check on remaining servers.");
                             }
                         }
                     }
@@ -277,11 +315,11 @@ namespace Ombi.Controllers.V1
                         user = new OmbiUser
                         {
                             UserType = UserType.PlexUser,
-                            UserName = account.user.username ?? account.user.id,
+                            UserName = plexUserName,
                             ProviderUserId = account.user.id,
                             Email = account.user.email ?? string.Empty,
                             Alias = string.Empty,
-                            StreamingCountry = userManagementSettings.DefaultStreamingCountry
+                            StreamingCountry = userManagementSettings.DefaultStreamingCountry ?? string.Empty
                         };
 
                         var createResult = await _userManager.CreateAsync(user);
@@ -292,30 +330,68 @@ namespace Ombi.Controllers.V1
                             {
                                 foreach (var err in roleResult.Errors)
                                 {
-                                    _log.LogError($"Failed to add auto-created Plex admin user {user.UserName} to Admin role: {err.Description}");
+                                    _log.LogError("Failed to add auto-created Plex admin user {UserName} to Admin role: {Description}", user.UserName, err.Description);
                                 }
+                                try
+                                {
+                                    await _userManager.DeleteAsync(user);
+                                }
+                                catch (Exception ex)
+                                {
+                                    _log.LogError(ex, "Failed to roll back auto-created Plex admin user {UserName} after role assignment failure", user.UserName);
+                                }
+                                return new JsonResult(new
+                                {
+                                    errorMessage = "Failed to assign admin permissions to the auto-created Plex admin user"
+                                });
                             }
                         }
                         else
                         {
-                            foreach (var err in createResult.Errors)
+                            // In case of a race condition where the user was created concurrently, try to fetch them
+                            user = await _userManager.Users.FirstOrDefaultAsync(x => x.ProviderUserId == account.user.id && x.UserType == UserType.PlexUser);
+                            if (user != null)
                             {
-                                _log.LogError($"Failed to auto-create Plex admin user {user.UserName}: {err.Description}");
+                                // Ensure the resolved fallback user is in the Admin role
+                                if (!await _userManager.IsInRoleAsync(user, OmbiRoles.Admin))
+                                {
+                                    var roleResult = await _userManager.AddToRoleAsync(user, OmbiRoles.Admin);
+                                    if (!roleResult.Succeeded)
+                                    {
+                                        foreach (var err in roleResult.Errors)
+                                        {
+                                            _log.LogError("Failed to add fallback Plex admin user {UserName} to Admin role: {Description}", user.UserName, err.Description);
+                                        }
+                                        return new JsonResult(new
+                                        {
+                                            errorMessage = "Failed to assign admin permissions to the fallback Plex admin user"
+                                        });
+                                    }
+                                }
                             }
-                            user = null;
+                            else
+                            {
+                                foreach (var err in createResult.Errors)
+                                {
+                                    _log.LogError("Failed to auto-create Plex admin user {UserName}: {Description}", plexUserName, err.Description);
+                                }
+                            }
                         }
                     }
                 }
 
                 if (user == null || user.UserType != UserType.PlexUser)
                 {
-                    return new UnauthorizedResult();
+                    return new JsonResult(new
+                    {
+                        errorMessage = "This Plex account is not authorized to access Ombi"
+                    });
                 }
             }
 
             user.MediaServerToken = account.user.authentication_token;
             await _userManager.UpdateAsync(user);
-
+ 
             return await CreateToken(true, user);
         }
 

--- a/src/Ombi/Controllers/V1/TokenController.cs
+++ b/src/Ombi/Controllers/V1/TokenController.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Ombi.Core.Authentication;
 using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
 using Ombi.Helpers;
 using Ombi.Models;
 using Ombi.Models.External;
@@ -38,7 +39,7 @@ namespace Ombi.Controllers.V1
     {
         public TokenController(OmbiUserManager um, ITokenRepository token,
             IPlexOAuthManager oAuthManager, ILogger<TokenController> logger, ISettingsService<AuthenticationSettings> auth,
-            ISettingsService<UserManagementSettings> userManagement)
+            ISettingsService<UserManagementSettings> userManagement, ISettingsService<PlexSettings> plexSettings)
         {
             _userManager = um;
             _token = token;
@@ -46,6 +47,7 @@ namespace Ombi.Controllers.V1
             _log = logger;
             _authSettings = auth;
             _userManagementSettings = userManagement;
+            _plexSettings = plexSettings;
         }
 
         private readonly ITokenRepository _token;
@@ -54,6 +56,7 @@ namespace Ombi.Controllers.V1
         private readonly ILogger<TokenController> _log;
         private readonly ISettingsService<AuthenticationSettings> _authSettings;
         private readonly ISettingsService<UserManagementSettings> _userManagementSettings;
+        private readonly ISettingsService<PlexSettings> _plexSettings;
 
         /// <summary>
         /// Gets the token.
@@ -201,14 +204,108 @@ namespace Ombi.Controllers.V1
 
             // Let's look for the users account
             var account = await _plexOAuthManager.GetAccount(accessToken);
+            if (account?.user == null)
+            {
+                return new UnauthorizedResult();
+            }
 
             // Get the ombi user
-            var user = await _userManager.FindByNameAsync(account.user.username);
+            OmbiUser user = null;
+            if (!string.IsNullOrEmpty(account.user.username))
+            {
+                user = await _userManager.FindByNameAsync(account.user.username);
+            }
 
             if (user == null)
             {
                 // Could this be an email login?
-                user = await _userManager.FindByEmailAsync(account.user.email);
+                if (!string.IsNullOrEmpty(account.user.email))
+                {
+                    user = await _userManager.FindByEmailAsync(account.user.email);
+                }
+
+                if (user == null)
+                {
+                    // Check if this user is the Plex Admin / Server Owner
+                    var isPlexAdmin = false;
+                    var plexSettings = await _plexSettings.GetSettingsAsync();
+                    if (plexSettings?.Servers != null)
+                    {
+                        foreach (var server in plexSettings.Servers)
+                        {
+                            if (string.IsNullOrEmpty(server.PlexAuthToken))
+                            {
+                                continue;
+                            }
+
+                            // If the tokens match, they are definitely the admin (case-sensitive check)
+                            if (!string.IsNullOrEmpty(account.user.authentication_token) &&
+                                string.Equals(server.PlexAuthToken, account.user.authentication_token, StringComparison.Ordinal))
+                            {
+                                isPlexAdmin = true;
+                                break;
+                            }
+
+                            try
+                            {
+                                // Otherwise, fetch the account for the server token and compare the stable unique ID
+                                var serverAdminAccount = await _plexOAuthManager.GetAccount(server.PlexAuthToken);
+                                if (serverAdminAccount?.user != null)
+                                {
+                                    var idMatch = !string.IsNullOrEmpty(serverAdminAccount.user.id) &&
+                                                  !string.IsNullOrEmpty(account.user.id) &&
+                                                  string.Equals(serverAdminAccount.user.id, account.user.id, StringComparison.OrdinalIgnoreCase);
+
+                                    if (idMatch)
+                                    {
+                                        isPlexAdmin = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                _log.LogWarning(ex, $"Failed to retrieve Plex account for server token on server '{server.Name}'. Continuing check on remaining servers.");
+                            }
+                        }
+                    }
+
+                    if (isPlexAdmin)
+                    {
+                        // Automatically import the Plex Admin
+                        var userManagementSettings = await _userManagementSettings.GetSettingsAsync();
+                        user = new OmbiUser
+                        {
+                            UserType = UserType.PlexUser,
+                            UserName = account.user.username ?? account.user.id,
+                            ProviderUserId = account.user.id,
+                            Email = account.user.email ?? string.Empty,
+                            Alias = string.Empty,
+                            StreamingCountry = userManagementSettings.DefaultStreamingCountry
+                        };
+
+                        var createResult = await _userManager.CreateAsync(user);
+                        if (createResult.Succeeded)
+                        {
+                            var roleResult = await _userManager.AddToRoleAsync(user, OmbiRoles.Admin);
+                            if (!roleResult.Succeeded)
+                            {
+                                foreach (var err in roleResult.Errors)
+                                {
+                                    _log.LogError($"Failed to add auto-created Plex admin user {user.UserName} to Admin role: {err.Description}");
+                                }
+                            }
+                        }
+                        else
+                        {
+                            foreach (var err in createResult.Errors)
+                            {
+                                _log.LogError($"Failed to auto-create Plex admin user {user.UserName}: {err.Description}");
+                            }
+                            user = null;
+                        }
+                    }
+                }
 
                 if (user == null || user.UserType != UserType.PlexUser)
                 {


### PR DESCRIPTION
Fixes #5441

### Summary
When a new or existing Ombi instance is configured with a Plex Media Server, the Plex owner/admin frequently fails to log in via Plex OAuth if they do not yet exist in the database (e.g. if the user importer has not run or has disabled admin imports). This results in a repeating "You are not authenticated to Ombi" error.

This PR solves this by validating if the logging-in Plex user matches the configured Plex Server Owner (by comparing tokens or fetching the server token account metadata). If they match, the user is automatically created in the database and assigned the Admin role.

### Changes
- **TokenController**:
  - Inject `ISettingsService<PlexSettings>`.
  - In the `OAuth` polling endpoint, if the user doesn't exist, check if they are the Plex Admin / Server Owner by comparing their token or matching user details against the server token owners.
  - If a match is found, create the `OmbiUser` and assign them the `Admin` role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plex server administrators are now automatically imported into Ombi during Plex sign-in when not already registered, with default streaming country applied.
* **Bug Fixes**
  * Plex OAuth sign-in now safely handles missing user details and improves admin/server-owner recognition across configured servers.
  * Request limit calculations now consistently use the provided current time for accuracy.
* **Tests**
  * Updated request limit tests to use fixed timestamps for deterministic results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->