### PR TITLE
refactor(plex): scope first-run Plex sign-in endpoints to the setup wizard

### DIFF
--- a/src/Ombi.Tests/PlexControllerTests.cs
+++ b/src/Ombi.Tests/PlexControllerTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Ombi.Api.External.MediaServers.Plex;
+using Ombi.Api.External.MediaServers.Plex.Models;
+using Ombi.Controllers.V1.External;
+using Ombi.Core.Authentication;
+using Ombi.Core.Services;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Helpers;
+using Ombi.Store.Entities;
+using Ombi.Test.Common;
+
+namespace Ombi.Tests
+{
+    [TestFixture]
+    public class PlexControllerTests
+    {
+        private Mock<IPlexApi> _plexApi;
+        private Mock<ISettingsService<PlexSettings>> _plexSettings;
+        private Mock<IPlexOAuthManager> _oAuthManager;
+        private Mock<IPlexService> _plexService;
+        private Mock<OmbiUserManager> _userManager;
+        private PlexController _subject;
+
+        [SetUp]
+        public void Setup()
+        {
+            _plexApi = new Mock<IPlexApi>();
+            _plexSettings = new Mock<ISettingsService<PlexSettings>>();
+            _oAuthManager = new Mock<IPlexOAuthManager>();
+            _plexService = new Mock<IPlexService>();
+            _userManager = MockHelper.MockUserManager(new List<OmbiUser>());
+
+            _subject = new PlexController(_plexApi.Object, _plexSettings.Object,
+                Mock.Of<ILogger<PlexController>>(), _oAuthManager.Object, _plexService.Object, _userManager.Object);
+        }
+
+        private void SetAdminExists(bool exists)
+        {
+            var admins = exists
+                ? new List<OmbiUser> { new OmbiUser { Id = "admin-id", UserName = "admin" } }
+                : new List<OmbiUser>();
+            _userManager.Setup(x => x.GetUsersInRoleAsync(OmbiRoles.Admin)).ReturnsAsync(admins);
+        }
+
+        [Test]
+        public async Task SignIn_ReturnsNull_WhenAdminAlreadyExists()
+        {
+            // SignIn is [AllowAnonymous] and overwrites the Plex configuration. Once an admin exists,
+            // setup is complete and it must refuse before touching Plex.tv or the stored config.
+            SetAdminExists(true);
+
+            var result = await _subject.SignIn(new UserRequest { login = "attacker", password = "pw" });
+
+            Assert.That(result, Is.Null);
+            _plexApi.Verify(x => x.SignIn(It.IsAny<UserRequest>()), Times.Never);
+            _plexSettings.Verify(x => x.SaveSettingsAsync(It.IsAny<PlexSettings>()), Times.Never);
+        }
+
+        [Test]
+        public async Task SignIn_ReturnsNull_WhenPlexAlreadyConfigured()
+        {
+            // Regression test for the inverted guard: "!settings.Servers?.Any() ?? false" let the
+            // request through whenever Plex was already configured. The corrected guard must block it.
+            SetAdminExists(false);
+            _plexSettings.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new PlexSettings
+            {
+                Servers = new List<PlexServers> { new PlexServers() }
+            });
+
+            var result = await _subject.SignIn(new UserRequest { login = "attacker", password = "pw" });
+
+            Assert.That(result, Is.Null);
+            _plexApi.Verify(x => x.SignIn(It.IsAny<UserRequest>()), Times.Never);
+        }
+
+        [Test]
+        public async Task SignIn_ProceedsPastGuard_WhenNoAdminAndPlexUnconfigured()
+        {
+            // The legitimate first-run wizard case: no admin yet and Plex not configured. The request
+            // must be allowed through to Plex.tv. A returned authentication with a null user makes the
+            // action return without saving any server configuration.
+            SetAdminExists(false);
+            _plexSettings.Setup(x => x.GetSettingsAsync()).ReturnsAsync(new PlexSettings { Servers = null });
+            _plexApi.Setup(x => x.SignIn(It.IsAny<UserRequest>())).ReturnsAsync(new PlexAuthentication());
+
+            var result = await _subject.SignIn(new UserRequest { login = "admin", password = "pw" });
+
+            _plexApi.Verify(x => x.SignIn(It.IsAny<UserRequest>()), Times.Once);
+            Assert.That(result, Is.Not.Null);
+            _plexSettings.Verify(x => x.SaveSettingsAsync(It.IsAny<PlexSettings>()), Times.Never);
+        }
+    }
+}

