### PR TITLE
feat(store): add selectable quality profile foundation

### DIFF
--- a/src/Ombi.Helpers/OmbiRoles.cs
+++ b/src/Ombi.Helpers/OmbiRoles.cs
@@ -18,5 +18,7 @@
         public const string EditCustomPage = nameof(EditCustomPage);
         public const string Request4KMovie = nameof(Request4KMovie);
         public const string AutoApprove4KMovie = nameof(AutoApprove4KMovie);
+        public const string SelectRadarrQualityProfile = nameof(SelectRadarrQualityProfile);
+        public const string SelectSonarrQualityProfile = nameof(SelectSonarrQualityProfile);
     }
 }

--- a/src/Ombi.Store/Context/OmbiContext.cs
+++ b/src/Ombi.Store/Context/OmbiContext.cs
@@ -53,6 +53,17 @@ namespace Ombi.Store.Context
             builder.Entity<PlexWatchlistUserStatus>()
                 .HasIndex(x => x.UserId)
                 .IsUnique();
+            builder.Entity<UserSelectableQualityProfile>()
+                .Property(x => x.UserId)
+                .HasMaxLength(128);
+            builder.Entity<UserSelectableQualityProfile>()
+                .HasIndex(x => new { x.UserId, x.Application, x.QualityProfileId, x.Is4K })
+                .IsUnique();
+            builder.Entity<UserSelectableQualityProfile>()
+                .HasOne(x => x.User)
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
 
@@ -62,6 +73,7 @@ namespace Ombi.Store.Context
         public DbSet<UserNotificationPreferences> UserNotificationPreferences { get; set; }
         public DbSet<MobileDevices> MobileDevices { get; set; }
         public DbSet<UserQualityProfiles> UserQualityProfileses { get; set; }
+        public DbSet<UserSelectableQualityProfile> UserSelectableQualityProfiles { get; set; }
         public DbSet<RequestQueue> RequestQueue { get; set; }
 
         public void Seed()

--- a/src/Ombi.Store/Context/OmbiContext.cs
+++ b/src/Ombi.Store/Context/OmbiContext.cs
@@ -58,6 +58,7 @@ namespace Ombi.Store.Context
                 .HasMaxLength(128);
             builder.Entity<UserSelectableQualityProfile>()
                 .HasIndex(x => new { x.UserId, x.Application, x.QualityProfileId, x.Is4K })
+                .HasDatabaseName("IX_UserSelectableQualityProfile_User_Application_Profile_Is4K")
                 .IsUnique();
             builder.Entity<UserSelectableQualityProfile>()
                 .HasOne(x => x.User)

--- a/src/Ombi.Store/Entities/Requests/MovieRequests.cs
+++ b/src/Ombi.Store/Entities/Requests/MovieRequests.cs
@@ -32,6 +32,7 @@ namespace Ombi.Store.Entities.Requests
 
         public int RootPathOverride { get; set; }
         public int QualityOverride { get; set; }
+        public int QualityOverride4K { get; set; }
 
         public bool Has4KRequest  { get; set; }
 

--- a/src/Ombi.Store/Entities/UserSelectableQualityProfile.cs
+++ b/src/Ombi.Store/Entities/UserSelectableQualityProfile.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Newtonsoft.Json;
+
+namespace Ombi.Store.Entities
+{
+    [Table(nameof(UserSelectableQualityProfile))]
+    public class UserSelectableQualityProfile : Entity
+    {
+        public string UserId { get; set; }
+        public SelectableQualityProfileApplication Application { get; set; }
+        public int QualityProfileId { get; set; }
+        public bool Is4K { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        [JsonIgnore]
+        public OmbiUser User { get; set; }
+    }
+
+    public enum SelectableQualityProfileApplication
+    {
+        Radarr = 0,
+        Sonarr = 1
+    }
+}

--- a/src/Ombi.Store/MigrationHelper.cs
+++ b/src/Ombi.Store/MigrationHelper.cs
@@ -44,7 +44,25 @@ WHERE NOT EXISTS(SELECT 1 FROM public.""AspNetRoles"" WHERE ""Name"" = '{role}')
             AddUserSelectableQualityProfiles(mb, DatabaseProvider.Postgres);
 
         public static void RemoveUserSelectableQualityProfiles(this MigrationBuilder mb)
+            => RemoveUserSelectableQualityProfiles(mb, DatabaseProvider.Sqlite);
+
+        public static void RemoveUserSelectableQualityProfilesMySql(this MigrationBuilder mb)
+            => RemoveUserSelectableQualityProfiles(mb, DatabaseProvider.MySql);
+
+        public static void RemoveUserSelectableQualityProfilesPostgres(this MigrationBuilder mb)
+            => RemoveUserSelectableQualityProfiles(mb, DatabaseProvider.Postgres);
+
+        private static void RemoveUserSelectableQualityProfiles(MigrationBuilder mb, DatabaseProvider provider)
         {
+            var rolesTable = provider switch
+            {
+                DatabaseProvider.Sqlite => "AspnetRoles WHERE Name",
+                DatabaseProvider.MySql => "AspNetRoles WHERE Name",
+                DatabaseProvider.Postgres => "public.\"AspNetRoles\" WHERE \"Name\"",
+                _ => throw new ArgumentOutOfRangeException(nameof(provider))
+            };
+
+            mb.Sql($"DELETE FROM {rolesTable} IN ('{OmbiRoles.SelectRadarrQualityProfile}', '{OmbiRoles.SelectSonarrQualityProfile}');");
             mb.DropTable("UserSelectableQualityProfile");
             mb.DropColumn("QualityOverride4K", "MovieRequests");
         }
@@ -80,7 +98,7 @@ WHERE NOT EXISTS(SELECT 1 FROM public.""AspNetRoles"" WHERE ""Name"" = '{role}')
                 tableBuilder.Annotation("MySql:CharSet", "utf8mb4");
             }
 
