### PR TITLE
fix(pipes): update HumanizePipe signature and add empty value handling

### DIFF
--- a/src/Ombi/ClientApp/src/app/pipes/HumanizePipe.spec.ts
+++ b/src/Ombi/ClientApp/src/app/pipes/HumanizePipe.spec.ts
@@ -27,4 +27,8 @@ describe('HumanizePipe', () => {
   it('should return non-string values as-is', () => {
     expect(pipe.transform(123 as any)).toBe(123);
   });
+
+  it('should return empty string as-is', () => {
+    expect(pipe.transform('')).toBe('');
+  });
 });

--- a/src/Ombi/ClientApp/src/app/pipes/HumanizePipe.ts
+++ b/src/Ombi/ClientApp/src/app/pipes/HumanizePipe.ts
@@ -1,16 +1,17 @@
-﻿import { Pipe, PipeTransform } from "@angular/core";
+import { Pipe, PipeTransform } from "@angular/core";
 
 @Pipe({
     standalone: true,
     name: "humanize",
 })
 export class HumanizePipe implements PipeTransform  {
-    public transform(value: string) {
-        if ((typeof value) !== "string") {
+    public transform(value: any): any {
+        if ((typeof value) !== "string" || !value) {
             return value;
         }
-        value = value.split(/(?=[A-Z])/).join(" ");
-        value = value[0].toUpperCase() + value.slice(1);
-        return value;
+        let str = value as string;
+        str = str.split(/(?=[A-Z])/).join(" ");
+        str = str[0].toUpperCase() + str.slice(1);
+        return str;
     }
 }


### PR DESCRIPTION
### Summary of Changes
Fixes Angular pipe interface signature and null/empty string handling in `HumanizePipe.ts`.
- Changes `transform` parameters and return type to match Angular's standard `PipeTransform` signature (`any`).
- Safely returns falsy/empty values as-is.
- Adds spec coverage for empty string input in `HumanizePipe.spec.ts`.

Part of splitting up #5447 into smaller, focused PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved empty and non-string values when using the humanisation pipe.
  * Continued formatting recognised strings into readable text as before.

* **Tests**
  * Added coverage confirming that empty strings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->