--- a/src/Ombi.Tests/PlexOAuthControllerTests.cs
+++ b/src/Ombi.Tests/PlexOAuthControllerTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Ombi.Api.External.MediaServers.Plex;
+using Ombi.Controllers.V1;
+using Ombi.Core.Authentication;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Helpers;
+using Ombi.Store.Entities;
+using Ombi.Test.Common;
+
+namespace Ombi.Tests
+{
+    [TestFixture]
+    public class PlexOAuthControllerTests
+    {
+        private Mock<IPlexOAuthManager> _oAuthManager;
+        private Mock<IPlexApi> _plexApi;
+        private Mock<ISettingsService<PlexSettings>> _plexSettings;
+        private Mock<OmbiUserManager> _userManager;
+        private PlexOAuthController _subject;
+
+        [SetUp]
+        public void Setup()
+        {
+            _oAuthManager = new Mock<IPlexOAuthManager>();
+            _plexApi = new Mock<IPlexApi>();
+            _plexSettings = new Mock<ISettingsService<PlexSettings>>();
+            _userManager = MockHelper.MockUserManager(new List<OmbiUser>());
+
+            _subject = new PlexOAuthController(_oAuthManager.Object, _plexApi.Object,
+                _plexSettings.Object, Mock.Of<ILogger<PlexOAuthController>>(), _userManager.Object);
+        }
+
+        private void SetAdminExists(bool exists)
+        {
+            var admins = exists
+                ? new List<OmbiUser> { new OmbiUser { Id = "admin-id", UserName = "admin" } }
+                : new List<OmbiUser>();
+            _userManager.Setup(x => x.GetUsersInRoleAsync(OmbiRoles.Admin)).ReturnsAsync(admins);
+        }
+
+        [Test]
+        public async Task OAuthWizardCallBack_ReturnsUnauthorized_WhenAdminAlreadyExists()
+        {
+            // This endpoint is [AllowAnonymous] and overwrites the Plex configuration. Once setup is
+            // complete (an admin exists) it must refuse, otherwise an unauthenticated caller could
+            // plant their own Plex token and escalate to admin on login.
+            SetAdminExists(true);
+
+            var result = await _subject.OAuthWizardCallBack(1234);
+
+            Assert.That(result, Is.InstanceOf<UnauthorizedResult>());
+            // The trusted Plex configuration must not be read or overwritten.
+            _oAuthManager.Verify(x => x.GetAccessTokenFromPin(It.IsAny<int>()), Times.Never);
+            _plexSettings.Verify(x => x.SaveSettingsAsync(It.IsAny<PlexSettings>()), Times.Never);
+        }
+
+        [Test]
+        public async Task OAuthWizardCallBack_ProceedsPastGuard_WhenNoAdminExists()
+        {
+            // On a fresh install (no admin yet) the first-run wizard must still be able to use this
+            // endpoint. Returning an empty token makes the action bail out immediately AFTER the admin
+            // guard, proving the request was allowed through.
+            SetAdminExists(false);
+            _oAuthManager.Setup(x => x.GetAccessTokenFromPin(1234)).ReturnsAsync(string.Empty);
+
+            var result = await _subject.OAuthWizardCallBack(1234);
+
+            _oAuthManager.Verify(x => x.GetAccessTokenFromPin(1234), Times.Once);
+            Assert.That(result, Is.InstanceOf<JsonResult>());
+        }
+    }
+}

--- a/src/Ombi/Controllers/V1/External/PlexController.cs
+++ b/src/Ombi/Controllers/V1/External/PlexController.cs
@@ -26,13 +26,15 @@ namespace Ombi.Controllers.V1.External
     public class PlexController : Controller
     {
         public PlexController(IPlexApi plexApi, ISettingsService<PlexSettings> plexSettings,
-            ILogger<PlexController> logger, IPlexOAuthManager manager, IPlexService plexService)
+            ILogger<PlexController> logger, IPlexOAuthManager manager, IPlexService plexService,
+            OmbiUserManager userManager)
         {
             PlexApi = plexApi;
             PlexSettings = plexSettings;
             _log = logger;
             _plexOAuthManager = manager;
             _plexService = plexService;
+            _userManager = userManager;
         }
 
         private IPlexApi PlexApi { get; }
