### PR TITLE
fix(i18n): keep paginator labels from rendering as translation keys

### DIFF
--- a/src/Ombi/ClientApp/src/app/localization/MatPaginatorI18n.spec.ts
+++ b/src/Ombi/ClientApp/src/app/localization/MatPaginatorI18n.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Subject } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { MatPaginatorI18n } from './MatPaginatorI18n';
+
+const LABELS: Record<string, string> = {
+  'Paginator.itemsPerPageLabel': 'Items per page:',
+  'Paginator.nextPageLabel': 'Next page',
+  'Paginator.previousPageLabel': 'Previous page',
+  'Paginator.firstPageLabel': 'First page',
+  'Paginator.lastPageLabel': 'Last page',
+};
+
+/**
+ * Stands in for TranslateService. The behaviour that matters here is the one that
+ * causes the bug: until the translation file has been fetched, instant() returns
+ * the key it was given rather than a translated string.
+ */
+function createTranslateStub() {
+  const onTranslationChange = new Subject<any>();
+  const onLangChange = new Subject<any>();
+  const onDefaultLangChange = new Subject<any>();
+  let loaded = false;
+
+  const stub = {
+    onTranslationChange,
+    onLangChange,
+    onDefaultLangChange,
+    instant: (key: string, params?: any) => {
+      if (!loaded) {
+        return key;
+      }
+      return LABELS[key] ?? key;
+    },
+    /** Mimics the translation file arriving over HTTP. */
+    completeLoad: () => {
+      loaded = true;
+      onTranslationChange.next({ lang: 'en' });
+    },
+    switchLanguage: () => {
+      loaded = true;
+      onLangChange.next({ lang: 'fr' });
+    },
+  };
+
+  return stub;
+}
+
+describe('MatPaginatorI18n', () => {
+  let translate: ReturnType<typeof createTranslateStub>;
+
+  beforeEach(() => {
+    translate = createTranslateStub();
+  });
+
+  const build = () => new MatPaginatorI18n(translate as unknown as TranslateService).getPaginatorIntl();
+
+  it('falls back to the key while the translations are still loading', () => {
+    const intl = build();
+
+    expect(intl.itemsPerPageLabel).toBe('Paginator.itemsPerPageLabel');
+  });
+
+  it('replaces the keys once the translations arrive', () => {
+    const intl = build();
+
+    translate.completeLoad();
+
+    expect(intl.itemsPerPageLabel).toBe('Items per page:');
+    expect(intl.nextPageLabel).toBe('Next page');
+    expect(intl.previousPageLabel).toBe('Previous page');
+    expect(intl.firstPageLabel).toBe('First page');
+    expect(intl.lastPageLabel).toBe('Last page');
+  });
+
+  it('notifies the paginator so it re-renders the new labels', () => {
+    const intl = build();
+    let emissions = 0;
+    intl.changes.subscribe(() => emissions++);
+
+    translate.completeLoad();
+
+    expect(emissions).toBeGreaterThan(0);
+  });
+
+  it('updates the labels when the language changes', () => {
+    const intl = build();
+
+    translate.switchLanguage();
+
+    expect(intl.itemsPerPageLabel).toBe('Items per page:');
+  });
+
+  it('still builds the range label from the translations', () => {
+    const intl = build();
+    translate.completeLoad();
+
+    expect(intl.getRangeLabel(0, 10, 0)).toBe('Paginator.rangePageLabel1');
+    expect(intl.getRangeLabel(1, 10, 35)).toBe('Paginator.rangePageLabel2');
+  });
+});

--- a/src/Ombi/ClientApp/src/app/localization/MatPaginatorI18n.ts
+++ b/src/Ombi/ClientApp/src/app/localization/MatPaginatorI18n.ts
@@ -1,5 +1,6 @@
 import { MatPaginatorIntl } from '@angular/material/paginator';
 import { TranslateService } from '@ngx-translate/core';
