### PR TITLE
Add independent schedule to availability checkers

### DIFF
--- a/src/Ombi.Schedule/OmbiScheduler.cs
+++ b/src/Ombi.Schedule/OmbiScheduler.cs
@@ -81,12 +81,12 @@ namespace Ombi.Schedule
         {
             await OmbiQuartz.Instance.AddJob<ISonarrSync>(nameof(ISonarrSync), "DVR", JobSettingsHelper.Sonarr(s));
             await OmbiQuartz.Instance.AddJob<IRadarrSync>(nameof(IRadarrSync), "DVR", JobSettingsHelper.Radarr(s));
-            await OmbiQuartz.Instance.AddJob<IArrAvailabilityChecker>(nameof(IArrAvailabilityChecker), "DVR", null);
+            await OmbiQuartz.Instance.AddJob<IArrAvailabilityChecker>(nameof(IArrAvailabilityChecker), "DVR", Cron.MinuteInterval(5));
             await OmbiQuartz.Instance.AddJob<ICouchPotatoSync>(nameof(ICouchPotatoSync), "DVR", JobSettingsHelper.CouchPotato(s));
             await OmbiQuartz.Instance.AddJob<ISickRageSync>(nameof(ISickRageSync), "DVR", JobSettingsHelper.SickRageSync(s));
             await OmbiQuartz.Instance.AddJob<ILidarrArtistSync>(nameof(ILidarrArtistSync), "DVR", JobSettingsHelper.LidarrArtistSync(s));
             await OmbiQuartz.Instance.AddJob<ILidarrAlbumSync>(nameof(ILidarrAlbumSync), "DVR", null);
-            await OmbiQuartz.Instance.AddJob<ILidarrAvailabilityChecker>(nameof(ILidarrAvailabilityChecker), "DVR", null);
+            await OmbiQuartz.Instance.AddJob<ILidarrAvailabilityChecker>(nameof(ILidarrAvailabilityChecker), "DVR", Cron.MinuteInterval(5));
         }
 
         private static async Task AddPlex(JobSettings s)
@@ -95,7 +95,7 @@ namespace Ombi.Schedule
             await OmbiQuartz.Instance.AddJob<IPlexContentSync>(nameof(IPlexContentSync) + "RecentlyAdded", "Plex", JobSettingsHelper.PlexRecentlyAdded(s), new Dictionary<string, string> { { JobDataKeys.RecentlyAddedSearch, "true" } });
             await OmbiQuartz.Instance.AddJob<IPlexUserImporter>(nameof(IPlexUserImporter), "Plex", JobSettingsHelper.UserImporter(s));
             await OmbiQuartz.Instance.AddJob<IPlexEpisodeSync>(nameof(IPlexEpisodeSync), "Plex", null);
-            await OmbiQuartz.Instance.AddJob<IPlexAvailabilityChecker>(nameof(IPlexAvailabilityChecker), "Plex", null);
+            await OmbiQuartz.Instance.AddJob<IPlexAvailabilityChecker>(nameof(IPlexAvailabilityChecker), "Plex", Cron.MinuteInterval(5));
             await OmbiQuartz.Instance.AddJob<IPlexWatchlistImport>(nameof(IPlexWatchlistImport), "Plex", JobSettingsHelper.PlexWatchlistImport(s));
         }
 
@@ -105,7 +105,7 @@ namespace Ombi.Schedule
             await OmbiQuartz.Instance.AddJob<IEmbyContentSync>(nameof(IEmbyContentSync) + "RecentlyAdded", "Emby", JobSettingsHelper.EmbyRecentlyAddedSync(s), new Dictionary<string, string> { { JobDataKeys.EmbyRecentlyAddedSearch, "true" } });
             await OmbiQuartz.Instance.AddJob<IEmbyEpisodeSync>(nameof(IEmbyEpisodeSync), "Emby", null);
             await OmbiQuartz.Instance.AddJob<IEmbyPlayedSync>(nameof(IEmbyPlayedSync), "Emby", null);
