### PR TITLE
fix(core): align engine parameter naming and in-memory query evaluation

### DIFF
--- a/src/Ombi.Core/Engine/MusicRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MusicRequestEngine.cs
@@ -559,7 +559,7 @@ namespace Ombi.Core.Engine
             };
         }
 
-        public async Task<RequestsViewModel<AlbumRequest>> GetRequests(int count, int position, string sortProperty, string sortOrder, string requestedByUserId = null)
+        public async Task<RequestsViewModel<AlbumRequest>> GetRequests(int count, int position, string sort, string sortOrder, string requestedByUserId = null)
         {
             var shouldHide = await HideFromOtherUsers();
             IQueryable<AlbumRequest> allRequests;
@@ -579,7 +579,7 @@ namespace Ombi.Core.Engine
             allRequests = FilterByRequestedUser(allRequests, requestedByUserId, shouldHide.IsAdmin);
 
             var total = await allRequests.CountAsync();
-            var requests = await ApplySortAlbums(allRequests, sortProperty, sortOrder)
+            var requests = await ApplySortAlbums(allRequests, sort, sortOrder)
                 .Skip(position).Take(count).ToListAsync();
 
             await CheckForSubscription(shouldHide, requests);

--- a/src/Ombi.Core/Engine/MusicRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MusicRequestEngine.cs
@@ -1,4 +1,4 @@
-﻿using Ombi.Api.External.ExternalApis.TheMovieDb;
+using Ombi.Api.External.ExternalApis.TheMovieDb;
 using Ombi.Core.Models.Requests;
 using Ombi.Helpers;
 using Ombi.Store.Entities;
@@ -510,7 +510,7 @@ namespace Ombi.Core.Engine
             return new RequestEngineResult { Result = true, Message = $"{model.Title} has been successfully added!", RequestId = model.Id };
         }
 
-        public async Task<RequestsViewModel<AlbumRequest>> GetRequestsByStatus(int count, int position, string sortProperty, string sortOrder, RequestStatus status, string requestedByUserId = null)
+        public async Task<RequestsViewModel<AlbumRequest>> GetRequestsByStatus(int count, int position, string sort, string sortOrder, RequestStatus available, string requestedByUserId = null)
         {
              var shouldHide = await HideFromOtherUsers();
             IQueryable<AlbumRequest> allRequests;
@@ -529,7 +529,7 @@ namespace Ombi.Core.Engine
 
             allRequests = FilterByRequestedUser(allRequests, requestedByUserId, shouldHide.IsAdmin);
 
-            switch (status)
+            switch (available)
             {
                 case RequestStatus.PendingApproval:
                     allRequests = allRequests.Where(x => !x.Approved && !x.Available && (!x.Denied.HasValue || !x.Denied.Value));
@@ -548,7 +548,7 @@ namespace Ombi.Core.Engine
             }
 
             var total = await allRequests.CountAsync();
-            var requests = await ApplySortAlbums(allRequests, sortProperty, sortOrder)
+            var requests = await ApplySortAlbums(allRequests, sort, sortOrder)
                 .Skip(position).Take(count).ToListAsync();
 
             await CheckForSubscription(shouldHide, requests);
@@ -590,10 +590,10 @@ namespace Ombi.Core.Engine
             };
         }
 
-        private static IQueryable<AlbumRequest> ApplySortAlbums(IQueryable<AlbumRequest> query, string sortProperty, string sortOrder)
+        private static IQueryable<AlbumRequest> ApplySortAlbums(IQueryable<AlbumRequest> query, string sort, string sortOrder)
         {
             var asc = sortOrder.Equals("asc", StringComparison.InvariantCultureIgnoreCase);
-            return sortProperty.ToLowerInvariant() switch
+            return sort.ToLowerInvariant() switch
             {
                 "id" => asc ? query.OrderBy(x => x.Id) : query.OrderByDescending(x => x.Id),
                 "title" => asc ? query.OrderBy(x => x.Title) : query.OrderByDescending(x => x.Title),

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -381,7 +381,7 @@ namespace Ombi.Core.Engine
                 return new RequestsViewModel<ChildRequests>();
             }
 
-            allRequests = FilterByRequestedUser(allRequests.AsQueryable(), requestedByUserId, shouldHide.IsAdmin).ToList();
+            allRequests = FilterByRequestedUser(allRequests.AsQueryable(), requestedByUserId, shouldHide.IsAdmin).AsEnumerable().ToList();
 
             allRequests = ApplySortTv(allRequests, sortProperty, sortOrder);
 
@@ -418,7 +418,7 @@ namespace Ombi.Core.Engine
 
             }
 
-            allRequests = FilterByRequestedUser(allRequests.AsQueryable(), requestedByUserId, shouldHide.IsAdmin).ToList();
+            allRequests = FilterByRequestedUser(allRequests.AsQueryable(), requestedByUserId, shouldHide.IsAdmin).AsEnumerable().ToList();
 
             switch (status)
             {
@@ -483,7 +483,7 @@ namespace Ombi.Core.Engine
                 return new RequestsViewModel<ChildRequests>();
             }
 
-            allRequests = FilterByRequestedUser(allRequests.AsQueryable(), requestedByUserId, shouldHide.IsAdmin).ToList();
+            allRequests = FilterByRequestedUser(allRequests.AsQueryable(), requestedByUserId, shouldHide.IsAdmin).AsEnumerable().ToList();
 
             allRequests = ApplySortTv(allRequests, sortProperty, sortOrder);
 


### PR DESCRIPTION
### Summary of Changes
Fixes SonarQube code smells in `MusicRequestEngine.cs` and `TvRequestEngine.cs`.
- Resolves S927 by renaming the `sortProperty` parameter to `sort` in `MusicRequestEngine.cs` to match `IMusicRequestEngine.cs`.
- Resolves S6966 by adding `.AsEnumerable()` before calling `.ToList()` on in-memory queryables in `TvRequestEngine.cs`.

Part of splitting up #5447 into smaller, focused PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of music request sorting when browsing request lists.
  * Improved TV request list handling, including filtered and unavailable requests.
  * Request listings now provide more consistent results when sorting and filtering by requester or status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->