### PR TITLE
fix(wizard): deduplicate element IDs in database setup template

### DIFF
--- a/src/Ombi/ClientApp/src/app/wizard/database/database.component.html
+++ b/src/Ombi/ClientApp/src/app/wizard/database/database.component.html
@@ -21,50 +21,50 @@
                         </p>
                     </mat-tab>
                     <mat-tab label="MySQL/MariaDB">
-                        <ng-container *ngTemplateOutlet="dbForm; context: { dbType: 'MySQL' }"></ng-container>
+                        <ng-container *ngTemplateOutlet="dbForm; context: { idPrefix: 'mysql', dbType: 'MySQL/MariaDB' }"></ng-container>
                     </mat-tab>
 
                     <mat-tab label="Postgres">
-                        <ng-container *ngTemplateOutlet="dbForm; context: { dbType: 'Postgres' }"></ng-container>
+                        <ng-container *ngTemplateOutlet="dbForm; context: { idPrefix: 'postgres', dbType: 'Postgres' }"></ng-container>
                     </mat-tab>
                 </mat-tab-group>
 
-                <ng-template #dbForm let-dbType="dbType">
+                <ng-template #dbForm let-idPrefix="idPrefix" let-dbType="dbType">
                     <p class="space-or">
                         Please enter your {{dbType}} connection details below
                     </p>
                     <div>
                         <mat-form-field>
-                            <input matInput type="text" formControlName="host" [id]="dbType.toLowerCase() + '-host'" placeholder="Host">
+                            <input matInput type="text" formControlName="host" [id]="idPrefix + '-host'" placeholder="Host">
                             <mat-error>This field is required</mat-error>
                         </mat-form-field>
                     </div>
                     <div>
                         <mat-form-field>
-                            <input matInput type="number" formControlName="port" [id]="dbType.toLowerCase() + '-port'" placeholder="Port">
+                            <input matInput type="number" formControlName="port" [id]="idPrefix + '-port'" placeholder="Port">
                             <mat-error>This field is required</mat-error>
                         </mat-form-field>
                     </div>
                     <div>
                         <mat-form-field>
-                            <input matInput type="text" formControlName="name" [id]="dbType.toLowerCase() + '-database'" placeholder="Database Name">
+                            <input matInput type="text" formControlName="name" [id]="idPrefix + '-database'" placeholder="Database Name">
                             <mat-error>This field is required</mat-error>
                         </mat-form-field>
                     </div>
                     <div>
                         <mat-form-field>
-                            <input matInput type="text" formControlName="user" [id]="dbType.toLowerCase() + '-user'" placeholder="User">
+                            <input matInput type="text" formControlName="user" [id]="idPrefix + '-user'" placeholder="User">
                         </mat-form-field>
                     </div>
                     <div>
                         <mat-form-field>
-                            <input matInput type="password" formControlName="password" [id]="dbType.toLowerCase() + '-password'" placeholder="Password">
+                            <input matInput type="password" formControlName="password" [id]="idPrefix + '-password'" placeholder="Password">
                         </mat-form-field>
                     </div>
                     <p>{{connectionString | async}}</p>
                     <div style="text-align: center; margin-top: 20px">
-                        <button (click)="save()" [id]="dbType.toLowerCase() + '-databaseSave'" mat-raised-button color="accent" type="button" class="viewon-btn database" [disabled]="form.invalid">Save</button>
-                        <div [id]="dbType.toLowerCase() + '-spinner'"></div>
+                        <button (click)="save()" [id]="idPrefix + '-databaseSave'" mat-raised-button color="accent" type="button" class="viewon-btn database" [disabled]="form.invalid">Save</button>
+                        <div [id]="idPrefix + '-spinner'"></div>
                     </div>
                 </ng-template>
             </form>

--- a/src/Ombi/ClientApp/src/app/wizard/database/database.component.html
+++ b/src/Ombi/ClientApp/src/app/wizard/database/database.component.html
@@ -1,4 +1,4 @@
-﻿<div class="mediaserver-container">
+<div class="mediaserver-container">
     <div class="left-container mediaserver">
         <i class="fa fa-database text-logo"></i>
     </div>
@@ -21,83 +21,52 @@
                         </p>
                     </mat-tab>
                     <mat-tab label="MySQL/MariaDB">
