### PR TITLE
fix(availability): mark movies available when Radarr only has a 4K file

### DIFF
--- a/src/Ombi.Schedule.Tests/ArrAvailabilityCheckerTests.cs
+++ b/src/Ombi.Schedule.Tests/ArrAvailabilityCheckerTests.cs
@@ -92,7 +92,11 @@ namespace Ombi.Schedule.Tests
 
             await _subject.Execute(null);
 
-            Assert.That(request.Available4K, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(request.Available4K, Is.True);
+                Assert.That(request.Available, Is.False, "the 4K copy should not satisfy a standard request while the 4K feature is on");
+            });
         }
 
         /// <summary>

--- a/src/Ombi.Schedule.Tests/ArrAvailabilityCheckerTests.cs
+++ b/src/Ombi.Schedule.Tests/ArrAvailabilityCheckerTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Ombi.Core.Services;
+using Ombi.Core.Settings;
+using Ombi.Hubs;
+using Ombi.Schedule.Jobs.Radarr;
+using Ombi.Settings.Settings.Models;
+using Ombi.Settings.Settings.Models.External;
+using Ombi.Store.Entities;
+using Ombi.Store.Entities.Requests;
+using Ombi.Store.Repository;
+using Ombi.Store.Repository.Requests;
+using Ombi.Tests;
+
+namespace Ombi.Schedule.Tests
+{
+    [TestFixture]
+    public class ArrAvailabilityCheckerTests
+    {
+        private AutoMocker _mocker;
+        private ArrAvailabilityChecker _subject;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mocker = new AutoMocker();
+            var hub = SignalRHelper.MockHub<NotificationHub>();
+            _mocker.Use(hub);
+
+            _mocker.Setup<ISettingsService<RadarrSettings>, Task<RadarrSettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new RadarrSettings { Enabled = true, ScanForAvailability = true });
+            _mocker.Setup<ISettingsService<SonarrSettings>, Task<SonarrSettings>>(x => x.GetSettingsAsync())
+                .ReturnsAsync(new SonarrSettings { Enabled = false, ScanForAvailability = false });
+
+            _subject = _mocker.CreateInstance<ArrAvailabilityChecker>();
+        }
+
+        private void GivenRadarrCache(params RadarrCache[] cache)
+            => _mocker.Setup<IExternalRepository<RadarrCache>, IQueryable<RadarrCache>>(x => x.GetAll())
+                      .Returns(cache.AsQueryable());
+
+        private void GivenRequests(params MovieRequests[] requests)
+            => _mocker.Setup<IMovieRequestRepository, IQueryable<MovieRequests>>(x => x.GetAll())
+                      .Returns(requests.AsQueryable());
+
+        /// <summary>
+        /// Single Radarr instance whose quality profile grabs 2160p. There is no dedicated
+        /// Radarr 4K instance, and the 4K request feature is off, so the movie should simply
+        /// be marked as available.
+        /// </summary>
+        [Test]
+        public async Task ProcessMovies_ShouldMarkAvailable_WhenSingleRadarrGrabbed4KFile()
+        {
+            GivenRadarrCache(new RadarrCache { TheMovieDbId = 99, HasFile = true, Has4K = true, HasRegular = false });
+            var request = new MovieRequests { Id = 1, TheMovieDbId = 99, Approved = true, Available = false, Has4KRequest = false };
+            GivenRequests(request);
+
+            await _subject.Execute(null);
+
+            Assert.That(request.Available, Is.True, "A 4K file from the only Radarr instance should satisfy a standard request");
+        }
+
+        /// <summary>
+        /// A 1080p grab must keep working exactly as before.
+        /// </summary>
+        [Test]
+        public async Task ProcessMovies_ShouldMarkAvailable_WhenRadarrGrabbedRegularFile()
+        {
+            GivenRadarrCache(new RadarrCache { TheMovieDbId = 99, HasFile = true, Has4K = false, HasRegular = true });
+            var request = new MovieRequests { Id = 1, TheMovieDbId = 99, Approved = true, Available = false, Has4KRequest = false };
+            GivenRequests(request);
+
+            await _subject.Execute(null);
+
+            Assert.That(request.Available, Is.True);
+        }
+
+        /// <summary>
+        /// With the 4K feature on and a genuine 4K request, the 4K flag is what should be set.
+        /// </summary>
+        [Test]
+        public async Task ProcessMovies_ShouldMark4KAvailable_When4KFeatureEnabledAndIs4KRequest()
+        {
+            _mocker.Setup<IFeatureService, Task<bool>>(x => x.FeatureEnabled(FeatureNames.Movie4KRequests)).ReturnsAsync(true);
+            GivenRadarrCache(new RadarrCache { TheMovieDbId = 99, HasFile = true, Has4K = true, HasRegular = false });
+            var request = new MovieRequests { Id = 1, TheMovieDbId = 99, Approved4K = true, Available4K = false, Has4KRequest = true };
+            GivenRequests(request);
+
+            await _subject.Execute(null);
+
+            Assert.That(request.Available4K, Is.True);
+        }
+
+        /// <summary>
+        /// Nothing downloaded yet - the request must stay unavailable.
+        /// </summary>
+        [Test]
+        public async Task ProcessMovies_ShouldNotMarkAvailable_WhenRadarrHasNoFile()
+        {
+            GivenRadarrCache(new RadarrCache { TheMovieDbId = 99, HasFile = false, Has4K = false, HasRegular = true });
+            var request = new MovieRequests { Id = 1, TheMovieDbId = 99, Approved = true, Available = false };
+            GivenRequests(request);
+
+            await _subject.Execute(null);
+
+            Assert.That(request.Available, Is.False);
+        }
+    }
+}