-            mb.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
+            mb.CreateIndex("IX_UserSelectableQualityProfile_User_Application_Profile_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
             mb.AddColumn<int>("QualityOverride4K", "MovieRequests", type: integerType, nullable: false, defaultValue: 0);
         }
 

--- a/src/Ombi.Store/MigrationHelper.cs
+++ b/src/Ombi.Store/MigrationHelper.cs
@@ -1,4 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ombi.Helpers;
 using System;
 
 namespace Ombi.Store
@@ -27,6 +32,116 @@ WHERE NOT EXISTS(SELECT 1 FROM AspNetRoles WHERE Name = '{role}');");
 INSERT INTO public.""AspNetRoles""(""Id"", ""ConcurrencyStamp"", ""Name"", ""NormalizedName"")
 SELECT '{Guid.NewGuid()}','{Guid.NewGuid()}','{role}', '{role.ToUpper()}'
 WHERE NOT EXISTS(SELECT 1 FROM public.""AspNetRoles"" WHERE ""Name"" = '{role}');");
+        }
+
+        public static void AddUserSelectableQualityProfiles(this MigrationBuilder mb) =>
+            AddUserSelectableQualityProfiles(mb, DatabaseProvider.Sqlite);
+
+        public static void AddUserSelectableQualityProfilesMySql(this MigrationBuilder mb) =>
+            AddUserSelectableQualityProfiles(mb, DatabaseProvider.MySql);
+
+        public static void AddUserSelectableQualityProfilesPostgres(this MigrationBuilder mb) =>
+            AddUserSelectableQualityProfiles(mb, DatabaseProvider.Postgres);
+
+        public static void RemoveUserSelectableQualityProfiles(this MigrationBuilder mb)
+        {
+            mb.DropTable("UserSelectableQualityProfile");
+            mb.DropColumn("QualityOverride4K", "MovieRequests");
+        }
+
+        private static void AddUserSelectableQualityProfiles(MigrationBuilder mb, DatabaseProvider provider)
+        {
+            InsertQualityProfileRoles(mb, provider);
+
+            var (integerType, userIdType, booleanType) = provider switch
+            {
+                DatabaseProvider.Sqlite => ("INTEGER", "TEXT", "INTEGER"),
+                DatabaseProvider.MySql => ("int", "varchar(128)", "tinyint(1)"),
+                DatabaseProvider.Postgres => ("integer", "character varying(128)", "boolean"),
+                _ => throw new ArgumentOutOfRangeException(nameof(provider))
+            };
+
+            var tableBuilder = mb.CreateTable(
+                name: "UserSelectableQualityProfile",
+                columns: table => new UserSelectableQualityProfileColumns(
+                    AddIdentityAnnotation(table.Column<int>(type: integerType, nullable: false), provider),
+                    AddUserIdAnnotation(table.Column<string>(type: userIdType, maxLength: 128, nullable: false), provider),
+                    table.Column<int>(type: integerType, nullable: false),
+                    table.Column<int>(type: integerType, nullable: false),
+                    table.Column<bool>(type: booleanType, nullable: false)),
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
+                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
+                });
+
+            if (provider == DatabaseProvider.MySql)
+            {
+                tableBuilder.Annotation("MySql:CharSet", "utf8mb4");
+            }
+
+            mb.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
+            mb.AddColumn<int>("QualityOverride4K", "MovieRequests", type: integerType, nullable: false, defaultValue: 0);
+        }
+
+        private static void InsertQualityProfileRoles(MigrationBuilder mb, DatabaseProvider provider)
+        {
+            Action<string> insertRole = provider switch
+            {
+                DatabaseProvider.Sqlite => mb.InsertRole,
+                DatabaseProvider.MySql => mb.InsertRoleMySql,
+                DatabaseProvider.Postgres => mb.InsertRolePostgres,
+                _ => throw new ArgumentOutOfRangeException(nameof(provider))
+            };
+
+            insertRole(OmbiRoles.SelectRadarrQualityProfile);
+            insertRole(OmbiRoles.SelectSonarrQualityProfile);
+        }
+
+        private static OperationBuilder<AddColumnOperation> AddIdentityAnnotation(
+            OperationBuilder<AddColumnOperation> column,
+            DatabaseProvider provider) => provider switch
+            {
+                DatabaseProvider.Sqlite => column.Annotation("Sqlite:Autoincrement", true),
+                DatabaseProvider.MySql => column.Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                DatabaseProvider.Postgres => column.Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                _ => throw new ArgumentOutOfRangeException(nameof(provider))
+            };
+
+        private static OperationBuilder<AddColumnOperation> AddUserIdAnnotation(
+            OperationBuilder<AddColumnOperation> column,
+            DatabaseProvider provider) => provider == DatabaseProvider.MySql
+                ? column.Annotation("MySql:CharSet", "utf8mb4")
+                : column;
+
+        private enum DatabaseProvider
+        {
+            Sqlite,
+            MySql,
+            Postgres
+        }
+
+        private sealed class UserSelectableQualityProfileColumns
+        {
+            public UserSelectableQualityProfileColumns(
+                OperationBuilder<AddColumnOperation> id,
+                OperationBuilder<AddColumnOperation> userId,
+                OperationBuilder<AddColumnOperation> application,
+                OperationBuilder<AddColumnOperation> qualityProfileId,
+                OperationBuilder<AddColumnOperation> is4K)
+            {
+                Id = id;
+                UserId = userId;
+                Application = application;
+                QualityProfileId = qualityProfileId;
+                Is4K = is4K;
+            }
+
+            public OperationBuilder<AddColumnOperation> Id { get; }
+            public OperationBuilder<AddColumnOperation> UserId { get; }
+            public OperationBuilder<AddColumnOperation> Application { get; }
+            public OperationBuilder<AddColumnOperation> QualityProfileId { get; }
+            public OperationBuilder<AddColumnOperation> Is4K { get; }
         }
     }
 }

