### PR TITLE
fix(discover): consolidate request button template to remove duplicate element IDs

### DIFF
--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
@@ -27,7 +27,7 @@
 
         <!-- Request button -->
         <div class="card-actions" *ngIf="!result.available && !result.approved && !result.requested">
-            <button [matMenuTriggerFor]="is4kEnabled && requestable && result.type === RequestType.movie ? menu : null"
+            <button [matMenuTriggerFor]="is4kEnabled && result.type === RequestType.movie ? menu : null"
                     id="requestButton{{result.id}}{{result.type}}{{discoverType}}"
                     *ngIf="requestable"
                     mat-raised-button

--- a/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
+++ b/src/Ombi/ClientApp/src/app/discover/components/card/discover-card.component.html
@@ -27,25 +27,20 @@
 
         <!-- Request button -->
         <div class="card-actions" *ngIf="!result.available && !result.approved && !result.requested">
-            <div *ngIf="is4kEnabled && requestable && result.type === RequestType.movie;then show4K else regular"></div>
-            <ng-template #show4K>
-                <button [matMenuTriggerFor]="menu" id="requestButton{{result.id}}{{result.type}}{{discoverType}}" mat-raised-button class="request-btn">
-                    <i *ngIf="!loading" class="fas fa-plus" aria-hidden="true"></i>
-                    <i *ngIf="loading" class="fas fa-spinner fa-pulse" aria-hidden="true"></i>
-                    <span>{{'Common.Request' | translate }}</span>
-                </button>
-                <mat-menu #menu="matMenu">
-                    <button mat-menu-item class="request-menu-item" (click)="request($event, false)">{{'Common.Request' | translate }}</button>
-                    <button mat-menu-item class="request-menu-item" (click)="request($event, true)">{{'Common.Request4K' | translate }}</button>
-                </mat-menu>
-            </ng-template>
-            <ng-template #regular>
-                <button id="requestButton{{result.id}}{{result.type}}{{discoverType}}" *ngIf="requestable" mat-raised-button class="request-btn" (click)="request($event, false)">
-                    <i *ngIf="!loading" class="fas fa-plus" aria-hidden="true"></i>
-                    <i *ngIf="loading" class="fas fa-spinner fa-pulse" aria-hidden="true"></i>
-                    <span>{{'Common.Request' | translate }}</span>
-                </button>
-            </ng-template>
+            <button [matMenuTriggerFor]="is4kEnabled && requestable && result.type === RequestType.movie ? menu : null"
+                    id="requestButton{{result.id}}{{result.type}}{{discoverType}}"
+                    *ngIf="requestable"
+                    mat-raised-button
+                    class="request-btn"
+                    (click)="!(is4kEnabled && result.type === RequestType.movie) ? request($event, false) : null">
+                <i *ngIf="!loading" class="fas fa-plus" aria-hidden="true"></i>
+                <i *ngIf="loading" class="fas fa-spinner fa-pulse" aria-hidden="true"></i>
+                <span>{{'Common.Request' | translate }}</span>
+            </button>
+            <mat-menu #menu="matMenu">
+                <button mat-menu-item class="request-menu-item" (click)="request($event, false)">{{'Common.Request' | translate }}</button>
+                <button mat-menu-item class="request-menu-item" (click)="request($event, true)">{{'Common.Request4K' | translate }}</button>
+            </mat-menu>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Summary of Changes
Fixes SonarQube code quality issue S7930 (Duplicate HTML IDs) in `discover-card.component.html`.
- Consolidates conditional 4K and regular request button templates into a single `<button>` element with dynamic menu trigger and click handler bindings, eliminating duplicate `requestButton...` element IDs.

Part of splitting up #5447 into smaller, focused PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the request controls for discoverable content.
  * Improved request handling when 4K options are available, including clearer access to standard and 4K requests.
  * Prevented unintended requests by only wiring the shared 4K request menu when the 4K+movie condition applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->