### PR TITLE
Fix non-exception send failures skipping the retry queue

### DIFF
--- a/src/Ombi.Core/Senders/MovieSender.cs
+++ b/src/Ombi.Core/Senders/MovieSender.cs
@@ -54,6 +54,7 @@ namespace Ombi.Core.Senders
 
         public async Task<SenderResult> Send(MovieRequests model, bool is4K)
         {
+            SenderResult result = null;
             try
             {
                 var cpSettings = await _couchPotatoSettings.GetSettingsAsync();
@@ -69,49 +70,42 @@ namespace Ombi.Core.Senders
                 }
                 if (radarrSettings.Enabled)
                 {
-                    return await SendToRadarr(model, radarrSettings, is4K);
+                    result = await SendToRadarr(model, radarrSettings, is4K);
                 }
-
-                var dogSettings = await _dogNzbSettings.GetSettingsAsync();
-                if (dogSettings.Enabled)
+                else
                 {
-                    await SendToDogNzb(model, dogSettings);
-                    return new SenderResult
+                    var dogSettings = await _dogNzbSettings.GetSettingsAsync();
+                    if (dogSettings.Enabled)
                     {
-                        Success = true,
-                        Sent = true,
-                    };
+                        await SendToDogNzb(model, dogSettings);
+                        result = new SenderResult
+                        {
+                            Success = true,
+                            Sent = true,
+                        };
+                    }
+                    else if (cpSettings.Enabled)
+                    {
+                        result = await SendToCp(model, cpSettings, cpSettings.DefaultProfileId);
+                    }
                 }
 
-                if (cpSettings.Enabled)
+                if (result != null && result.Success)
                 {
-                    return await SendToCp(model, cpSettings, cpSettings.DefaultProfileId);
+                    return result;
                 }
             }
             catch (Exception e)
             {
                 _log.LogError(e, "Error when sending movie to DVR app, added to the request queue");
+                await AddToRequestFailureQueue(model, e.Message);
+            }
 
-                // Check if already in request quee
-                var existingQueue = await _requestQueuRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id);
-                if (existingQueue != null)
-                {
-                    existingQueue.RetryCount++;
-                    existingQueue.Error = e.Message;
-                    await _requestQueuRepository.SaveChangesAsync();
-                }
-                else
-                {
-                    await _requestQueuRepository.Add(new RequestQueue
-                    {
-                        Dts = DateTime.UtcNow,
-                        Error = e.Message,
-                        RequestId = model.Id,
-                        Type = RequestType.Movie,
-                        RetryCount = 0
-                    });
-                    await _notificationHelper.Notify(model, NotificationType.ItemAddedToFaultQueue);
-                }
+            if (result != null && !result.Success)
+            {
+                _log.LogWarning("Movie send to DVR app failed: {Message}, added to the request queue", result.Message);
+                await AddToRequestFailureQueue(model, result.Message);
+                return result;
             }
 
             return new SenderResult
@@ -272,6 +266,29 @@ namespace Ombi.Core.Senders
             existingTag ??= await _radarrV3Api.CreateTag(s.ApiKey, s.FullUri, tagName);
 
             return existingTag;
+        }
+
+        private async Task AddToRequestFailureQueue(MovieRequests model, string errorMessage)
+        {
+            var existingQueue = await _requestQueuRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id);
+            if (existingQueue != null)
+            {
+                existingQueue.RetryCount++;
+                existingQueue.Error = errorMessage;
+                await _requestQueuRepository.SaveChangesAsync();
+            }
+            else
+            {
+                await _requestQueuRepository.Add(new RequestQueue
+                {
+                    Dts = DateTime.UtcNow,
+                    Error = errorMessage,
+                    RequestId = model.Id,
+                    Type = RequestType.Movie,
+                    RetryCount = 0
+                });
+                await _notificationHelper.Notify(model, NotificationType.ItemAddedToFaultQueue);
+            }
         }
     }
 }

--- a/src/Ombi.Core/Senders/MovieSender.cs
+++ b/src/Ombi.Core/Senders/MovieSender.cs
@@ -99,6 +99,7 @@ namespace Ombi.Core.Senders
             {
                 _log.LogError(e, "Error when sending movie to DVR app, added to the request queue");
                 await AddToRequestFailureQueue(model, e.Message);
+                return new SenderResult { Success = false, Sent = false, Message = e.Message };
             }
 
             if (result != null && !result.Success)
@@ -270,7 +271,7 @@ namespace Ombi.Core.Senders
 
         private async Task AddToRequestFailureQueue(MovieRequests model, string errorMessage)
         {
-            var existingQueue = await _requestQueuRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id);
+            var existingQueue = await _requestQueuRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id && x.Type == RequestType.Movie);
             if (existingQueue != null)
             {
                 existingQueue.RetryCount++;

--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -44,6 +44,7 @@ namespace Ombi.Core.Senders
 
         public async Task<SenderResult> Send(ChildRequests model)
         {
+            SenderResult senderResult = null;
             try
             {
                 var sonarr = await SonarrSettings.GetSettingsAsync();
@@ -59,7 +60,7 @@ namespace Ombi.Core.Senders
                         };
                     }
                 }
-                
+
                 var sr = await SickRageSettings.GetSettingsAsync();
                 if (sr.Enabled)
                 {
@@ -72,39 +73,30 @@ namespace Ombi.Core.Senders
                             Success = true
                         };
                     }