--- a/src/Ombi.Store/Migrations/OmbiMySql/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiMySql/20260723000000_UserSelectableQualityProfiles.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Ombi.Store.Context.MySql;
+using Ombi.Helpers;
+
+#nullable disable
+
+namespace Ombi.Store.Migrations.OmbiMySql
+{
+    [DbContext(typeof(OmbiMySqlContext))]
+    [Migration("20260723000000_UserSelectableQualityProfiles")]
+    public partial class UserSelectableQualityProfiles : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertRoleMySql(OmbiRoles.SelectRadarrQualityProfile);
+            migrationBuilder.InsertRoleMySql(OmbiRoles.SelectSonarrQualityProfile);
+            migrationBuilder.CreateTable(
+                name: "UserSelectableQualityProfile",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false).Annotation("MySql:ValueGenerationStrategy", Microsoft.EntityFrameworkCore.Metadata.MySqlValueGenerationStrategy.IdentityColumn),
+                    UserId = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false).Annotation("MySql:CharSet", "utf8mb4"),
+                    Application = table.Column<int>(type: "int", nullable: false),
+                    QualityProfileId = table.Column<int>(type: "int", nullable: false),
+                    Is4K = table.Column<bool>(type: "tinyint(1)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
+                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
+                }).Annotation("MySql:CharSet", "utf8mb4");
+            migrationBuilder.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
+            migrationBuilder.AddColumn<int>(
+                name: "QualityOverride4K",
+                table: "MovieRequests",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("UserSelectableQualityProfile");
+            migrationBuilder.DropColumn("QualityOverride4K", "MovieRequests");
+        }
+    }
+}

--- a/src/Ombi.Store/Migrations/OmbiMySql/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiMySql/20260723000000_UserSelectableQualityProfiles.cs
@@ -18,7 +18,7 @@ namespace Ombi.Store.Migrations.OmbiMySql
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.RemoveUserSelectableQualityProfiles();
+            migrationBuilder.RemoveUserSelectableQualityProfilesMySql();
         }
     }
 }

--- a/src/Ombi.Store/Migrations/OmbiMySql/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiMySql/20260723000000_UserSelectableQualityProfiles.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Ombi.Store.Context.MySql;
-using Ombi.Helpers;
+using Ombi.Store;
 
 #nullable disable
 
@@ -13,36 +13,12 @@ namespace Ombi.Store.Migrations.OmbiMySql
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.InsertRoleMySql(OmbiRoles.SelectRadarrQualityProfile);
-            migrationBuilder.InsertRoleMySql(OmbiRoles.SelectSonarrQualityProfile);
-            migrationBuilder.CreateTable(
-                name: "UserSelectableQualityProfile",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false).Annotation("MySql:ValueGenerationStrategy", Microsoft.EntityFrameworkCore.Metadata.MySqlValueGenerationStrategy.IdentityColumn),
-                    UserId = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false).Annotation("MySql:CharSet", "utf8mb4"),
-                    Application = table.Column<int>(type: "int", nullable: false),
-                    QualityProfileId = table.Column<int>(type: "int", nullable: false),
-                    Is4K = table.Column<bool>(type: "tinyint(1)", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
-                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
-                }).Annotation("MySql:CharSet", "utf8mb4");
-            migrationBuilder.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
-            migrationBuilder.AddColumn<int>(
-                name: "QualityOverride4K",
-                table: "MovieRequests",
-                type: "int",
-                nullable: false,
-                defaultValue: 0);
+            migrationBuilder.AddUserSelectableQualityProfilesMySql();
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable("UserSelectableQualityProfile");
-            migrationBuilder.DropColumn("QualityOverride4K", "MovieRequests");
+            migrationBuilder.RemoveUserSelectableQualityProfiles();
         }
     }
 }

--- a/src/Ombi.Store/Migrations/OmbiMySql/OmbiMySqlContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/OmbiMySql/OmbiMySqlContextModelSnapshot.cs
@@ -740,6 +740,9 @@ namespace Ombi.Store.Migrations.OmbiMySql
                     b.Property<int>("QualityOverride")
                         .HasColumnType("int");
 