-            await OmbiQuartz.Instance.AddJob<IEmbyAvaliabilityChecker>(nameof(IEmbyAvaliabilityChecker), "Emby", null);
+            await OmbiQuartz.Instance.AddJob<IEmbyAvaliabilityChecker>(nameof(IEmbyAvaliabilityChecker), "Emby", Cron.MinuteInterval(5));
             await OmbiQuartz.Instance.AddJob<IEmbyUserImporter>(nameof(IEmbyUserImporter), "Emby", JobSettingsHelper.UserImporter(s));
         }
 
@@ -113,7 +113,7 @@ namespace Ombi.Schedule
         {
             await OmbiQuartz.Instance.AddJob<IJellyfinContentSync>(nameof(IJellyfinContentSync), "Jellyfin", JobSettingsHelper.JellyfinContent(s));
             await OmbiQuartz.Instance.AddJob<IJellyfinEpisodeSync>(nameof(IJellyfinEpisodeSync), "Jellyfin", null);
-            await OmbiQuartz.Instance.AddJob<IJellyfinAvaliabilityChecker>(nameof(IJellyfinAvaliabilityChecker), "Jellyfin", null);
+            await OmbiQuartz.Instance.AddJob<IJellyfinAvaliabilityChecker>(nameof(IJellyfinAvaliabilityChecker), "Jellyfin", Cron.MinuteInterval(5));
             await OmbiQuartz.Instance.AddJob<IJellyfinUserImporter>(nameof(IJellyfinUserImporter), "Jellyfin", JobSettingsHelper.UserImporter(s));
         }
 


### PR DESCRIPTION
## Problem

All five availability checkers (Plex, Arr/Sonarr/Radarr, Emby, Jellyfin, Lidarr) are registered in `OmbiScheduler.cs` with `null` cron expressions. This means they have no independent schedule and only run when explicitly triggered by their respective content sync jobs via `TriggerJob` at the end of the sync.

If a content sync job throws an exception before reaching its `TriggerJob` call, the availability checker never fires. Approved requests that have become available sit in "Processing" state indefinitely, because nothing ever rechecks them against the cached content.

This is particularly fragile because:
- `PlexContentSync` only triggers the checker when `recentlyAddedSearch` is true AND `processedContent.HasProcessedContent` is true
- `RadarrSync` and `SonarrSync` trigger the checker inside a try block after database writes
- `EmbyAvailabilityChecker` and `JellyfinAvailabilityChecker` are only triggered from `RefreshMetadata`, which is itself a trigger-only job with a null cron

Any single failure in this chain silently breaks availability detection until the next successful sync run.

## Impact

200+ requests can pile up in "Processing" when sync jobs error out. Users see their requests approved but never marked as available, even though the content exists in their media server.

## Fix

Give each availability checker a 5-minute cron schedule (`Cron.MinuteInterval(5)`) as a safety net. This is appropriate because availability checkers are lightweight DB queries that compare existing requests against already-cached content -- they make no external API calls.

The existing `TriggerJob` calls from sync jobs are **untouched** -- the normal fast path still works exactly as before. The cron schedule is purely a fallback that ensures availability is eventually checked even when the sync trigger chain breaks.

### Jobs changed

| Checker | Group | Before | After |
|---------|-------|--------|-------|
| `IArrAvailabilityChecker` | DVR | `null` | Every 5 min |
| `ILidarrAvailabilityChecker` | DVR | `null` | Every 5 min |
| `IPlexAvailabilityChecker` | Plex | `null` | Every 5 min |
| `IEmbyAvaliabilityChecker` | Emby | `null` | Every 5 min |
| `IJellyfinAvaliabilityChecker` | Jellyfin | `null` | Every 5 min |

### Not changed

- All `TriggerJob` calls in sync jobs (PlexContentSync, RadarrSync, SonarrSync, RefreshMetadata, LidarrAlbumSync)
- Other trigger-only jobs (PlexEpisodeSync, EmbyEpisodeSync, JellyfinEpisodeSync, EmbyPlayedSync, LidarrAlbumSync, RefreshMetadata, NotificationService)
- No new dependencies or configuration

## Testing

- Verified the solution builds cleanly (0 errors, only pre-existing warnings)
- Change is limited to a single file (`OmbiScheduler.cs`), 5 lines changed
- `Cron.MinuteInterval(5)` produces `0 0/5 * 1/1 * ? *`, a valid Quartz.NET 7-field cron expression already used elsewhere in the codebase