### PR TITLE
fix(rules): optimize media server availability rule and episode checks

### DIFF
--- a/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/AvailabilityRuleHelper.cs
@@ -34,20 +34,13 @@ namespace Ombi.Core.Rule.Rules.Search
             {
                 var airedButNotAvailable = search.SeasonRequests.Any(x =>
                     x.Episodes.Any(c => !c.Available && c.AirDate <= DateTime.Now.Date && c.AirDate != DateTime.MinValue));
-                if (!airedButNotAvailable)
+                
+                var unknownAirDateUnavailable = search.SeasonRequests.Any(x =>
+                    x.Episodes.Any(c => !c.Available && c.AirDate == DateTime.MinValue));
+
+                if (!airedButNotAvailable && !unknownAirDateUnavailable && search.PartlyAvailable)
                 {
-                    var unknownAirDateUnavailable = search.SeasonRequests.Any(x =>
-                        x.Episodes.Any(c => !c.Available && c.AirDate == DateTime.MinValue));
-                    if (!unknownAirDateUnavailable)
-                    {
-                        // Only treat the remaining (unaired) episodes as non-blocking when we
-                        // actually have something available already. A show where nothing has
-                        // aired yet has no available episodes and must not be marked available.
-                        if (search.PartlyAvailable)
-                        {
-                            search.FullyAvailable = true;
-                        }
-                    }
+                    search.FullyAvailable = true;
                 }
             }
 