-                    return new SenderResult
+                    senderResult = new SenderResult
                     {
                         Message = "Could not send to SickRage!"
                     };
                 }
-                return new SenderResult
+                else
                 {
-                    Success = true
-                };
+                    return new SenderResult
+                    {
+                        Success = true
+                    };
+                }
             }
             catch (Exception e)
             {
                 Logger.LogError(e, "Exception thrown when sending a movie to DVR app, added to the request queue");
-                // Check if already in request queue
-                var existingQueue = await _requestQueueRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id);
-                if (existingQueue != null)
-                {
-                    existingQueue.RetryCount++;
-                    existingQueue.Error = e.Message;
-                    await _requestQueueRepository.SaveChangesAsync();
-                }
-                else
-                {
-                    await _requestQueueRepository.Add(new RequestQueue
-                    {
-                        Dts = DateTime.UtcNow,
-                        Error = e.Message,
-                        RequestId = model.Id,
-                        Type = RequestType.TvShow,
-                        RetryCount = 0
-                    });
-                    await _notificationHelper.Notify(model, NotificationType.ItemAddedToFaultQueue);
-                }
+                await AddToRequestFailureQueue(model, e.Message);
+            }
+
+            if (senderResult != null && !senderResult.Success)
+            {
+                Logger.LogWarning("TV send to DVR app failed: {Message}, added to the request queue", senderResult.Message);
+                await AddToRequestFailureQueue(model, senderResult.Message);
+                return senderResult;
             }
 
             return new SenderResult
@@ -613,6 +605,29 @@ namespace Ombi.Core.Senders
 
             Logger.LogError("No matching root folder found for ID: {PathId}", pathId);
             return string.Empty;
+        }
+
+        private async Task AddToRequestFailureQueue(ChildRequests model, string errorMessage)
+        {
+            var existingQueue = await _requestQueueRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id);
+            if (existingQueue != null)
+            {
+                existingQueue.RetryCount++;
+                existingQueue.Error = errorMessage;
+                await _requestQueueRepository.SaveChangesAsync();
+            }
+            else
+            {
+                await _requestQueueRepository.Add(new RequestQueue
+                {
+                    Dts = DateTime.UtcNow,
+                    Error = errorMessage,
+                    RequestId = model.Id,
+                    Type = RequestType.TvShow,
+                    RetryCount = 0
+                });
+                await _notificationHelper.Notify(model, NotificationType.ItemAddedToFaultQueue);
+            }
         }
     }
 }

--- a/src/Ombi.Core/Senders/TvSender.cs
+++ b/src/Ombi.Core/Senders/TvSender.cs
@@ -88,7 +88,7 @@ namespace Ombi.Core.Senders
             }
             catch (Exception e)
             {
-                Logger.LogError(e, "Exception thrown when sending a movie to DVR app, added to the request queue");
+                Logger.LogError(e, "Exception thrown when sending a series to DVR app, added to the request queue");
                 await AddToRequestFailureQueue(model, e.Message);
             }
 
@@ -609,7 +609,7 @@ namespace Ombi.Core.Senders
 
         private async Task AddToRequestFailureQueue(ChildRequests model, string errorMessage)
         {
-            var existingQueue = await _requestQueueRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id);
+            var existingQueue = await _requestQueueRepository.FirstOrDefaultAsync(x => x.RequestId == model.Id && x.Type == RequestType.TvShow);
             if (existingQueue != null)
             {
                 existingQueue.RetryCount++;


### PR DESCRIPTION
## Summary

When `SendToRadarr()`, `SendToCp()`, or `SendToSickRage()` return a failure `SenderResult` **without throwing an exception**, the `Send()` method returns that failure directly from inside the `try` block. The `catch` block — which contains all the `RequestQueue` insertion logic — never executes. The request stays in "Processing" permanently with no retry path.

This affects:
- **MovieSender**: Radarr API errors in the response body (not HTTP exceptions), "movie is already monitored" responses, CouchPotato API failures
- **TvSender**: SickRage add-series failures

## Fix

Instead of returning failure results directly from inside the `try` block, capture them into a variable and only return early on success. After the `try/catch`, check for non-exception failures and queue them identically to how exceptions are queued — including the duplicate-entry check and fault queue notification.

The queue insertion logic is extracted into a private `AddToRequestFailureQueue` helper in each class to avoid duplicating it between the `catch` block and the new post-catch check.

## What this does NOT change

- Exception handling behavior (catch block still works identically)
- The post-catch `SenderResult` return values (Bug 5 — MovieSender returning `Success = true` after catch — is a separate issue)
- Any logic inside `SendToRadarr`, `SendToCp`, `SendToSonarr`, or `SendToSickRage`

## Test plan

- [ ] Verify Radarr API error response (non-exception) creates a `RequestQueue` entry
- [ ] Verify "movie is already monitored" case creates a `RequestQueue` entry
- [ ] Verify SickRage failure creates a `RequestQueue` entry
- [ ] Verify exception-based failures still queue correctly (no regression)
- [ ] Verify successful sends still return immediately without queueing
- [ ] Verify duplicate queue entries are updated (retry count incremented) rather than duplicated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of movie and TV requests when provider integrations are unavailable or return an error.
  * Failed requests are now consistently recorded for retry, including failures caused by exceptions.
  * Successful requests return immediately without unnecessary failure-queue processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->