+                    b.Property<int>("QualityOverride4K")
+                        .HasColumnType("int");
+
                     b.Property<DateTime>("ReleaseDate")
                         .HasColumnType("datetime(6)");
 
@@ -922,6 +925,19 @@ namespace Ombi.Store.Migrations.OmbiMySql
                     b.HasIndex("UserId");
 
                     b.ToTable("UserNotificationPreferences");
+                });
+
+            modelBuilder.Entity("Ombi.Store.Entities.UserSelectableQualityProfile", b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd().HasColumnType("int");
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
+                    b.Property<int>("Application").HasColumnType("int");
+                    b.Property<bool>("Is4K").HasColumnType("tinyint(1)");
+                    b.Property<int>("QualityProfileId").HasColumnType("int");
+                    b.Property<string>("UserId").IsRequired().HasMaxLength(128).HasColumnType("varchar(128)");
+                    b.HasKey("Id");
+                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique();
+                    b.ToTable("UserSelectableQualityProfile");
                 });
 
             modelBuilder.Entity("Ombi.Store.Entities.UserQualityProfiles", b =>
@@ -1231,6 +1247,12 @@ namespace Ombi.Store.Migrations.OmbiMySql
                         .WithMany("UserNotificationPreferences")
                         .HasForeignKey("UserId");
 
+                    b.Navigation("User");
+                });
+
+            modelBuilder.Entity("Ombi.Store.Entities.UserSelectableQualityProfile", b =>
+                {
+                    b.HasOne("Ombi.Store.Entities.OmbiUser", "User").WithMany().HasForeignKey("UserId").OnDelete(DeleteBehavior.Cascade).IsRequired();
                     b.Navigation("User");
                 });
 

--- a/src/Ombi.Store/Migrations/OmbiMySql/OmbiMySqlContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/OmbiMySql/OmbiMySqlContextModelSnapshot.cs
@@ -936,7 +936,7 @@ namespace Ombi.Store.Migrations.OmbiMySql
                     b.Property<int>("QualityProfileId").HasColumnType("int");
                     b.Property<string>("UserId").IsRequired().HasMaxLength(128).HasColumnType("varchar(128)");
                     b.HasKey("Id");
-                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique();
+                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique().HasDatabaseName("IX_UserSelectableQualityProfile_User_Application_Profile_Is4K");
                     b.ToTable("UserSelectableQualityProfile");
                 });
 

--- a/src/Ombi.Store/Migrations/OmbiPostgres/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiPostgres/20260723000000_UserSelectableQualityProfiles.cs
@@ -1,8 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Ombi.Store.Context.Postgres;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using Ombi.Helpers;
+using Ombi.Store;
 
 #nullable disable
 
@@ -14,36 +13,12 @@ namespace Ombi.Store.Migrations.OmbiPostgres
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.InsertRolePostgres(OmbiRoles.SelectRadarrQualityProfile);
-            migrationBuilder.InsertRolePostgres(OmbiRoles.SelectSonarrQualityProfile);
-            migrationBuilder.CreateTable(
-                name: "UserSelectableQualityProfile",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "integer", nullable: false).Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    UserId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
-                    Application = table.Column<int>(type: "integer", nullable: false),
-                    QualityProfileId = table.Column<int>(type: "integer", nullable: false),
-                    Is4K = table.Column<bool>(type: "boolean", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
-                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
-                });
-            migrationBuilder.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
-            migrationBuilder.AddColumn<int>(
-                name: "QualityOverride4K",
-                table: "MovieRequests",
-                type: "integer",
-                nullable: false,
-                defaultValue: 0);
+            migrationBuilder.AddUserSelectableQualityProfilesPostgres();
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable("UserSelectableQualityProfile");
-            migrationBuilder.DropColumn("QualityOverride4K", "MovieRequests");
+            migrationBuilder.RemoveUserSelectableQualityProfiles();
         }
     }
 }

--- a/src/Ombi.Store/Migrations/OmbiPostgres/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiPostgres/20260723000000_UserSelectableQualityProfiles.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Ombi.Store.Context.Postgres;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Ombi.Helpers;
+
+#nullable disable
+
+namespace Ombi.Store.Migrations.OmbiPostgres
+{
+    [DbContext(typeof(OmbiPostgresContext))]
+    [Migration("20260723000000_UserSelectableQualityProfiles")]
+    public partial class UserSelectableQualityProfiles : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertRolePostgres(OmbiRoles.SelectRadarrQualityProfile);
+            migrationBuilder.InsertRolePostgres(OmbiRoles.SelectSonarrQualityProfile);
+            migrationBuilder.CreateTable(
+                name: "UserSelectableQualityProfile",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false).Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Application = table.Column<int>(type: "integer", nullable: false),
+                    QualityProfileId = table.Column<int>(type: "integer", nullable: false),
+                    Is4K = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
+                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
+                });
+            migrationBuilder.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
+            migrationBuilder.AddColumn<int>(
+                name: "QualityOverride4K",
+                table: "MovieRequests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("UserSelectableQualityProfile");
+            migrationBuilder.DropColumn("QualityOverride4K", "MovieRequests");
+        }
+    }
+}