--- a/src/Ombi.Schedule/Jobs/ArrAvailabilityChecker.cs
+++ b/src/Ombi.Schedule/Jobs/ArrAvailabilityChecker.cs
@@ -6,10 +6,12 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Ombi.Core;
+using Ombi.Core.Services;
 using Ombi.Core.Settings;
 using Ombi.Helpers;
 using Ombi.Hubs;
 using Ombi.Notifications.Models;
+using Ombi.Settings.Settings.Models;
 using Ombi.Settings.Settings.Models.External;
 using Ombi.Store.Entities;
 using Ombi.Store.Repository;
@@ -26,6 +28,7 @@ namespace Ombi.Schedule.Jobs.Radarr
         private readonly ISettingsService<SonarrSettings> _sonarrSettings;
         private readonly IExternalRepository<SonarrEpisodeCache> _sonarrEpisodeRepo;
         private readonly IMovieRequestRepository _movies;
+        private readonly IFeatureService _featureService;
 
         public ArrAvailabilityChecker(
             IExternalRepository<RadarrCache> radarrRepo,
@@ -35,7 +38,8 @@ namespace Ombi.Schedule.Jobs.Radarr
             ITvRequestRepository tvRequest, IMovieRequestRepository movies,
             ILogger<ArrAvailabilityChecker> log,
             ISettingsService<RadarrSettings> radarrSettings,
-            ISettingsService<SonarrSettings> sonarrSettings)
+            ISettingsService<SonarrSettings> sonarrSettings,
+            IFeatureService featureService)
              : base(tvRequest, notification, log, notificationHubService)
         {
             _radarrRepo = radarrRepo;
@@ -44,6 +48,7 @@ namespace Ombi.Schedule.Jobs.Radarr
             _movies = movies;
             _radarrSettings = radarrSettings;
             _sonarrSettings = sonarrSettings;
+            _featureService = featureService;
         }
         public async Task Execute(IJobExecutionContext job)
         {
@@ -63,6 +68,7 @@ namespace Ombi.Schedule.Jobs.Radarr
 
         private async Task ProcessMovies()
         {
+            var feature4kEnabled = await _featureService.FeatureEnabled(FeatureNames.Movie4KRequests);
             var availableRadarrMovies = _radarrRepo.GetAll().Where(x => x.HasFile).ToImmutableHashSet();
             var unavailableMovieRequests = _movies.GetAll().Where(x => !x.Available || (!x.Available4K && x.Has4KRequest)).ToImmutableHashSet();
 
@@ -74,7 +80,7 @@ namespace Ombi.Schedule.Jobs.Radarr
                 if (available != null)
                 {
                     _log.LogInformation($"Found move '{movieRequest.Title}' available in Radarr");
-                    if (available.Has4K && !movieRequest.Available4K)
+                    if (movieRequest.Has4KRequest && available.Has4K && !movieRequest.Available4K && feature4kEnabled)
                     {
                         itemsForAvailability.Add(new AvailabilityModel
                         {
@@ -84,7 +90,8 @@ namespace Ombi.Schedule.Jobs.Radarr
                         movieRequest.Available4K = true;
                         movieRequest.MarkedAsAvailable4K = DateTime.UtcNow;
                     }
-                    if (available.HasRegular)
+                    // If we have a non-4k version or we don't care about versions, then mark as available
+                    if (!movieRequest.Available && (!feature4kEnabled || available.HasRegular))
                     {
                         itemsForAvailability.Add(new AvailabilityModel
                         {


### PR DESCRIPTION
## 📝 Description

`ArrAvailabilityChecker` only ever set `MovieRequests.Available` when the cached Radarr entry had `HasRegular` set:

```csharp
if (available.HasRegular)
{
    movieRequest.Available = true;
    ...
}
```

`RadarrSync` writes that flag as `HasRegular = !is4k`, where `is4k` comes from the resolution of the movie file Radarr actually grabbed. So a movie downloaded at 2160p is cached as `Has4K = true, HasRegular = false`, and the request is never marked available. Since `MovieRequests.RequestStatus` is derived purely from `Available`, those requests sit on **Processing Request** or **Pending Approval** forever, even though the movie is downloaded and playing fine.

This does not require the 4K request feature to be turned on, and it does not require an unusual setup. It happens on any single-instance Radarr whose quality profile prefers 2160p but falls back to whatever is available — a common configuration for people who want 4K where possible but do not run a separate 4K pipeline.

The `HasRegular` / `Has4K` split is mutually exclusive by construction, which only makes sense in the two-instance model where a regular Radarr and a Radarr 4K each hold their own copy of the film. With one instance there is a single file, and it cannot be both.

### Why the media server checkers do not have this problem

Plex, Emby and Jellyfin all consult `FeatureNames.Movie4KRequests` and mark a request available when the 4K feature is disabled, regardless of the quality that was found. `EmbyAvaliabilityChecker`:

```csharp
// If we have a non-4k version or we don't care about versions, then mark as available
if (!movie.Available && ( !feature4kEnabled || embyContent.Quality != null ))
```

`ArrAvailabilityChecker` never got the same treatment. This PR brings it in line.

### Changes

- Mark `Available` when the 4K feature is off, or when a regular version is present — mirroring the Emby/Jellyfin condition, with `available.HasRegular` standing in for `embyContent.Quality != null`.
- Only set `Available4K` for an actual 4K request while the 4K feature is enabled, instead of setting it on any request that happens to match a 4K file. This matches `PlexAvailabilityChecker`, and avoids writing 4K state onto requests that never asked for it.

`IFeatureService` is injected the same way the other three checkers already do it, and its registration (`AddScoped`) versus this job (`AddTransient`) matches the existing, working pattern.

Two lines of behaviour change, plus the dependency wiring.

## 🔗 Related Issues

No open issue — found while debugging a single-Radarr 4K setup.

This is the Radarr-side counterpart of #4592, which reported the identical symptom ("still listed as 'Pending Approval' or 'Processing Request' even though the 4k version is available"). That was fixed for Plex only, in #4594, by introducing the `feature4kEnabled` gate this PR now applies to the Radarr path.

## 🧪 Testing

Added `src/Ombi.Schedule.Tests/ArrAvailabilityCheckerTests.cs` (new file — there was no existing coverage for this job).

Confirmed the tests fail before the change and pass after:

```
Before:  Failed: 1, Passed: 3
  Failed ProcessMovies_ShouldMarkAvailable_WhenSingleRadarrGrabbed4KFile
    A 4K file from the only Radarr instance should satisfy a standard request
    Expected: True
    But was:  False

After:   Passed: 4
```

The other three tests pass both before and after, so they pin the existing behaviour rather than just describing the new code:

| Test | Covers |
|---|---|
| `ShouldMarkAvailable_WhenSingleRadarrGrabbed4KFile` | the bug — 4K grab, 4K feature off |
| `ShouldMarkAvailable_WhenRadarrGrabbedRegularFile` | 1080p grab still works |
| `ShouldMark4KAvailable_When4KFeatureEnabledAndIs4KRequest` | genuine 4K request path preserved |
| `ShouldNotMarkAvailable_WhenRadarrHasNoFile` | nothing downloaded yet stays unavailable |

Full solution test run on this branch: **625 passed, 0 failed** across all six test projects (`Ombi.Core.Tests`, `Ombi.Helpers.Tests`, `Ombi.Notifications.Tests`, `Ombi.Schedule.Tests`, `Ombi.Settings.Tests`, `Ombi.Tests`).

Also compared compiler warnings against a clean `--no-incremental` rebuild of `develop` — identical sets, no new warnings.

- [x] Unit tests pass
- [ ] Integration tests pass *(none in the repo)*
- [ ] Manual testing completed *(see Additional Notes)*
- [x] No breaking changes

## 📸 Screenshots (if applicable)

N/A — no UI changes.

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(N/A)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

**Verification:** I have reviewed the diff line by line, and the reasoning is reproducible from the code — the failing test above is the check I would ask a reviewer to run first. I have not run this against a live Ombi instance, so the verification is the unit tests and the code path analysis rather than an end-to-end confirmation. Please weigh it accordingly.

**Note on the second condition.** Adding `movieRequest.Has4KRequest` to the `Available4K` branch is a small behaviour change beyond the reported bug: today, with the 4K feature enabled, a plain non-4K request that matches a 4K file gets `Available4K = true` written to it. I included it because it aligns this checker with `PlexAvailabilityChecker` and avoids storing 4K state on requests that never asked for it — but I am happy to split it out if you would rather keep the fix to a single condition.

**Not addressed here.** Pointing a Radarr 4K instance at the *same* server as the primary Radarr also breaks availability, for a related but distinct reason: `RadarrSync` never updates `HasRegular` on its second pass, so the flag keeps the value from the first pass. That is arguably a configuration that should be rejected or warned about rather than silently supported, so I have left it alone rather than guessing at the intended behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved movie availability tracking for 4K requests.
  - 4K availability is recognised only when 4K requests are enabled and a suitable 4K file is available.
  - Regular movie availability continues to be recognised from standard files.
- **Bug Fixes**
  - Prevented 4K files from incorrectly marking standard requests as available.
  - Movies remain unavailable when no matching file has been found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->