### PR TITLE
fix: prevent DB lock from orphaning auto-approved requests

### DIFF
--- a/src/Ombi.Core/Engine/Interfaces/IMovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/Interfaces/IMovieRequestEngine.cs
@@ -18,7 +18,7 @@ namespace Ombi.Core.Engine.Interfaces
         Task RemoveAllMovieRequests();
         Task<MovieRequests> GetRequest(int requestId);
         Task<MovieRequests> UpdateMovieRequest(MovieRequests request);
-        Task<RequestEngineResult> ApproveMovie(MovieRequests request, bool is4K);
+        Task<RequestEngineResult> ApproveMovie(MovieRequests request, bool is4K, bool isAutoApprove = false);
         Task<RequestEngineResult> ApproveMovieById(int requestId, bool is4K);
         Task<RequestEngineResult> DenyMovieById(int modelId, string denyReason, bool is4K);
         Task<RequestsViewModel<MovieRequests>> GetRequests(int count, int position, string sortProperty, string sortOrder, string requestedByUserId = null);

--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -903,8 +903,8 @@ namespace Ombi.Core.Engine
 
         private static bool IsTransientSqliteLock(DbUpdateException ex)
         {
-            var message = ex.InnerException?.Message ?? ex.Message;
-            return message.Contains("database is locked", StringComparison.OrdinalIgnoreCase);
+            return ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqliteEx
+                && sqliteEx.SqliteErrorCode == 5; // SQLITE_BUSY
         }
     }
 }

--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -630,7 +630,20 @@ namespace Ombi.Core.Engine
                 request.Approved = true;
                 request.Denied = false;
             }
-            await MovieRepository.Update(request);
+            try
+            {
+                await MovieRepository.Update(request);
+            }
+            catch (DbUpdateException ex)
+            {
+                // The auto-approve path already saved this request via AddMovieRequest().
+                // A transient DB failure here (e.g. SQLite lock from concurrent writes) must
+                // not prevent the movie from being sent to Radarr -- an orphaned "Processing"
+                // request with no retry queue entry is worse than a missing MarkedAsApproved
+                // timestamp. The in-memory entity still has the correct Approved state for the
+                // sender below.
+                Logger.LogError(ex, "Failed to update movie request {RequestId} during approval (request may have already been saved); continuing to send to downstream service", request.Id);
+            }
 
             var canNotify = await RunSpecificRule(request, SpecificRules.CanSendNotification, string.Empty);
             if (canNotify.Success)

--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -173,7 +173,7 @@ namespace Ombi.Core.Engine
                 var requestEngineResult = await AddMovieRequest(requestModel, fullMovieName, model.RequestOnBehalf, isExisting, is4kRequest);
                 if (requestEngineResult.Result)
                 {
-                    var result = await ApproveMovie(requestModel, model.Is4kRequest);
+                    var result = await ApproveMovie(requestModel, model.Is4kRequest, isAutoApprove: true);
                     if (result.IsError)
                     {
                         Logger.LogWarning("Tried auto sending movie but failed. Message: {0}", result.Message);
@@ -608,7 +608,7 @@ namespace Ombi.Core.Engine
             };
         }
 
-        public async Task<RequestEngineResult> ApproveMovie(MovieRequests request, bool is4K)
+        public async Task<RequestEngineResult> ApproveMovie(MovieRequests request, bool is4K, bool isAutoApprove = false)
         {
             if (request == null)
             {
@@ -634,15 +634,19 @@ namespace Ombi.Core.Engine
             {
                 await MovieRepository.Update(request);
             }
-            catch (DbUpdateException ex)
+            catch (DbUpdateException ex) when (IsTransientSqliteLock(ex))
             {
-                // The auto-approve path already saved this request via AddMovieRequest().
-                // A transient DB failure here (e.g. SQLite lock from concurrent writes) must
-                // not prevent the movie from being sent to Radarr -- an orphaned "Processing"
-                // request with no retry queue entry is worse than a missing MarkedAsApproved
-                // timestamp. The in-memory entity still has the correct Approved state for the
-                // sender below.
-                Logger.LogError(ex, "Failed to update movie request {RequestId} during approval (request may have already been saved); continuing to send to downstream service", request.Id);
+                if (!isAutoApprove)
+                {
+                    // Manual approval: this DB update is the first save of Approved=true.
+                    // If it failed, the approval was never persisted — do not proceed.
+                    throw;
+                }
+
+                // Auto-approve path: AddMovieRequest() already persisted Approved=true.
+                // A transient SQLite lock here only loses the MarkedAsApproved timestamp.
+                // The in-memory entity still has the correct state for the sender below.
+                Logger.LogError(ex, "Transient SQLite lock updating movie request {RequestId} during auto-approval (request already saved); continuing to send to downstream service", request.Id);
             }
 
             var canNotify = await RunSpecificRule(request, SpecificRules.CanSendNotification, string.Empty);
@@ -895,6 +899,12 @@ namespace Ombi.Core.Engine
             });
 
             return new RequestEngineResult { Result = true, Message = $"{movieName} has been successfully added!", RequestId = model.Id };