--- a/src/Ombi.Store/Migrations/OmbiPostgres/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiPostgres/20260723000000_UserSelectableQualityProfiles.cs
@@ -18,7 +18,7 @@ namespace Ombi.Store.Migrations.OmbiPostgres
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.RemoveUserSelectableQualityProfiles();
+            migrationBuilder.RemoveUserSelectableQualityProfilesPostgres();
         }
     }
 }

--- a/src/Ombi.Store/Migrations/OmbiPostgres/OmbiPostgresContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/OmbiPostgres/OmbiPostgresContextModelSnapshot.cs
@@ -979,7 +979,7 @@ namespace Ombi.Store.Migrations.OmbiPostgres
                     b.Property<int>("QualityProfileId").HasColumnType("integer");
                     b.Property<string>("UserId").IsRequired().HasMaxLength(128).HasColumnType("character varying(128)");
                     b.HasKey("Id");
-                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique();
+                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique().HasDatabaseName("IX_UserSelectableQualityProfile_User_Application_Profile_Is4K");
                     b.ToTable("UserSelectableQualityProfile");
                 });
 

--- a/src/Ombi.Store/Migrations/OmbiPostgres/OmbiPostgresContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/OmbiPostgres/OmbiPostgresContextModelSnapshot.cs
@@ -773,6 +773,9 @@ namespace Ombi.Store.Migrations.OmbiPostgres
                     b.Property<int>("QualityOverride")
                         .HasColumnType("integer");
 
+                    b.Property<int>("QualityOverride4K")
+                        .HasColumnType("integer");
+
                     b.Property<DateTime>("ReleaseDate")
                         .HasColumnType("timestamp with time zone");
 
@@ -965,6 +968,19 @@ namespace Ombi.Store.Migrations.OmbiPostgres
                     b.HasIndex("UserId");
 
                     b.ToTable("UserNotificationPreferences");
+                });
+
+            modelBuilder.Entity("Ombi.Store.Entities.UserSelectableQualityProfile", b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd().HasColumnType("integer");
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+                    b.Property<int>("Application").HasColumnType("integer");
+                    b.Property<bool>("Is4K").HasColumnType("boolean");
+                    b.Property<int>("QualityProfileId").HasColumnType("integer");
+                    b.Property<string>("UserId").IsRequired().HasMaxLength(128).HasColumnType("character varying(128)");
+                    b.HasKey("Id");
+                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique();
+                    b.ToTable("UserSelectableQualityProfile");
                 });
 
             modelBuilder.Entity("Ombi.Store.Entities.UserQualityProfiles", b =>
@@ -1282,6 +1298,12 @@ namespace Ombi.Store.Migrations.OmbiPostgres
                         .WithMany("UserNotificationPreferences")
                         .HasForeignKey("UserId");
 
+                    b.Navigation("User");
+                });
+
+            modelBuilder.Entity("Ombi.Store.Entities.UserSelectableQualityProfile", b =>
+                {
+                    b.HasOne("Ombi.Store.Entities.OmbiUser", "User").WithMany().HasForeignKey("UserId").OnDelete(DeleteBehavior.Cascade).IsRequired();
                     b.Navigation("User");
                 });
 

--- a/src/Ombi.Store/Migrations/OmbiSqlite/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiSqlite/20260723000000_UserSelectableQualityProfiles.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Ombi.Helpers;
 using Ombi.Store;
 using Ombi.Store.Context.Sqlite;
 
@@ -14,36 +13,12 @@ namespace Ombi.Store.Migrations.OmbiSqlite
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.InsertRole(OmbiRoles.SelectRadarrQualityProfile);
-            migrationBuilder.InsertRole(OmbiRoles.SelectSonarrQualityProfile);
-            migrationBuilder.CreateTable(
-                name: "UserSelectableQualityProfile",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false).Annotation("Sqlite:Autoincrement", true),
-                    UserId = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
-                    Application = table.Column<int>(type: "INTEGER", nullable: false),
-                    QualityProfileId = table.Column<int>(type: "INTEGER", nullable: false),
-                    Is4K = table.Column<bool>(type: "INTEGER", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
-                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
-                });
-            migrationBuilder.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
-            migrationBuilder.AddColumn<int>(
-                name: "QualityOverride4K",
-                table: "MovieRequests",
-                type: "INTEGER",
-                nullable: false,
-                defaultValue: 0);
+            migrationBuilder.AddUserSelectableQualityProfiles();
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable("UserSelectableQualityProfile");
-            migrationBuilder.DropColumn("QualityOverride4K", "MovieRequests");
+            migrationBuilder.RemoveUserSelectableQualityProfiles();
         }
     }
 }