@@ -67,22 +60,21 @@ namespace Ombi.Core.Rule.Rules.Search
             IMediaServerEpisode epExists = null;
             try
             {
-
-                if (useImdb)
+                if (useImdb && !string.IsNullOrEmpty(item.ImdbId))
                 {
                     epExists = await allEpisodes.FirstOrDefaultAsync(x =>
                         x.EpisodeNumber == episode.EpisodeNumber && x.SeasonNumber == season.SeasonNumber &&
                         x.Series.ImdbId == item.ImdbId);
                 }
 
-                if (useTheMovieDb)
+                if (epExists == null && useTheMovieDb && !string.IsNullOrEmpty(item.TheMovieDbId))
                 {
                     epExists = await allEpisodes.FirstOrDefaultAsync(x =>
                         x.EpisodeNumber == episode.EpisodeNumber && x.SeasonNumber == season.SeasonNumber &&
                         x.Series.TheMovieDbId == item.TheMovieDbId);
                 }
 
-                if (useTvDb)
+                if (epExists == null && useTvDb && !string.IsNullOrEmpty(item.TvDbId))
                 {
                     epExists = await allEpisodes.FirstOrDefaultAsync(x =>
                         x.EpisodeNumber == episode.EpisodeNumber && x.SeasonNumber == season.SeasonNumber &&

--- a/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
@@ -139,14 +139,11 @@ namespace Ombi.Core.Rule.Rules.Search
                 Log.LogError(ex, "Exception thrown when pre-fetching series episodes for availability check");
             }
 
-            foreach (var season in search.SeasonRequests.ToList())
+            foreach (var season in search.SeasonRequests)
             {
-                foreach (var episode in season.Episodes.ToList())
+                foreach (var episode in season.Episodes.Where(e => seriesEpisodes.Any(x => x.EpisodeNumber == e.EpisodeNumber && x.SeasonNumber == season.SeasonNumber)))
                 {
-                    if (seriesEpisodes.Any(x => x.EpisodeNumber == episode.EpisodeNumber && x.SeasonNumber == season.SeasonNumber))
-                    {
-                        episode.Available = true;
-                    }
+                    episode.Available = true;
                 }
             }
 

--- a/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
@@ -111,6 +111,11 @@ namespace Ombi.Core.Rule.Rules.Search
 
         private async Task CheckEpisodeAvailability(SearchTvShowViewModel search, ContentLookupResult lookup, IMediaServerContent item)
         {
+            if (await ShouldDeferToSonarr())
+            {
+                return;
+            }
+
             if (!search.SeasonRequests.Any())
             {
                 return;
@@ -139,9 +144,11 @@ namespace Ombi.Core.Rule.Rules.Search
                 Log.LogError(ex, "Exception thrown when pre-fetching series episodes for availability check");
             }
 
+            var episodeSet = seriesEpisodes.Select(x => (x.SeasonNumber, x.EpisodeNumber)).ToHashSet();
+
             foreach (var season in search.SeasonRequests)
             {
-                foreach (var episode in season.Episodes.Where(e => seriesEpisodes.Any(x => x.EpisodeNumber == e.EpisodeNumber && x.SeasonNumber == season.SeasonNumber)))
+                foreach (var episode in season.Episodes.Where(e => episodeSet.Contains((season.SeasonNumber, e.EpisodeNumber))))
                 {
                     episode.Available = true;
                 }

--- a/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/MediaServerAvailabilityRule.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ombi.Core.Models.Search;
 using Ombi.Core.Rule.Interfaces;
@@ -20,8 +22,6 @@ namespace Ombi.Core.Rule.Rules.Search
         private readonly ISettingsService<SonarrSettings> _sonarrSettings;
 
         protected ILogger Log { get; }
-        private bool? _deferToRadarr;
-        private bool? _deferToSonarr;
 
         protected MediaServerAvailabilityRule(
             ILogger log,
@@ -111,24 +111,42 @@ namespace Ombi.Core.Rule.Rules.Search
 
         private async Task CheckEpisodeAvailability(SearchTvShowViewModel search, ContentLookupResult lookup, IMediaServerContent item)
         {
-            if (await ShouldDeferToSonarr())
-            {
-                return;
-            }
-
             if (!search.SeasonRequests.Any())
             {
                 return;
             }
 
             var allEpisodes = GetAllEpisodes();
+            var seriesEpisodes = new List<IMediaServerEpisode>();
+
+            try
+            {
+                if (lookup.UseImdb && !string.IsNullOrEmpty(item.ImdbId))
+                {
+                    seriesEpisodes = await allEpisodes.Where(x => x.Series.ImdbId == item.ImdbId).ToListAsync();
+                }
+                else if (lookup.UseTheMovieDb && !string.IsNullOrEmpty(item.TheMovieDbId))
+                {
+                    seriesEpisodes = await allEpisodes.Where(x => x.Series.TheMovieDbId == item.TheMovieDbId).ToListAsync();
+                }
+                else if (lookup.UseTvDb && !string.IsNullOrEmpty(item.TvDbId))
+                {
+                    seriesEpisodes = await allEpisodes.Where(x => x.Series.TvDbId == item.TvDbId).ToListAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.LogError(ex, "Exception thrown when pre-fetching series episodes for availability check");
+            }
+
             foreach (var season in search.SeasonRequests.ToList())
             {
                 foreach (var episode in season.Episodes.ToList())
                 {
-                    await AvailabilityRuleHelper.SingleEpisodeCheck(
-                        lookup.UseImdb, allEpisodes, episode, season, item,
-                        lookup.UseTheMovieDb, lookup.UseTvDb, Log);
+                    if (seriesEpisodes.Any(x => x.EpisodeNumber == episode.EpisodeNumber && x.SeasonNumber == season.SeasonNumber))
+                    {
+                        episode.Available = true;
+                    }
                 }
             }
 
@@ -137,40 +155,26 @@ namespace Ombi.Core.Rule.Rules.Search
 
         private async Task<bool> ShouldDeferToRadarr()
         {
-            if (_deferToRadarr.HasValue)
-            {
-                return _deferToRadarr.Value;
-            }
-
             if (_radarrSettings == null)
             {
-                _deferToRadarr = false;
                 return false;
             }
 
             var settings = await _radarrSettings.GetSettingsAsync();
-            _deferToRadarr = settings != null && settings.Enabled &&
+            return settings != null && settings.Enabled &&
                    settings.ScanForAvailability && settings.PrioritizeArrAvailability;
-            return _deferToRadarr.Value;
         }
 
         private async Task<bool> ShouldDeferToSonarr()
         {
-            if (_deferToSonarr.HasValue)
-            {
-                return _deferToSonarr.Value;
-            }
-
             if (_sonarrSettings == null)
             {
-                _deferToSonarr = false;
                 return false;
             }
 
             var settings = await _sonarrSettings.GetSettingsAsync();
-            _deferToSonarr = settings != null && settings.Enabled &&
+            return settings != null && settings.Enabled &&
                    settings.ScanForAvailability && settings.PrioritizeArrAvailability;
-            return _deferToSonarr.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
### Summary of Changes
Fixes SonarQube complexity issues S1066 / S3776 and optimizes episode availability lookups:
- Flattens nested `if` statements in `AvailabilityRuleHelper.CheckForUnairedEpisodes`.
- Optimizes `CheckEpisodeAvailability` in `MediaServerAvailabilityRule.cs` by pre-fetching series episodes outside the per-episode iteration loops.
- Adds guards against empty provider IDs (`ImdbId`, `TheMovieDbId`, `TvDbId`) to prevent false-positive availability matches on empty strings.
- Uses `.Any()` for existence checks in episode availability evaluation.

Part of splitting up #5447 into smaller, focused PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promotion of shows from partly to fully available when unaired episode data is present.
  * Avoided unnecessary episode lookups when external provider identifiers are empty.
  * Improved media-server episode availability matching by prefetching and matching episodes using the selected provider.
  * Corrected availability deferral behaviour to always reflect current settings, including when settings are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->