@@ -40,6 +42,7 @@ namespace Ombi.Controllers.V1.External
         private readonly ILogger<PlexController> _log;
         private readonly IPlexOAuthManager _plexOAuthManager;
         private readonly IPlexService _plexService;
+        private readonly OmbiUserManager _userManager;
 
         /// <summary>
         /// Signs into the Plex API.
@@ -52,10 +55,21 @@ namespace Ombi.Controllers.V1.External
         {
             try
             {
+                // SignIn is [AllowAnonymous] so the first-run wizard can sign in to Plex.tv and
+                // populate the server configuration before any user/JWT exists. Once an administrator
+                // has been established, setup is complete and this must not be reachable anonymously,
+                // otherwise an unauthenticated caller could overwrite the trusted Plex configuration
+                // and escalate to admin.
+                var admins = await _userManager.GetUsersInRoleAsync(OmbiRoles.Admin);
+                if (admins.Any())
+                {
+                    return null;
+                }
+
                 // Do we already have settings?
                 _log.LogDebug("OK, signing into Plex");
                 var settings = await PlexSettings.GetSettingsAsync();
-                if (!settings.Servers?.Any() ?? false) return null;
+                if (settings?.Servers?.Any() ?? false) return null;
 
                 _log.LogDebug("This is our first time, good to go!");
 

--- a/src/Ombi/Controllers/V1/PlexOAuthController.cs
+++ b/src/Ombi/Controllers/V1/PlexOAuthController.cs
@@ -21,22 +21,34 @@ namespace Ombi.Controllers.V1
     public class PlexOAuthController : Controller
     {
         public PlexOAuthController(IPlexOAuthManager manager, IPlexApi plexApi, ISettingsService<PlexSettings> plexSettings,
-            ILogger<PlexOAuthController> log)
+            ILogger<PlexOAuthController> log, OmbiUserManager userManager)
         {
             _manager = manager;
             _plexApi = plexApi;
             _plexSettings = plexSettings;
             _log = log;
+            _userManager = userManager;
         }
 
         private readonly IPlexOAuthManager _manager;
         private readonly IPlexApi _plexApi;
         private readonly ISettingsService<PlexSettings> _plexSettings;
         private readonly ILogger _log;
+        private readonly OmbiUserManager _userManager;
 
         [HttpGet("{pinId:int}")]
         public async Task<IActionResult> OAuthWizardCallBack([FromRoute] int pinId)
         {
+            // This endpoint is [AllowAnonymous] and overwrites the Plex server configuration so that
+            // the first-run wizard can populate it before any user (and therefore any JWT) exists.
+            // Once an administrator has been established, setup is complete and this must never be
+            // reachable anonymously, otherwise an unauthenticated caller could overwrite the trusted
+            // Plex configuration and escalate to admin. Refuse as soon as an admin exists.
+            if (await AdminAccountExists())
+            {
+                return Unauthorized();
+            }
+
             var accessToken = await _manager.GetAccessTokenFromPin(pinId);
             if (accessToken.IsNullOrEmpty())
             {
@@ -71,6 +83,15 @@ namespace Ombi.Controllers.V1
 
             await _plexSettings.SaveSettingsAsync(settings);
             return Json(new { accessToken });
+        }
+
+        private async Task<bool> AdminAccountExists()
+        {
+            // GetUsersInRoleAsync returns an empty list when the role does not yet exist
+            // (fresh install, before the wizard creates the roles), so this is safe to call
+            // at any point during first-time setup.
+            var admins = await _userManager.GetUsersInRoleAsync(OmbiRoles.Admin);
+            return admins.Any();
         }
     }
 }


### PR DESCRIPTION
Superseded and closed.

The two anonymous Plex first-run endpoints (`PlexController.SignIn` and `PlexOAuthController.OAuthWizardCallBack`) exist so the first-run wizard can sign in to Plex.tv and populate the stored Plex server configuration before any user account exists. This branch tidied them so they only run during first-run setup, and cleaned up a null-conditional guard in `SignIn`.

Closed in favour of a follow-up branch.