--- a/src/Ombi.Store/Migrations/OmbiSqlite/20260723000000_UserSelectableQualityProfiles.cs
+++ b/src/Ombi.Store/Migrations/OmbiSqlite/20260723000000_UserSelectableQualityProfiles.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Ombi.Helpers;
+using Ombi.Store;
+using Ombi.Store.Context.Sqlite;
+
+#nullable disable
+
+namespace Ombi.Store.Migrations.OmbiSqlite
+{
+    [DbContext(typeof(OmbiSqliteContext))]
+    [Migration("20260723000000_UserSelectableQualityProfiles")]
+    public partial class UserSelectableQualityProfiles : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertRole(OmbiRoles.SelectRadarrQualityProfile);
+            migrationBuilder.InsertRole(OmbiRoles.SelectSonarrQualityProfile);
+            migrationBuilder.CreateTable(
+                name: "UserSelectableQualityProfile",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false).Annotation("Sqlite:Autoincrement", true),
+                    UserId = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                    Application = table.Column<int>(type: "INTEGER", nullable: false),
+                    QualityProfileId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Is4K = table.Column<bool>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSelectableQualityProfile", x => x.Id);
+                    table.ForeignKey("FK_UserSelectableQualityProfile_AspNetUsers_UserId", x => x.UserId, "AspNetUsers", "Id", onDelete: ReferentialAction.Cascade);
+                });
+            migrationBuilder.CreateIndex("IX_UserSelectableQualityProfile_UserId_Application_QualityProfileId_Is4K", "UserSelectableQualityProfile", new[] { "UserId", "Application", "QualityProfileId", "Is4K" }, unique: true);
+            migrationBuilder.AddColumn<int>(
+                name: "QualityOverride4K",
+                table: "MovieRequests",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("UserSelectableQualityProfile");
+            migrationBuilder.DropColumn("QualityOverride4K", "MovieRequests");
+        }
+    }
+}

--- a/src/Ombi.Store/Migrations/OmbiSqlite/OmbiSqliteContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/OmbiSqlite/OmbiSqliteContextModelSnapshot.cs
@@ -933,7 +933,7 @@ namespace Ombi.Store.Migrations.OmbiSqlite
                     b.Property<int>("QualityProfileId").HasColumnType("INTEGER");
                     b.Property<string>("UserId").IsRequired().HasMaxLength(128).HasColumnType("TEXT");
                     b.HasKey("Id");
-                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique();
+                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique().HasDatabaseName("IX_UserSelectableQualityProfile_User_Application_Profile_Is4K");
                     b.ToTable("UserSelectableQualityProfile");
                 });
 

--- a/src/Ombi.Store/Migrations/OmbiSqlite/OmbiSqliteContextModelSnapshot.cs
+++ b/src/Ombi.Store/Migrations/OmbiSqlite/OmbiSqliteContextModelSnapshot.cs
@@ -738,6 +738,9 @@ namespace Ombi.Store.Migrations.OmbiSqlite
                     b.Property<int>("QualityOverride")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int>("QualityOverride4K")
+                        .HasColumnType("INTEGER");
+
                     b.Property<DateTime>("ReleaseDate")
                         .HasColumnType("TEXT");
 
@@ -920,6 +923,18 @@ namespace Ombi.Store.Migrations.OmbiSqlite
                     b.HasIndex("UserId");
 
                     b.ToTable("UserNotificationPreferences");
+                });
+
+            modelBuilder.Entity("Ombi.Store.Entities.UserSelectableQualityProfile", b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd().HasColumnType("INTEGER");
+                    b.Property<int>("Application").HasColumnType("INTEGER");
+                    b.Property<bool>("Is4K").HasColumnType("INTEGER");
+                    b.Property<int>("QualityProfileId").HasColumnType("INTEGER");
+                    b.Property<string>("UserId").IsRequired().HasMaxLength(128).HasColumnType("TEXT");
+                    b.HasKey("Id");
+                    b.HasIndex("UserId", "Application", "QualityProfileId", "Is4K").IsUnique();
+                    b.ToTable("UserSelectableQualityProfile");
                 });
 
             modelBuilder.Entity("Ombi.Store.Entities.UserQualityProfiles", b =>
@@ -1229,6 +1244,16 @@ namespace Ombi.Store.Migrations.OmbiSqlite
                         .WithMany("UserNotificationPreferences")
                         .HasForeignKey("UserId");
 
+                    b.Navigation("User");
+                });
+
+            modelBuilder.Entity("Ombi.Store.Entities.UserSelectableQualityProfile", b =>
+                {
+                    b.HasOne("Ombi.Store.Entities.OmbiUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                     b.Navigation("User");
                 });
 

--- a/src/Ombi.Store/Repository/BaseRepository.cs
+++ b/src/Ombi.Store/Repository/BaseRepository.cs
@@ -67,10 +67,15 @@ namespace Ombi.Store.Repository
             await InternalSaveChanges();
         }
 
-        public async Task DeleteRange(IEnumerable<T> req)
+        public Task DeleteRange(IEnumerable<T> req) => DeleteRange(req, true);
+
+        public async Task DeleteRange(IEnumerable<T> req, bool save)
         {
             _db.RemoveRange(req);
-            await InternalSaveChanges();
+            if (save)
+            {
+                await InternalSaveChanges();
+            }
         }
 
         public async Task<int> SaveChangesAsync()

--- a/src/Ombi.Store/Repository/IExternalRepository.cs
+++ b/src/Ombi.Store/Repository/IExternalRepository.cs
@@ -17,6 +17,7 @@ namespace Ombi.Store.Repository
         Task AddRange(IEnumerable<T> content, bool save = true);
         Task<T> Add(T content);
         Task DeleteRange(IEnumerable<T> req);
+        Task DeleteRange(IEnumerable<T> req, bool save);
         Task Delete(T request);
         Task<int> SaveChangesAsync();
 

