### PR TITLE
fix(requests): report 4K request status instead of leaving it pending

### DIFF
--- a/src/Ombi.Core.Tests/Entities/MovieRequestsTests.cs
+++ b/src/Ombi.Core.Tests/Entities/MovieRequestsTests.cs
@@ -1,0 +1,143 @@
+using System;
+using NUnit.Framework;
+using Ombi.Store.Entities.Requests;
+
+namespace Ombi.Core.Tests.Entities
+{
+    [TestFixture]
+    public class MovieRequestsTests
+    {
+        private static MovieRequests StandardRequest() => new MovieRequests { RequestedDate = DateTime.UtcNow };
+
+        private static MovieRequests FourKRequest() => new MovieRequests
+        {
+            Has4KRequest = true,
+            RequestedDate = default,
+            RequestedDate4k = DateTime.UtcNow
+        };
+
+        private static MovieRequests CombinedRequest() => new MovieRequests
+        {
+            Has4KRequest = true,
+            RequestedDate = DateTime.UtcNow,
+            RequestedDate4k = DateTime.UtcNow
+        };
+
+        [Test]
+        public void RequestStatus_StandardRequest_PendingApproval()
+        {
+            Assert.That(StandardRequest().RequestStatus, Is.EqualTo("Common.PendingApproval"));
+        }
+
+        [Test]
+        public void RequestStatus_StandardRequest_Processing_WhenApproved()
+        {
+            var request = StandardRequest();
+            request.Approved = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.ProcessingRequest"));
+        }
+
+        [Test]
+        public void RequestStatus_StandardRequest_Available()
+        {
+            var request = StandardRequest();
+            request.Approved = true;
+            request.Available = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.Available"));
+        }
+
+        [Test]
+        public void RequestStatus_StandardRequest_Denied()
+        {
+            var request = StandardRequest();
+            request.Denied = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.Denied"));
+        }
+
+        [Test]
+        public void RequestStatus_4KRequest_PendingApproval4K()
+        {
+            Assert.That(FourKRequest().RequestStatus, Is.EqualTo("Common.PendingApproval4K"));
+        }
+
+        [Test]
+        public void RequestStatus_4KRequest_Processing4K_WhenApproved4K()
+        {
+            var request = FourKRequest();
+            request.Approved4K = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.ProcessingRequest4K"));
+        }
+
+        /// <summary>
+        /// A 4K only request never sets Available, so reading the status from that flag
+        /// alone left a fulfilled request reading as "Pending Approval" forever.
+        /// </summary>
+        [Test]
+        public void RequestStatus_4KRequest_Available4K_WhenFulfilled()
+        {
+            var request = FourKRequest();
+            request.Approved4K = true;
+            request.Available4K = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.Available4K"));
+        }
+
+        [Test]
+        public void RequestStatus_4KRequest_Denied4K()
+        {
+            var request = FourKRequest();
+            request.Denied4K = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.RequestDenied4K"));
+        }
+
+        [Test]
+        public void RequestStatus_CombinedRequest_ReportsStandardWhileItIsOutstanding()
+        {
+            var request = CombinedRequest();
+            request.Approved = true;
+            request.Approved4K = true;
+            request.Available4K = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.ProcessingRequest"));
+        }
+
+        [Test]
+        public void RequestStatus_CombinedRequest_FallsThroughTo4K_OnceStandardIsAvailable()
+        {
+            var request = CombinedRequest();
+            request.Approved = true;
+            request.Available = true;
+            request.Approved4K = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.ProcessingRequest4K"));
+        }
+
+        [Test]
+        public void RequestStatus_CombinedRequest_Available_WhenBothFulfilled()
+        {
+            var request = CombinedRequest();
+            request.Approved = true;
+            request.Available = true;
+            request.Approved4K = true;
+            request.Available4K = true;
+
+            Assert.That(request.RequestStatus, Is.EqualTo("Common.Available"));
+        }
+
+        [Test]
+        public void RequestStatus_IsNeverEmpty()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(StandardRequest().RequestStatus, Is.Not.Empty);
+                Assert.That(FourKRequest().RequestStatus, Is.Not.Empty);
+                Assert.That(CombinedRequest().RequestStatus, Is.Not.Empty);
+            });
+        }
+    }
+}

--- a/src/Ombi.Store/Entities/Requests/MovieRequests.cs
+++ b/src/Ombi.Store/Entities/Requests/MovieRequests.cs
@@ -69,47 +69,45 @@ namespace Ombi.Store.Entities.Requests
         [JsonIgnore]
         public string LanguageCode => LangCode.IsNullOrEmpty() ? "en" : LangCode;
 