+import { merge } from 'rxjs';
 
 export class MatPaginatorI18n {
 
@@ -7,13 +8,30 @@ export class MatPaginatorI18n {
 
     getPaginatorIntl(): MatPaginatorIntl {
         const paginatorIntl = new MatPaginatorIntl();
+        paginatorIntl.getRangeLabel = this.getRangeLabel.bind(this);
+
+        this.applyLabels(paginatorIntl);
+
+        // The translations are fetched over HTTP, so the labels above can be read
+        // before that request has come back, and translate.instant() then hands us
+        // the key itself. Re-read them whenever the translations land or the
+        // language changes, and emit on `changes` so the paginator re-renders.
+        merge(
+            this.translate.onTranslationChange,
+            this.translate.onLangChange,
+            this.translate.onDefaultLangChange,
+        ).subscribe(() => this.applyLabels(paginatorIntl));
+
+        return paginatorIntl;
+    }
+
+    private applyLabels(paginatorIntl: MatPaginatorIntl): void {
         paginatorIntl.itemsPerPageLabel = this.translate.instant('Paginator.itemsPerPageLabel');
         paginatorIntl.nextPageLabel = this.translate.instant('Paginator.nextPageLabel');
         paginatorIntl.previousPageLabel = this.translate.instant('Paginator.previousPageLabel');
         paginatorIntl.firstPageLabel = this.translate.instant('Paginator.firstPageLabel');
         paginatorIntl.lastPageLabel = this.translate.instant('Paginator.lastPageLabel');
-        paginatorIntl.getRangeLabel = this.getRangeLabel.bind(this);
-        return paginatorIntl;
+        paginatorIntl.changes.next();
     }
 
     private getRangeLabel(page: number, pageSize: number, length: number): string {


### PR DESCRIPTION
## 📝 Description

Paginators sometimes render the raw translation key instead of the label — `Paginator.itemsPerPageLabel` where "Items per page:" should be. I hit it on the requests list, but the provider is global, so it affects all four paginators (the movies, TV and albums grids, and the issues table).

`MatPaginatorI18n` reads the five labels **once**, when `MatPaginatorIntl` is first injected:

```ts
paginatorIntl.itemsPerPageLabel = this.translate.instant('Paginator.itemsPerPageLabel');
```

`translate.instant()` is synchronous, but the translations are not. `TranslateHttpLoader` fetches them over HTTP, and `setDefaultLang` / `use` are only called from `AppComponent.ngOnInit`:

```ts
this.translate.setDefaultLang("en");
this.translate.use(browserLang.match(/.../) ? browserLang : "en");
```

So that read can happen before the language file has arrived, and when it does, ngx-translate returns the key it was handed.

Nothing corrected it afterwards. The labels were captured once, and `MatPaginatorIntl.changes` — the stream the paginator subscribes to for exactly this purpose, documented as *"Stream to emit from when labels are changed. Use this to notify components when the labels have changed after initialization"* — was never emitted on. The key stayed on screen until the next full reload.

Because it comes down to whether the translation request beats the first render, it is intermittent: it shows up on a refresh landing directly on a page with a table, and not when navigating to that page from inside the app, where the translations loaded long ago.

### A second symptom from the same cause

The labels also never followed a language change — neither the one applied from user preferences after login (`app.component.ts`) nor a manual switch in user preferences. That part is not a race; it never worked, because nothing re-reads the labels.

### Changes

Re-read the labels whenever the translations load or the language changes, and emit on `changes` so the paginator picks them up.

`getRangeLabel` is untouched. It was already correct — it is a bound function evaluated on every render, which is why the range text stayed readable while the labels did not.

## 🔗 Related Issues

No open issue — noticed on the requests list after a page refresh, then traced back from there.

## 🧪 Testing

Added `src/Ombi/ClientApp/src/app/localization/MatPaginatorI18n.spec.ts` (no existing coverage for this file).

Confirmed against the **unmodified** implementation first:

```
Before:  Tests  3 failed | 2 passed (5)
  × replaces the keys once the translations arrive
      → expected 'Paginator.itemsPerPageLabel' to be 'Items per page:'
  × notifies the paginator so it re-renders the new labels
      → expected 0 to be greater than 0
  × updates the labels when the language changes
      → expected 'Paginator.itemsPerPageLabel' to be 'Items per page:'

After:   Tests  5 passed (5)
```

That first assertion message is the exact string that appears on screen.

The two that pass either way pin existing behaviour: the key fallback while loading, and `getRangeLabel`.

| Test | Covers |
|---|---|
| `falls back to the key while the translations are still loading` | the starting condition — passes before and after |
| `replaces the keys once the translations arrive` | the bug |
| `notifies the paginator so it re-renders the new labels` | `changes` is emitted |
| `updates the labels when the language changes` | the language-switch symptom |
| `still builds the range label from the translations` | `getRangeLabel` unchanged |

Full frontend suite under `TZ=UTC`, matching CI: **1020 passed, 114/114 files, 0 failed.**

`ng build -c production` succeeds. The only warnings are the pre-existing SCSS budget ones in `_shared-card-grid.scss`, `login.component.scss` and `media-details.component.scss`, none of which this PR touches.

- [x] Unit tests pass
- [ ] Integration tests pass *(none covering this)*
- [ ] Manual testing completed *(see Additional Notes)*
- [x] No breaking changes

## 📸 Screenshots (if applicable)

No markup changes. The paginator on an affected page reads `Paginator.itemsPerPageLabel` before, and `Items per page:` after.

## 📋 Checklist

- [x] My code follows the project's coding standards
- [x] I have mentioned if this is a vibe coded PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(N/A)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 🎯 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## 📚 Additional Notes

**Verification:** the bug itself was observed on a running instance — that is where it was noticed, on the requests list after a refresh. The fix is verified by the unit tests above and a production build; I have not gone back and confirmed the corrected labels in a running instance, so that last step is outstanding.

**Subscription lifetime.** The subscription is not torn down. `MatPaginatorIntl` is provided at the application root and has no `ngOnDestroy` hook, so it lives for the lifetime of the app and there is nothing to leak into. Happy to wrap it if you would rather it were explicit.

**Alternative worth considering.** A narrower fix would be to give `TranslateModule.forRoot` a `defaultLanguage`, or to block bootstrap on the translations with an `APP_INITIALIZER`. Either would close the race, but neither fixes the language-switch symptom, and the `changes` stream is the mechanism Angular Material provides for this. I went with reacting to the translation events for that reason.

**Two unrelated things noticed while working in `ClientApp`,** both pre-existing and left alone here — happy to raise either separately:

- `OmbiDatePipe.spec.ts` fails outside UTC. `pipe.transform('2023-01-01T00:00:00Z', 'yyyy')` returns `2022` at any negative UTC offset. It passes in CI because CI runs UTC.
- The checked-in `yarn.lock` is yarn v1 format, but with no `packageManager` field in `package.json`, corepack resolves a Yarn 3 line and refuses the lockfile. It also silently rewrites the lockfile into berry format as a side effect of the .NET build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Paginator labels now update automatically when translations or the selected language changes.
  - Range labels remain correctly translated after language updates.
  - Paginators refresh reliably whenever translated text is updated.

- **Tests**
  - Added coverage for loading-state fallbacks, translated labels, language changes, paginator notifications, and translated range labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->