--- a/src/Ombi.Store/Repository/IRepository.cs
+++ b/src/Ombi.Store/Repository/IRepository.cs
@@ -19,6 +19,7 @@ namespace Ombi.Store.Repository
         Task AddRange(IEnumerable<T> content, bool save = true);
         Task<T> Add(T content);
         Task DeleteRange(IEnumerable<T> req);
+        Task DeleteRange(IEnumerable<T> req, bool save);
         Task Delete(T request);
         Task<int> SaveChangesAsync();
 

--- a/src/Ombi.Tests/Migrations/UserSelectableQualityProfilesTests.cs
+++ b/src/Ombi.Tests/Migrations/UserSelectableQualityProfilesTests.cs
@@ -3,9 +3,13 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using NUnit.Framework;
 using Ombi.Helpers;
 using Ombi.Store.Context.Sqlite;
+using MySqlMigration = Ombi.Store.Migrations.OmbiMySql.UserSelectableQualityProfiles;
+using PostgresMigration = Ombi.Store.Migrations.OmbiPostgres.UserSelectableQualityProfiles;
+using SqliteMigration = Ombi.Store.Migrations.OmbiSqlite.UserSelectableQualityProfiles;
 
 namespace Ombi.Tests.Migrations
 {
@@ -15,6 +19,7 @@ namespace Ombi.Tests.Migrations
     {
         private const string MigrationId = "20260723000000_UserSelectableQualityProfiles";
         private const string PreviousMigrationId = "20260417000001_AddPlexWatchlistUserStatus";
+        private const string IndexName = "IX_UserSelectableQualityProfile_User_Application_Profile_Is4K";
 
         [Test]
         public async Task SqliteMigration_CreatesProfilesSchemaAndRolesForFreshAndExistingInstall()
@@ -64,15 +69,23 @@ namespace Ombi.Tests.Migrations
                 await context.SaveChangesAsync();
                 Assert.That(context.UserSelectableQualityProfiles.Count(), Is.Zero);
 
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.GetService<IMigrator>().MigrateAsync(PreviousMigrationId);
+                var migrator = context.Database.GetService<IMigrator>();
+                await migrator.MigrateAsync(PreviousMigrationId);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.Database.GetAppliedMigrations(), Does.Not.Contain(MigrationId));
+                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectRadarrQualityProfile), Is.False);
+                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectSonarrQualityProfile), Is.False);
+                });
+
                 await context.Database.MigrateAsync();
 
                 Assert.Multiple(() =>
                 {
                     Assert.That(context.Database.GetAppliedMigrations(), Does.Contain(MigrationId));
-                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectRadarrQualityProfile), Is.True);
-                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectSonarrQualityProfile), Is.True);
+                    Assert.That(context.Roles.Count(x => x.Name == OmbiRoles.SelectRadarrQualityProfile), Is.EqualTo(1));
+                    Assert.That(context.Roles.Count(x => x.Name == OmbiRoles.SelectSonarrQualityProfile), Is.EqualTo(1));
                     Assert.That(context.UserSelectableQualityProfiles.Count(), Is.Zero);
                     Assert.That(context.MovieRequests.All(x => x.QualityOverride4K == 0), Is.True);
                 });
@@ -81,6 +94,36 @@ namespace Ombi.Tests.Migrations
             {
                 System.IO.File.Delete(databasePath);
             }
+        }
+
+        [TestCase("Sqlite", "DELETE FROM AspnetRoles WHERE Name IN ('SelectRadarrQualityProfile', 'SelectSonarrQualityProfile');")]
+        [TestCase("MySql", "DELETE FROM AspNetRoles WHERE Name IN ('SelectRadarrQualityProfile', 'SelectSonarrQualityProfile');")]
+        [TestCase("Postgres", "DELETE FROM public.\"AspNetRoles\" WHERE \"Name\" IN ('SelectRadarrQualityProfile', 'SelectSonarrQualityProfile');")]
+        public void MigrationOperations_UseProviderSpecificRollbackSqlAndSafeIndexName(string provider, string expectedSql)
+        {
+            Migration migration = provider switch
+            {
+                "Sqlite" => new SqliteMigration(),
+                "MySql" => new MySqlMigration(),
+                "Postgres" => new PostgresMigration(),
+                _ => throw new System.ArgumentOutOfRangeException(nameof(provider))
+            };
+
+            var index = migration.UpOperations.OfType<CreateIndexOperation>().Single();
+            var downOperations = migration.DownOperations;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(index.Name, Is.EqualTo(IndexName));
+                Assert.That(System.Text.Encoding.ASCII.GetByteCount(index.Name), Is.LessThanOrEqualTo(63));
+                Assert.That(index.Table, Is.EqualTo("UserSelectableQualityProfile"));
+                Assert.That(index.Columns, Is.EqualTo(new[] { "UserId", "Application", "QualityProfileId", "Is4K" }));
+                Assert.That(index.IsUnique, Is.True);
+                Assert.That(downOperations, Has.Count.EqualTo(3));
+                Assert.That(((SqlOperation)downOperations[0]).Sql, Is.EqualTo(expectedSql));
+                Assert.That(((DropTableOperation)downOperations[1]).Name, Is.EqualTo("UserSelectableQualityProfile"));
+                Assert.That(((DropColumnOperation)downOperations[2]).Name, Is.EqualTo("QualityOverride4K"));
+            });
         }
     }
 }