+        /// <summary>
+        /// A request tracks a standard copy and a 4K copy independently. Report whichever
+        /// one is still outstanding, preferring the standard copy while both are, which
+        /// matches how the media details page reads.
+        /// </summary>
         [NotMapped]
-        public string RequestStatus {
-            get
+        public string RequestStatus => RequestCombination == RequestCombination.FourK
+            ? Get4KStatus()
+            : GetStandardStatus();
+
+        private string GetStandardStatus()
+        {
+            if (!Available)
             {
-                // A request tracks a standard copy and a 4K copy independently, so report
-                // whichever one is still outstanding. The standard copy takes precedence
-                // while both are, which matches how the media details page reads.
-                var hasStandardRequest = RequestCombination != RequestCombination.FourK;
-
-                if (hasStandardRequest && !Available)
+                if (Denied ?? false)
                 {
-                    if (Denied ?? false)
-                    {
-                        return "Common.Denied";
-                    }
-
-                    return Approved ? "Common.ProcessingRequest" : "Common.PendingApproval";
+                    return "Common.Denied";
                 }
 
-                if (Has4KRequest && !Available4K)
-                {
-                    if (Denied4K ?? false)
-                    {
-                        return "Common.RequestDenied4K";
-                    }
-
-                    return Approved4K ? "Common.ProcessingRequest4K" : "Common.PendingApproval4K";
-                }
-
-                if (hasStandardRequest && Available)
-                {
-                    return "Common.Available";
-                }
-
-                if (Has4KRequest && Available4K)
-                {
-                    return "Common.Available4K";
-                }
-
-                return string.Empty;
+                return Approved ? "Common.ProcessingRequest" : "Common.PendingApproval";
             }
+
+            // The standard copy has landed, but a combined request may still owe a 4K one.
+            return Has4KRequest && !Available4K ? Get4KStatus() : "Common.Available";
+        }
+
+        private string Get4KStatus()
+        {
+            if (!Available4K)
+            {
+                if (Denied4K ?? false)
+                {
+                    return "Common.RequestDenied4K";
+                }
+
+                return Approved4K ? "Common.ProcessingRequest4K" : "Common.PendingApproval4K";
+            }
+
+            return "Common.Available4K";
         }
 
         [NotMapped]

--- a/src/Ombi.Store/Entities/Requests/MovieRequests.cs
+++ b/src/Ombi.Store/Entities/Requests/MovieRequests.cs
@@ -73,24 +73,39 @@ namespace Ombi.Store.Entities.Requests
         public string RequestStatus {
             get
             {
-                if (Available)
+                // A request tracks a standard copy and a 4K copy independently, so report
+                // whichever one is still outstanding. The standard copy takes precedence
+                // while both are, which matches how the media details page reads.
+                var hasStandardRequest = RequestCombination != RequestCombination.FourK;
+
+                if (hasStandardRequest && !Available)
+                {
+                    if (Denied ?? false)
+                    {
+                        return "Common.Denied";
+                    }
+
+                    return Approved ? "Common.ProcessingRequest" : "Common.PendingApproval";
+                }
+
+                if (Has4KRequest && !Available4K)
+                {
+                    if (Denied4K ?? false)
+                    {
+                        return "Common.RequestDenied4K";
+                    }
+
+                    return Approved4K ? "Common.ProcessingRequest4K" : "Common.PendingApproval4K";
+                }
+
+                if (hasStandardRequest && Available)
                 {
                     return "Common.Available";
                 }
 
-                if (Denied ?? false)
+                if (Has4KRequest && Available4K)
                 {
-                    return "Common.Denied";
-                }
-
-                if (Approved & !Available)
-                {
-                    return "Common.ProcessingRequest";
-                }
-
-                if (!Approved && !Available)
-                {
-                    return "Common.PendingApproval";
+                    return "Common.Available4K";
                 }
 
                 return string.Empty;


### PR DESCRIPTION
## 📝 Description

`MovieRequests.RequestStatus` derived the displayed status purely from the standard `Approved` / `Available` / `Denied` fields and never looked at their 4K counterparts:

```csharp
if (Available)                 return "Common.Available";
if (Denied ?? false)           return "Common.Denied";
if (Approved & !Available)     return "Common.ProcessingRequest";
if (!Approved && !Available)   return "Common.PendingApproval";
```

A 4K-only request deliberately leaves those standard fields alone. `MovieRequestEngine` stores `RequestedDate = DateTime.MinValue` for a 4K request and tracks everything in `Approved4K` / `Available4K`:

```csharp
RequestedDate   = model.Is4kRequest ? DateTime.MinValue : DateTime.UtcNow,
RequestedDate4k = model.Is4kRequest ? DateTime.UtcNow   : DateTime.MinValue,
```

So `RequestStatus` falls through to `"Common.PendingApproval"` and **stays there permanently** — including after the availability checker has correctly set `Available4K = true`. The request is fulfilled, and the UI still says it is waiting for approval.

The requests list renders this value directly (`movies-grid.component.html`), so a completed 4K request displays as "Pending Approval" sitting right next to its own `4K` badge. The optimistic update in `requests-list.component.ts` even comments *"Need to do this here, as the status is calculated on the server"* — confirming this property is the authoritative source.

The media details page already handles 4K correctly in its own `getStatus()`, returning `Common.ProcessingRequest4K` / `Common.PendingApproval4K` / `Common.RequestDenied4K`. Only the server-side status was missing.

### Changes

Report whichever copy is still outstanding, preferring the standard one when a request covers both — which mirrors the ordering the details page already uses. Requests without a 4K component are unaffected.

The existing `RequestCombination` property is reused to decide whether a standard copy was requested at all, so the 4K-only, standard-only and combined cases each resolve to the right track.

### No new strings, no frontend change needed

- Every key already exists in `wwwroot/translations/en.json` and the other language files: `Common.Available4K`, `Common.ProcessingRequest4K`, `Common.PendingApproval4K`, `Common.RequestDenied4K`.
- `getStatusClass()` in `base-grid.component.ts` matches by substring (`'available'`, `'pending'`, `'processing'`, `'denied'`), so all four new values already resolve to the correct badge classes.

## 🔗 Related Issues

No open issue — found while debugging 4K requests that never left "Pending Approval".

## 🧪 Testing

Added `src/Ombi.Core.Tests/Entities/MovieRequestsTests.cs`, covering the standard, 4K-only and combined cases.

Confirmed against the **unmodified** implementation first:

```
Before:  Passed: 7, Failed: 5
  Failed RequestStatus_4KRequest_PendingApproval4K
  Failed RequestStatus_4KRequest_Processing4K_WhenApproved4K
  Failed RequestStatus_4KRequest_Available4K_WhenFulfilled
  Failed RequestStatus_4KRequest_Denied4K
  Failed RequestStatus_CombinedRequest_FallsThroughTo4K_OnceStandardIsAvailable

After:   Passed: 12
```

The important half is the seven that passed *before* the change. All four standard-request assertions (`PendingApproval`, `Processing_WhenApproved`, `Available`, `Denied`) pass against both the old and new implementation, so they pin the existing behaviour and demonstrate the diff cannot regress non-4K users.

Full solution test run on this branch: **633 passed, 0 failed** across all six test projects.

Also compared compiler warnings against a clean `--no-incremental` rebuild of `develop` — identical sets, no new warnings.

- [x] Unit tests pass
- [ ] Integration tests pass *(none in the repo)*
- [ ] Manual testing completed *(see Additional Notes)*
- [x] No breaking changes *(with one caveat — see Additional Notes)*

## 📸 Screenshots (if applicable)

No markup changes. The visible effect is that a fulfilled 4K request in the requests list now reads **Available 4K** (green badge) instead of **Pending Approval** (amber badge).

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(N/A)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

**Verification:** I have reviewed the diff line by line. The before/after test run above is the check I would ask a reviewer to run first — particularly the four standard-request tests that pass on both implementations. I have not run this against a live Ombi instance, so the verification is unit tests and code path analysis rather than end-to-end confirmation.

**One caveat on "no breaking changes".** `requestStatus` is serialised on the requests API, and this change means it can now return four values it never returned before. Ombi's own frontend handles them (substring matching, and the translation keys already exist), but a third-party API consumer switching on the exact old strings would see something unfamiliar for 4K requests. I judged that acceptable since the previous value was simply wrong, but it is your call whether that warrants a note in the release.

**Test placement.** `MovieRequests` lives in `Ombi.Store`, which has no test project. I put the test in `Ombi.Core.Tests/Entities/` rather than adding a new project inside a bug-fix PR — happy to move it if you would prefer it elsewhere.

**Combined requests.** Where a request covers both a standard and a 4K copy, a single string cannot express two independent states. I chose to report the standard copy while it is outstanding and fall through to the 4K one afterwards, matching `getStatus()` on the details page. If you would rather surface both, that is a larger change to the view model and I would rather agree the shape with you first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved movie request status reporting when standard and 4K versions are requested together.
  - Standard requests now correctly show denial, processing, approval, and availability states.
  - 4K-only requests correctly display availability once fulfilled instead of remaining pending.
  - Combined requests now accurately show outstanding 4K availability after the standard version is available.
  - Availability statuses are consistently reported for standard and 4K requests, ensuring the status is never blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->