+        }
+
+        private static bool IsTransientSqliteLock(DbUpdateException ex)
+        {
+            var message = ex.InnerException?.Message ?? ex.Message;
+            return message.Contains("database is locked", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -686,16 +686,12 @@ namespace Ombi.Core.Engine
                 }
             }
 
-            try
-            {
-                await TvRepository.UpdateChild(request);
-            }
-            catch (DbUpdateException ex)
-            {
-                // A transient DB failure (e.g. SQLite lock) must not prevent the show from
-                // being sent to Sonarr. The in-memory entity has the correct Approved state.
-                _logger.LogError(ex, "Failed to update child request {RequestId} during approval; continuing to send to downstream service", request.Id);
-            }
+            // No catch here: ApproveChildRequest is always a manual approval. The DB update
+            // is the first save of Approved=true, so if it fails the approval was never
+            // persisted and we must not proceed to send. (The auto-approve path saves via
+            // AddRequest/AddExistingRequest and sends via ProcessSendingShow, never through
+            // this method.)
+            await TvRepository.UpdateChild(request);
             await _mediaCacheService.Purge();
 
             if (request.Approved)

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -686,7 +686,16 @@ namespace Ombi.Core.Engine
                 }
             }
 
-            await TvRepository.UpdateChild(request);
+            try
+            {
+                await TvRepository.UpdateChild(request);
+            }
+            catch (DbUpdateException ex)
+            {
+                // A transient DB failure (e.g. SQLite lock) must not prevent the show from
+                // being sent to Sonarr. The in-memory entity has the correct Approved state.
+                _logger.LogError(ex, "Failed to update child request {RequestId} during approval; continuing to send to downstream service", request.Id);
+            }
             await _mediaCacheService.Purge();
 
             if (request.Approved)


### PR DESCRIPTION
## Summary

When a movie or TV request is auto-approved, `ApproveMovie()` / `ApproveChildRequest()` performs a DB update (setting `MarkedAsApproved` timestamp and re-confirming `Approved=true`) **before** calling `ProcessSendingMovie()` / `TvSender.Send()`. In the auto-approve path, this update is redundant — `AddMovieRequest()` already committed the request with `Approved=true`.

If that intermediate DB update throws — e.g. `Microsoft.Data.Sqlite.SqliteException: SQLite Error 5: 'database is locked'` from concurrent `RefreshMetadata` writes — the exception escapes before the send is ever called. The request is stuck permanently in "Processing" (`Approved=true, Available=false`) with no retry queue entry. The movie/show never reaches Radarr/Sonarr.

Real-world trigger: SQLite WAL contention during the Plex metadata refresh window, which overlaps with peak request activity.

## Fix

Wrap the `MovieRepository.Update()` and `TvRepository.UpdateChild()` calls in `ApproveMovie()` and `ApproveChildRequest()` with `try/catch (DbUpdateException)`. The error is logged but execution continues to the sender. The in-memory entity already holds the correct `Approved` state, so the sender operates correctly.

This is the minimal fix — no reordering, no removal of the update (it's needed for manual approval via `ApproveMovieById`), just resilience against transient DB failures in the path between save and send.

## Changes

- `MovieRequestEngine.cs`: `ApproveMovie()` — wrap `MovieRepository.Update()` in try/catch
- `TvRequestEngine.cs`: `ApproveChildRequest()` — wrap `TvRepository.UpdateChild()` in try/catch

## Test plan

- [ ] Auto-approve a movie request — verify it reaches Radarr
- [ ] Manually approve a movie request — verify it reaches Radarr and `MarkedAsApproved` is set
- [ ] Auto-approve a TV request — verify it reaches Sonarr
- [ ] Manually approve a TV child request — verify it reaches Sonarr
- [ ] Simulate SQLite lock during auto-approve (e.g. hold a write transaction from another connection) — verify the movie/show still reaches Radarr/Sonarr and the error is logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic movie approvals now continue with notifications, cache updates and downstream processing when a transient database lock occurs.
  * Transient database lock errors during automatic approvals are logged for improved troubleshooting.
  * Manual movie approvals continue to report database update failures normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->