--- a/src/Ombi.Tests/Migrations/UserSelectableQualityProfilesTests.cs
+++ b/src/Ombi.Tests/Migrations/UserSelectableQualityProfilesTests.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NUnit.Framework;
+using Ombi.Helpers;
+using Ombi.Store.Context.Sqlite;
+
+namespace Ombi.Tests.Migrations
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class UserSelectableQualityProfilesTests
+    {
+        private const string MigrationId = "20260723000000_UserSelectableQualityProfiles";
+        private const string PreviousMigrationId = "20260417000001_AddPlexWatchlistUserStatus";
+
+        [Test]
+        public async Task SqliteMigration_CreatesProfilesSchemaAndRolesForFreshAndExistingInstall()
+        {
+            var databasePath = System.IO.Path.GetTempFileName();
+            try
+            {
+                var options = new DbContextOptionsBuilder<OmbiSqliteContext>()
+                    .UseSqlite($"Data Source={databasePath}")
+                    .Options;
+                await using var context = new OmbiSqliteContext(options);
+                await context.Database.MigrateAsync();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.Database.GetAppliedMigrations(), Does.Contain(MigrationId));
+                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectRadarrQualityProfile), Is.True);
+                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectSonarrQualityProfile), Is.True);
+                    Assert.That(context.UserSelectableQualityProfiles.Count(), Is.Zero);
+                    Assert.That(context.MovieRequests.All(x => x.QualityOverride4K == 0), Is.True);
+                });
+
+                var user = new Ombi.Store.Entities.OmbiUser
+                {
+                    Id = "allowlist-user",
+                    UserName = "allowlist-user",
+                    NormalizedUserName = "ALLOWLIST-USER",
+                    StreamingCountry = "US"
+                };
+                context.Users.Add(user);
+                context.UserSelectableQualityProfiles.Add(new Ombi.Store.Entities.UserSelectableQualityProfile
+                {
+                    UserId = user.Id,
+                    Application = Ombi.Store.Entities.SelectableQualityProfileApplication.Radarr,
+                    QualityProfileId = 7
+                });
+                await context.SaveChangesAsync();
+                context.UserSelectableQualityProfiles.Add(new Ombi.Store.Entities.UserSelectableQualityProfile
+                {
+                    UserId = user.Id,
+                    Application = Ombi.Store.Entities.SelectableQualityProfileApplication.Radarr,
+                    QualityProfileId = 7
+                });
+                Assert.ThrowsAsync<DbUpdateException>(async () => await context.SaveChangesAsync());
+                context.ChangeTracker.Clear();
+                context.Users.Remove(await context.Users.FindAsync(user.Id));
+                await context.SaveChangesAsync();
+                Assert.That(context.UserSelectableQualityProfiles.Count(), Is.Zero);
+
+                await context.Database.EnsureDeletedAsync();
+                await context.Database.GetService<IMigrator>().MigrateAsync(PreviousMigrationId);
+                await context.Database.MigrateAsync();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.Database.GetAppliedMigrations(), Does.Contain(MigrationId));
+                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectRadarrQualityProfile), Is.True);
+                    Assert.That(context.Roles.Any(x => x.Name == OmbiRoles.SelectSonarrQualityProfile), Is.True);
+                    Assert.That(context.UserSelectableQualityProfiles.Count(), Is.Zero);
+                    Assert.That(context.MovieRequests.All(x => x.QualityOverride4K == 0), Is.True);
+                });
+            }
+            finally
+            {
+                System.IO.File.Delete(databasePath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracted from #5449 as the first focused PR in the selectable Arr quality-profile series.

This PR only adds the shared persistence foundation:
- selectable Radarr and Sonarr roles;
- `UserSelectableQualityProfile` storage and unique index;
- repository support needed by later backend PRs;
- separate standard/4K movie quality overrides;
- consolidated SQLite, MySQL and PostgreSQL migrations;
- migration regression coverage.

It intentionally contains no request-engine, API or frontend behavior. Those are prepared as separate follow-up PRs and will be opened against `develop` after their prerequisites merge, so each review shows only its own diff.

## Validation

- `git diff --check`
- migration structure validation for SQLite/MySQL/PostgreSQL
- PostgreSQL snapshot verified to preserve all existing `timestamp with time zone` mappings
- Angular-facing follow-up integration: 88 focused Vitest tests pass
- Angular development build passes
- full split integration reviewed: **APPROVE** by the native read-only reviewer

The .NET and real provider migration suites remain required CI checks because no local .NET SDK is available on the contribution host.

## Series

1. **This PR:** shared persistence/roles/migrations
2. Radarr backend validation
3. Sonarr backend validation
4. user administration controls
5. movie request UI (SD/4K)
6. TV request UI

Supersedes the foundation portion of #5449.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-specific Radarr and Sonarr quality profile selections, including a dedicated 4K (Is4K) option.
  * Added new permissions for selecting Radarr/Sonarr quality profiles, scoped per user, application, quality profile, and 4K choice.
* **Bug Fixes**
  * Improved request handling by introducing a dedicated 4K quality override field.
* **Refactor**
  * Enhanced bulk deletion to optionally skip immediate persistence when saving is not required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->