-                        <p class="space-or">
-                            Please enter your MySQL/MariaDB connection details below
-                        </p>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="text" formControlName="host" id="host" placeholder="Host">
-                                    <mat-error>This field is required</mat-error>
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="number" formControlName="port" id="port" placeholder="Port">
-                                    <mat-error>This field is required</mat-error>
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="text" formControlName="name" id="database" placeholder="Database Name">
-                                    <mat-error>This field is required</mat-error>
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="text"  formControlName="user" id="user" placeholder="User">
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="password"  formControlName="password" id="password" placeholder="Password">
-                                </mat-form-field>
-                            </div>
-                            <p>{{connectionString | async}}</p>
-                            <div style="text-align: center; margin-top: 20px">
-                                <button (click)="save()" id="databaseSave" mat-raised-button color="accent" type="button" class="viewon-btn database" [disabled]="form.invalid">Save</button>
-                                <div id="spinner"></div>
-                            </div>
+                        <ng-container *ngTemplateOutlet="dbForm; context: { dbType: 'MySQL' }"></ng-container>
                     </mat-tab>
 
                     <mat-tab label="Postgres">
-                        <p class="space-or">
-                            Please enter your Postgres connection details below
-                        </p>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="text" formControlName="host" id="host" placeholder="Host">
-                                    <mat-error>This field is required</mat-error>
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="number" formControlName="port" id="port" placeholder="Port">
-                                    <mat-error>This field is required</mat-error>
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="text" formControlName="name" id="database" placeholder="Database Name">
-                                    <mat-error>This field is required</mat-error>
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="text"  formControlName="user" id="user" placeholder="User">
-                                </mat-form-field>
-                            </div>
-                            <div>
-                                <mat-form-field>
-                                    <input matInput type="password"  formControlName="password" id="password" placeholder="Password">
-                                </mat-form-field>
-                            </div>
-                            <p>{{connectionString | async}}</p>
-                            <div style="text-align: center; margin-top: 20px">
-                                <button (click)="save()" id="databaseSave" mat-raised-button color="accent" type="button" class="viewon-btn database" [disabled]="form.invalid">Save</button>
-                                <div id="spinner"></div>
-                            </div>
+                        <ng-container *ngTemplateOutlet="dbForm; context: { dbType: 'Postgres' }"></ng-container>
                     </mat-tab>
                 </mat-tab-group>
+
+                <ng-template #dbForm let-dbType="dbType">
+                    <p class="space-or">
+                        Please enter your {{dbType}} connection details below
+                    </p>
+                    <div>
+                        <mat-form-field>
+                            <input matInput type="text" formControlName="host" [id]="dbType.toLowerCase() + '-host'" placeholder="Host">
+                            <mat-error>This field is required</mat-error>
+                        </mat-form-field>
+                    </div>
+                    <div>
+                        <mat-form-field>
+                            <input matInput type="number" formControlName="port" [id]="dbType.toLowerCase() + '-port'" placeholder="Port">
+                            <mat-error>This field is required</mat-error>
+                        </mat-form-field>
+                    </div>
+                    <div>
+                        <mat-form-field>
+                            <input matInput type="text" formControlName="name" [id]="dbType.toLowerCase() + '-database'" placeholder="Database Name">
+                            <mat-error>This field is required</mat-error>
+                        </mat-form-field>
+                    </div>
+                    <div>
+                        <mat-form-field>
+                            <input matInput type="text" formControlName="user" [id]="dbType.toLowerCase() + '-user'" placeholder="User">
+                        </mat-form-field>
+                    </div>
+                    <div>
+                        <mat-form-field>
+                            <input matInput type="password" formControlName="password" [id]="dbType.toLowerCase() + '-password'" placeholder="Password">
+                        </mat-form-field>
+                    </div>
+                    <p>{{connectionString | async}}</p>
+                    <div style="text-align: center; margin-top: 20px">
+                        <button (click)="save()" [id]="dbType.toLowerCase() + '-databaseSave'" mat-raised-button color="accent" type="button" class="viewon-btn database" [disabled]="form.invalid">Save</button>
+                        <div [id]="dbType.toLowerCase() + '-spinner'"></div>
+                    </div>
+                </ng-template>
             </form>
         </div>
     </div>


### PR DESCRIPTION
### Summary of Changes
Fixes SonarQube code quality issue S7930 (Duplicate HTML IDs) in `database.component.html`.
- Deduplicates element IDs across MySQL and Postgres wizard tabs by introducing an `<ng-template>` with dynamic `[id]` bindings (`mysql-` and `postgres-` prefixes).

Part of splitting up #5447 into smaller, focused PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the database-connection wizard for MySQL/MariaDB and PostgreSQL by sharing a single reusable form layout for both options.
  * Standardised database-specific messaging and indicators, while keeping the same required fields and validation behaviour.
  * Improved element identification within the wizard to keep controls and loading states consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->