### PR TITLE
fix: stop the TV discover endpoints duplicating episode data (#5472)

### DIFF
--- a/src/Ombi.Core.Tests/Engine/V2/TvSearchEngineV2Tests.cs
+++ b/src/Ombi.Core.Tests/Engine/V2/TvSearchEngineV2Tests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using MockQueryable.Moq;
+using Moq;
+using NUnit.Framework;
+using Ombi.Api.External.ExternalApis.TheMovieDb;
+using Ombi.Api.External.ExternalApis.TheMovieDb.Models;
+using Ombi.Api.External.ExternalApis.Trakt;
+using Ombi.Api.External.ExternalApis.TvMaze;
+using Ombi.Core.Authentication;
+using Ombi.Core.Engine.Interfaces;
+using Ombi.Core.Engine.V2;
+using Ombi.Core.Helpers;
+using Ombi.Core.Models.Requests;
+using Ombi.Core.Models.Search;
+using Ombi.Core.Rule;
+using Ombi.Core.Rule.Interfaces;
+using Ombi.Core.Services;
+using Ombi.Core.Settings;
+using Ombi.Helpers;
+using Ombi.Mapping.Profiles;
+using Ombi.Settings.Settings.Models;
+using Ombi.Store.Entities;
+using Ombi.Store.Entities.Requests;
+using Ombi.Store.Repository;
+using Ombi.Store.Repository.Requests;
+using Ombi.Test.Common;
+
+namespace Ombi.Core.Tests.Engine.V2
+{
+    [TestFixture]
+    public class TvSearchEngineV2Tests
+    {
+        private const int TheMovieDbId = 1399;
+        private const int SeasonCount = 2;
+        private const int EpisodesPerSeason = 3;
+
+        private TvSearchEngineV2 _engine;
+        private Mock<IMovieDbApi> _movieApi;
+        private Mock<ISettingsService<CustomizationSettings>> _customizationSettings;
+        private CustomizationSettings _customization;
+        private List<MovieDbSearchResult> _cachedApiResults;
+        private List<SearchTvShowViewModel> _rulesRanAgainst;
+
+        [SetUp]
+        public void Setup()
+        {
+            _customization = new CustomizationSettings { HideAvailableFromDiscover = true };
+            _customizationSettings = new Mock<ISettingsService<CustomizationSettings>>();
+            _customizationSettings.Setup(x => x.GetSettingsAsync()).ReturnsAsync(() => _customization);
+
+            // The engine caches the results from TheMovieDb, so every call gets the same instances back
+            _cachedApiResults = new List<MovieDbSearchResult>
+            {
+                new MovieDbSearchResult { Id = TheMovieDbId, Title = "Game of Thrones" }
+            };
+
+            _movieApi = new Mock<IMovieDbApi>();
+            _movieApi.Setup(x => x.PopularTv(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_cachedApiResults);
+            _movieApi.Setup(x => x.GetTVInfo(TheMovieDbId.ToString(), It.IsAny<string>()))
+                .ReturnsAsync(new TvInfo
+                {
+                    id = TheMovieDbId,
+                    name = "Game of Thrones",
+                    seasons = Enumerable.Range(0, SeasonCount + 1)
+                        .Select(x => new Season { season_number = x })
+                        .ToList()
+                });
+            _movieApi.Setup(x => x.GetSeasonEpisodes(TheMovieDbId, It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync((int _, int seasonNumber, CancellationToken __, string ___) => new SeasonDetails
+                {
+                    season_number = seasonNumber,
+                    episodes = Enumerable.Range(1, EpisodesPerSeason)
+                        .Select(x => new Episode
+                        {
+                            season_number = seasonNumber,
+                            episode_number = x,
+                            name = $"S{seasonNumber}E{x}",
+                            air_date = "2011-04-17"
+                        }).ToArray()
+                });
+
+            _rulesRanAgainst = new List<SearchTvShowViewModel>();
+            var rules = new Mock<IRuleEvaluator>();
+            rules.Setup(x => x.StartSearchRules(It.IsAny<SearchViewModel>()))
+                .ReturnsAsync((SearchViewModel model) =>
+                {
+                    // Capture a snapshot of what the availability rules were given
+                    var tv = (SearchTvShowViewModel)model;
+                    _rulesRanAgainst.Add(new SearchTvShowViewModel
+                    {
+                        Id = tv.Id,
+                        SeasonRequests = tv.SeasonRequests.Select(s => new SeasonRequests
+                        {
+                            SeasonNumber = s.SeasonNumber,
+                            Episodes = s.Episodes.ToList()
+                        }).ToList()
+                    });
+                    return new List<RuleResult>();
+                });
+
+            var currentUser = new Mock<ICurrentUser>();
+            currentUser.Setup(x => x.GetUser()).ReturnsAsync((OmbiUser)null);
+
+            var tvRepo = new Mock<ITvRequestRepository>();
+            tvRepo.Setup(x => x.Get()).Returns(new List<TvRequests>().AsQueryable().BuildMock());
+            var requestService = new Mock<IRequestServiceMain>();
+            requestService.Setup(x => x.TvRequestService).Returns(tvRepo.Object);
+
+            var mapper = new MapperConfiguration(cfg => cfg.AddProfile<TvProfile>()).CreateMapper();
+
+            _engine = new TvSearchEngineV2(currentUser.Object, requestService.Object, new Mock<ITvMazeApi>().Object,
+                mapper, new Mock<ITraktApi>().Object, rules.Object,
+                MockHelper.MockUserManager(new List<OmbiUser>()).Object, new TestCacheService(),
+                new Mock<ISettingsService<OmbiSettings>>().Object, new Mock<IRepository<RequestSubscription>>().Object,
+                _movieApi.Object, _customizationSettings.Object, new Mock<ITvRequestEngine>().Object,
+                new Mock<IFeatureService>().Object);
+        }
+
+        [Test]
+        public async Task Popular_DoesNotWriteSeasonsOntoTheCachedApiResults()
+        {
+            await _engine.Popular(0, 10);
+
+            Assert.That(_cachedApiResults[0].SeasonRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Popular_DoesNotDuplicateEpisodes_WhenCalledRepeatedly()
+        {
+            // The response cache is purged whenever a request is added/approved/denied, so the
+            // engine runs again against the same cached results from TheMovieDb
+            await _engine.Popular(0, 10);
+            await _engine.Popular(0, 10);
+            await _engine.Popular(0, 10);
+
+            Assert.That(_rulesRanAgainst, Has.Count.EqualTo(3));
+            foreach (var ranAgainst in _rulesRanAgainst)
+            {
+                Assert.That(ranAgainst.SeasonRequests, Has.Count.EqualTo(SeasonCount));
+                Assert.That(ranAgainst.SeasonRequests.SelectMany(x => x.Episodes).Count(),
+                    Is.EqualTo(SeasonCount * EpisodesPerSeason));
+            }
+        }
+
+        [Test]
+        public async Task Popular_GivesTheSeasonsToTheAvailabilityRules()
+        {
+            await _engine.Popular(0, 10);
+
+            var ranAgainst = _rulesRanAgainst.Single();
+            // Season 0 (specials) is skipped
+            Assert.That(ranAgainst.SeasonRequests.Select(x => x.SeasonNumber), Is.EquivalentTo(new[] { 1, 2 }));
+            Assert.That(ranAgainst.SeasonRequests.SelectMany(x => x.Episodes).Count(),
+                Is.EqualTo(SeasonCount * EpisodesPerSeason));
+        }
+
+        [Test]
+        public async Task Popular_DoesNotReturnTheSeasonsToTheClient()
+        {
+            var result = await _engine.Popular(0, 10);
+
+            Assert.That(result.Single().SeasonRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Popular_DoesNotLookupSeasons_WhenNotHidingAvailableContent()
+        {
+            _customization.HideAvailableFromDiscover = false;
+
+            var result = await _engine.Popular(0, 10);
+
+            Assert.That(result.Single().SeasonRequests, Is.Empty);
+            _movieApi.Verify(x => x.GetSeasonEpisodes(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>(),
+                It.IsAny<string>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Mirrors the real cache, the same instances are handed back on every call.
+        /// </summary>
+        private class TestCacheService : ICacheService
+        {
+            private readonly Dictionary<string, object> _cache = new Dictionary<string, object>();
+
+            public async Task<T> GetOrAddAsync<T>(string cacheKey, Func<Task<T>> factory, DateTimeOffset absoluteExpiration = default)
+            {
+                if (_cache.TryGetValue(cacheKey, out var cached))
+                {
+                    return (T)cached;
+                }
+
+                var result = await factory();
+                _cache[cacheKey] = result;
+                return result;
+            }
+
+            public T GetOrAdd<T>(string cacheKey, Func<T> factory, DateTimeOffset absoluteExpiration)
+            {
+                if (_cache.TryGetValue(cacheKey, out var cached))
+                {
+                    return (T)cached;
+                }
+
+                var result = factory();
+                _cache[cacheKey] = result;
+                return result;
+            }
+
+            public void Remove(string key) => _cache.Remove(key);
+        }
+    }
+}

--- a/src/Ombi.Core.Tests/Engine/V2/TvSearchEngineV2Tests.cs
+++ b/src/Ombi.Core.Tests/Engine/V2/TvSearchEngineV2Tests.cs
@@ -71,8 +71,8 @@ namespace Ombi.Core.Tests.Engine.V2
                         .Select(x => new Season { season_number = x })
                         .ToList()
                 });
-            _movieApi.Setup(x => x.GetSeasonEpisodes(TheMovieDbId, It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
-                .ReturnsAsync((int _, int seasonNumber, CancellationToken __, string ___) => new SeasonDetails
+            _movieApi.Setup(x => x.GetSeasonEpisodes(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync((int showId, int seasonNumber, CancellationToken _, string __) => new SeasonDetails
                 {
                     season_number = seasonNumber,
                     episodes = Enumerable.Range(1, EpisodesPerSeason)
@@ -80,7 +80,7 @@ namespace Ombi.Core.Tests.Engine.V2
                         {
                             season_number = seasonNumber,
                             episode_number = x,
-                            name = $"S{seasonNumber}E{x}",
+                            name = $"{showId}-S{seasonNumber}E{x}",
                             air_date = "2011-04-17"
                         }).ToArray()
                 });
@@ -169,6 +169,28 @@ namespace Ombi.Core.Tests.Engine.V2
         }
 
         [Test]
+        public async Task Popular_DoesNotMixUpTheEpisodesOfShowsWithColidingCacheKeys()
+        {
+            // Show 1 season 23 and show 12 season 3 both used to build the key "SeasonEpisodes123"
+            _cachedApiResults.Clear();
+            _cachedApiResults.Add(new MovieDbSearchResult { Id = 1, Title = "First" });
+            _cachedApiResults.Add(new MovieDbSearchResult { Id = 12, Title = "Second" });
+            SetupShow(1, 23);
+            SetupShow(12, 3);
+
+            await _engine.Popular(0, 10);
+
+            var first = _rulesRanAgainst.Single(x => x.Id == 1);
+            var second = _rulesRanAgainst.Single(x => x.Id == 12);
+            Assert.That(first.SeasonRequests.Select(x => x.SeasonNumber), Is.EquivalentTo(Enumerable.Range(1, 23)));
+            Assert.That(second.SeasonRequests.Select(x => x.SeasonNumber), Is.EquivalentTo(Enumerable.Range(1, 3)));
+            Assert.That(first.SeasonRequests.SelectMany(x => x.Episodes).Select(x => x.Title),
+                Has.All.StartWith("1-"));
+            Assert.That(second.SeasonRequests.SelectMany(x => x.Episodes).Select(x => x.Title),
+                Has.All.StartWith("12-"));
+        }
+
+        [Test]
         public async Task Popular_DoesNotLookupSeasons_WhenNotHidingAvailableContent()
         {
             _customization.HideAvailableFromDiscover = false;
@@ -178,6 +200,19 @@ namespace Ombi.Core.Tests.Engine.V2
             Assert.That(result.Single().SeasonRequests, Is.Empty);
             _movieApi.Verify(x => x.GetSeasonEpisodes(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>(),
                 It.IsAny<string>()), Times.Never);
+        }
+
+        private void SetupShow(int theMovieDbId, int seasonCount)
+        {
+            _movieApi.Setup(x => x.GetTVInfo(theMovieDbId.ToString(), It.IsAny<string>()))
+                .ReturnsAsync(new TvInfo
+                {
+                    id = theMovieDbId,
+                    name = $"Show {theMovieDbId}",
+                    seasons = Enumerable.Range(0, seasonCount + 1)
+                        .Select(x => new Season { season_number = x })
+                        .ToList()
+                });
         }
 
         /// <summary>

--- a/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
@@ -227,42 +227,65 @@ namespace Ombi.Core.Engine.V2
 
             var nonDemoItems = items.Where(item => !DemoCheck(item.Title)).ToList();
 
-            if (settings.HideAvailableFromDiscover)
-            {
-                foreach (var tvMazeSearch in nonDemoItems)
-                {
-                    var show = await Cache.GetOrAddAsync(nameof(GetShowInformation) + tvMazeSearch.Id.ToString(),
-                        () => _movieApi.GetTVInfo(tvMazeSearch.Id.ToString()), DateTime.Now.AddHours(12));
-
-                    if (show == null || string.IsNullOrEmpty(show.name) || show.seasons == null)
-                    {
-                        continue;
-                    }
-
-                    var seasons = show.seasons.Where(x => x.season_number != 0).ToList();
-                    foreach (var tvSeason in seasons)
-                    {
-                        var seasonEpisodes = await Cache.GetOrAddAsync("SeasonEpisodes" + show.id + tvSeason.season_number,
-                            () => _movieApi.GetSeasonEpisodes(show.id, tvSeason.season_number, CancellationToken.None),
-                            DateTimeOffset.Now.AddHours(12));
-                        MapSeasons(tvMazeSearch.SeasonRequests, tvSeason, seasonEpisodes);
-                    }
-                }
-            }
-
             // Run ProcessResult sequentially (RunSearchRules accesses DbContext which is not thread-safe)
             var retVal = new List<SearchTvShowViewModel>();
             foreach (var item in nonDemoItems)
             {
-                var result = await ProcessResult(item);
+                // We only need the episodes to work out how much of the show is available.
+                // The results from TheMovieDb are cached and shared by every request, so the seasons
+                // must be built into a new list each time. Writing them onto the cached item would
+                // append another copy of every episode each time we are called.
+                var seasonRequests = settings.HideAvailableFromDiscover
+                    ? await GetSeasonsForAvailability(item.Id)
+                    : new List<SeasonRequests>();
+
+                var result = await ProcessResult(item, seasonRequests);
                 if (result == null || (settings.HideAvailableFromDiscover && result.Available))
                 {
                     continue;
                 }
+
+                // The availability rules have had their use out of the seasons, the discover views
+                // do not display them and they are megabytes worth of JSON per page.
+                result.SeasonRequests = new List<SeasonRequests>();
                 retVal.Add(result);
             }
 
             return retVal;
+        }
+
+        /// <summary>
+        /// Builds the season and episode information used to determine how much of a show we
+        /// already have. Always returns a new list, the caller must not write it back onto any
+        /// cached object.
+        /// </summary>
+        private async Task<List<SeasonRequests>> GetSeasonsForAvailability(int theMovieDbId)
+        {
+            var seasonRequests = new List<SeasonRequests>();
+
+            var show = await Cache.GetOrAddAsync(nameof(GetShowInformation) + theMovieDbId,
+                () => _movieApi.GetTVInfo(theMovieDbId.ToString()), DateTimeOffset.Now.AddHours(12));
+
+            if (show == null || string.IsNullOrEmpty(show.name) || show.seasons == null)
+            {
+                return seasonRequests;
+            }
+
+            foreach (var tvSeason in show.seasons.Where(x => x.season_number != 0))
+            {
+                var seasonEpisodes = await Cache.GetOrAddAsync("SeasonEpisodes" + show.id + tvSeason.season_number,
+                    () => _movieApi.GetSeasonEpisodes(show.id, tvSeason.season_number, CancellationToken.None),
+                    DateTimeOffset.Now.AddHours(12));
+
+                if (seasonEpisodes?.episodes == null)
+                {
+                    continue;
+                }
+
+                MapSeasons(seasonRequests, tvSeason, seasonEpisodes);
+            }
+
+            return seasonRequests;
         }
 
         private static void MapSeasons(List<SeasonRequests> seasonRequests, Season tvSeason, SeasonDetails seasonEpisodes)
@@ -314,9 +337,11 @@ namespace Ombi.Core.Engine.V2
             }
         }
 
-        private async Task<SearchTvShowViewModel> ProcessResult<T>(T tvMazeSearch)
+        private async Task<SearchTvShowViewModel> ProcessResult<T>(T tvMazeSearch, List<SeasonRequests> seasonRequests)
         {
             var item = _mapper.Map<SearchTvShowViewModel>(tvMazeSearch);
+            // The availability rules use the seasons to set FullyAvailable/PartlyAvailable
+            item.SeasonRequests = seasonRequests;
 
             await RunSearchRules(item);
             return item;

--- a/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
+++ b/src/Ombi.Core/Engine/V2/TvSearchEngineV2.cs
@@ -273,7 +273,7 @@ namespace Ombi.Core.Engine.V2
 
             foreach (var tvSeason in show.seasons.Where(x => x.season_number != 0))
             {
-                var seasonEpisodes = await Cache.GetOrAddAsync("SeasonEpisodes" + show.id + tvSeason.season_number,
+                var seasonEpisodes = await Cache.GetOrAddAsync($"SeasonEpisodes|{show.id}|{tvSeason.season_number}",
                     () => _movieApi.GetSeasonEpisodes(show.id, tvSeason.season_number, CancellationToken.None),
                     DateTimeOffset.Now.AddHours(12));
 

--- a/src/Ombi.Helpers.Tests/MediaCacheServiceTests.cs
+++ b/src/Ombi.Helpers.Tests/MediaCacheServiceTests.cs
@@ -70,12 +70,20 @@ namespace Ombi.Helpers.Tests
         }
 
         [Test]
-        public async Task Purge_ForgetsTheKeysItHasAlreadyPurged()
+        public async Task Purge_StillRemovesAValueThatWasStoredDuringAPurge()
         {
-            await _subject.GetOrAddAsync("first", () => Task.FromResult("1"));
+            // The key is registered before the factory runs, so a purge can land in between.
+            // The value must still be tracked, otherwise it sits there until it expires.
+            var purgeDuringFactory = _subject.GetOrAddAsync("first", async () =>
+            {
+                await _subject.Purge();
+                return "1";
+            });
+            await purgeDuringFactory;
+
             await _subject.Purge();
 
-            Assert.That(_memoryCache.Get<HashSet<string>>(TrackedKeys), Is.Null);
+            Assert.That(_memoryCache.Get<string>("first"), Is.Null);
         }
     }
 }

--- a/src/Ombi.Helpers.Tests/MediaCacheServiceTests.cs
+++ b/src/Ombi.Helpers.Tests/MediaCacheServiceTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Caching.Memory;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Ombi.Helpers.Tests
+{
+    [TestFixture]
+    public class MediaCacheServiceTests
+    {
+        private const string TrackedKeys = "MediaCacheServiceKeys";
+
+        private MemoryCache _memoryCache;
+        private MediaCacheService _subject;
+
+        [SetUp]
+        public void Setup()
+        {
+            _memoryCache = new MemoryCache(new MemoryCacheOptions());
+            _subject = new MediaCacheService(_memoryCache);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _memoryCache?.Dispose();
+        }
+
+        [Test]
+        public async Task GetOrAddAsync_OnlyCallsTheFactoryOnce()
+        {
+            var factoryCalls = 0;
+
+            var first = await _subject.GetOrAddAsync("key", () =>
+            {
+                factoryCalls++;
+                return Task.FromResult("value");
+            });
+            var second = await _subject.GetOrAddAsync("key", () =>
+            {
+                factoryCalls++;
+                return Task.FromResult("other value");
+            });
+
+            Assert.That(first, Is.EqualTo("value"));
+            Assert.That(second, Is.EqualTo("value"));
+            Assert.That(factoryCalls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task GetOrAddAsync_OnlyTracksTheKeyOnce()
+        {
+            await _subject.GetOrAddAsync("key", () => Task.FromResult("value"));
+            await _subject.GetOrAddAsync("key", () => Task.FromResult("value"));
+            await _subject.GetOrAddAsync("key", () => Task.FromResult("value"));
+
+            Assert.That(_memoryCache.Get<HashSet<string>>(TrackedKeys), Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Purge_RemovesEverythingWeHaveCached()
+        {
+            await _subject.GetOrAddAsync("first", () => Task.FromResult("1"));
+            await _subject.GetOrAddAsync("second", () => Task.FromResult("2"));
+
+            await _subject.Purge();
+
+            Assert.That(_memoryCache.Get<string>("first"), Is.Null);
+            Assert.That(_memoryCache.Get<string>("second"), Is.Null);
+        }
+
+        [Test]
+        public async Task Purge_ForgetsTheKeysItHasAlreadyPurged()
+        {
+            await _subject.GetOrAddAsync("first", () => Task.FromResult("1"));
+            await _subject.Purge();
+
+            Assert.That(_memoryCache.Get<HashSet<string>>(TrackedKeys), Is.Null);
+        }
+    }
+}

--- a/src/Ombi.Helpers/MediaCacheService.cs
+++ b/src/Ombi.Helpers/MediaCacheService.cs
@@ -14,6 +14,7 @@ namespace Ombi.Helpers
     public class MediaCacheService : CacheService, IMediaCacheService
     {
         private const string _cacheKey = "MediaCacheServiceKeys";
+        private static readonly object _lock = new object();
 
         public MediaCacheService(IMemoryCache memoryCache) : base(memoryCache)
         {
@@ -26,12 +27,7 @@ namespace Ombi.Helpers
                 absoluteExpiration = DateTimeOffset.Now.AddHours(1);
             }
 
-            if (_memoryCache.TryGetValue<T>($"MediaCacheService_{cacheKey}", out var result))
-            {
-                return (T)result;
-            }
-
-            // Not in the cache, so add this Key into our MediaServiceCache
+            // Keep track of the key so that we know what to remove when we purge
             UpdateLocalCache(cacheKey);
 
             return await _memoryCache.GetOrCreateAsync<T>(cacheKey, entry =>
@@ -43,26 +39,36 @@ namespace Ombi.Helpers
 
         private void UpdateLocalCache(string cacheKey)
         {
-            var mediaServiceCache = _memoryCache.Get<List<string>>(_cacheKey);
-            if (mediaServiceCache == null)
+            lock (_lock)
             {
-                mediaServiceCache = new List<string>();
+                var mediaServiceCache = _memoryCache.Get<HashSet<string>>(_cacheKey);
+                if (mediaServiceCache == null)
+                {
+                    mediaServiceCache = new HashSet<string>();
+                }
+                if (!mediaServiceCache.Add(cacheKey))
+                {
+                    // We are already tracking this key
+                    return;
+                }
+                _memoryCache.Set(_cacheKey, mediaServiceCache);
             }
-            mediaServiceCache.Add(cacheKey);
-            _memoryCache.Remove(_cacheKey);
-            _memoryCache.Set(_cacheKey, mediaServiceCache);
         }
 
         public Task Purge()
         {
-            var keys = _memoryCache.Get<List<string>>(_cacheKey);
-            if (keys == null)
+            lock (_lock)
             {
-                return Task.CompletedTask;
-            }
-            foreach (var key in keys)
-            {
-                base.Remove(key);
+                var keys = _memoryCache.Get<HashSet<string>>(_cacheKey);
+                if (keys == null)
+                {
+                    return Task.CompletedTask;
+                }
+                foreach (var key in keys)
+                {
+                    base.Remove(key);
+                }
+                _memoryCache.Remove(_cacheKey);
             }
             return Task.CompletedTask;
         }

--- a/src/Ombi.Helpers/MediaCacheService.cs
+++ b/src/Ombi.Helpers/MediaCacheService.cs
@@ -68,7 +68,9 @@ namespace Ombi.Helpers
                 {
                     base.Remove(key);
                 }
-                _memoryCache.Remove(_cacheKey);
+                // We deliberately keep tracking the keys. A caller can register its key and then
+                // be pre-empted by a purge before it has stored the value, forgetting the key here
+                // would leave that value in the cache until it expires.
             }
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Fixes #5472 - the discover TV endpoints were appending season/episode data onto the cached TheMovieDb results on every call, growing the response until it hit hundreds of MB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV discover results by applying availability rules with the correct season and episode information for each show.
  * Prevented episode data from different shows being mixed when their identifiers could otherwise overlap.
  * Ensured invalid TV results return cleanly without incomplete season data.
  * Improved media cache consistency, including reliable entry tracking and purging of entries stored during an active purge.
  * Prevented duplicate cache-key tracking during repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->