### PR TITLE
fix: movie retry failures silently marked as completed

### DIFF
--- a/src/Ombi.Core/Senders/MovieSender.cs
+++ b/src/Ombi.Core/Senders/MovieSender.cs
@@ -116,7 +116,7 @@ namespace Ombi.Core.Senders
 
             return new SenderResult
             {
-                Success = true,
+                Success = false,
                 Sent = false,
             };
         }


### PR DESCRIPTION
## Summary

`MovieSender.Send()` returns `Success = true` after its catch block handles an exception (increments `RetryCount` and saves to the request queue). `ResendFailedRequests` checks `result.Success` and marks the queue entry as `Completed` when true, so movie retries that throw exceptions are simultaneously incremented AND completed -- the entry exits the retry queue on the first exception instead of being retried.

`TvSender.Send()` correctly returns `Success = false` in the same position (line 112), so TV retries stay in the queue as intended. This one-line change aligns `MovieSender` with that pattern.

## What changed

- `src/Ombi.Core/Senders/MovieSender.cs` line 119: `Success = true` -> `Success = false` in the fallthrough return after the catch block.

## Test plan

- [ ] Verify movie requests that fail with an exception during retry stay in the request queue (`Completed` remains null)
- [ ] Verify movie requests that succeed during retry are still marked as completed
- [ ] Verify TV request retry behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected movie delivery failure reporting so unsuccessful sends are no longer marked as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->